### PR TITLE
Prevent card from stretching on profile page

### DIFF
--- a/resources/assets/sass/custom.scss
+++ b/resources/assets/sass/custom.scss
@@ -51,7 +51,7 @@ body, button, input, textarea {
 .card.status-container {
 }
 
-img.card-img-top {
+.card-img-top {
   height: auto;
 }
 

--- a/resources/assets/sass/custom.scss
+++ b/resources/assets/sass/custom.scss
@@ -51,6 +51,10 @@ body, button, input, textarea {
 .card.status-container {
 }
 
+img.card-img-top {
+  height: auto;
+}
+
 .card.status-container .status-photo {
   display: -webkit-box !important;
   display: -ms-flexbox !important;


### PR DESCRIPTION
Still trying to understand the asset structure better; if I'm doing this wrong, let me know.

Basically I found that resizing the browser window caused the card elements to stretch in a weird way:
![pixelfed](https://user-images.githubusercontent.com/401560/40826850-c3b4cab0-6530-11e8-977a-a5638cbf3a88.jpg)

I found that setting the `height` property to `auto` on `.card-img-top` fixes this:

![pixelfed](https://user-images.githubusercontent.com/401560/40826887-e8a9aaca-6530-11e8-87b9-b09fae88d270.jpg)

As a bonus, it doesn't disrupt any existing views.