### PR TITLE
Add accept attribute

### DIFF
--- a/resources/views/timeline/personal.blade.php
+++ b/resources/views/timeline/personal.blade.php
@@ -24,7 +24,7 @@
           @csrf
           <div class="form-group">
             <label class="font-weight-bold text-muted small">Upload Image</label>
-            <input type="file" class="form-control-file" name="photo">
+            <input type="file" class="form-control-file" name="photo" accept="image/*">
           </div>
           <div class="form-group">
             <label class="font-weight-bold text-muted small">Caption</label>

--- a/resources/views/timeline/public.blade.php
+++ b/resources/views/timeline/public.blade.php
@@ -24,7 +24,7 @@
           @csrf
           <div class="form-group">
             <label class="font-weight-bold text-muted small">Upload Image</label>
-            <input type="file" class="form-control-file" name="photo">
+            <input type="file" class="form-control-file" name="photo" accept="image/*">
           </div>
           <div class="form-group">
             <label class="font-weight-bold text-muted small">Caption</label>


### PR DESCRIPTION
I think this is all that is necessary to implement my suggestion in #79. Adding these attributes indicates to the client that it should ignore anything that isn't an image when looking for files to upload; I think this would be a tiny UX improvement.

(I apologise for the added newlines at the end of both files, if you care about style at that level. The github editor automatically added those.)