### PR TITLE
Use inRandomOrder instead of orderByRaw in Discover page

### DIFF
--- a/app/Console/Commands/SeedFollows.php
+++ b/app/Console/Commands/SeedFollows.php
@@ -41,10 +41,10 @@ class SeedFollows extends Command
     {
         $limit = 10000;
 
-        for ($i=0; $i < $limit; $i++) { 
+        for ($i=0; $i < $limit; $i++) {
             try {
-                $actor = Profile::orderByRaw('rand()')->firstOrFail();
-                $target = Profile::orderByRaw('rand()')->firstOrFail();
+                $actor = Profile::inRandomOrder()->firstOrFail();
+                $target = Profile::inRandomOrder()->firstOrFail();
 
                 $follow = new Follower;
                 $follow->profile_id = $actor->id;

--- a/app/Http/Controllers/DiscoverController.php
+++ b/app/Http/Controllers/DiscoverController.php
@@ -16,7 +16,7 @@ class DiscoverController extends Controller
     public function home()
     {
       $following = Follower::whereProfileId(Auth::user()->profile->id)->pluck('following_id');
-      $people = Profile::whereNotIn('id', $following)->orderByRaw('rand()')->take(3)->get();
+      $people = Profile::inRandomOrder()->whereNotIn('id', $following)->take(3)->get();
       $posts = Status::whereHas('media')->whereNotIn('profile_id', $following)->orderBy('created_at', 'desc')->take('21')->get();
       return view('discover.home', compact('people', 'posts'));
     }


### PR DESCRIPTION
This fixes #92 by using `inRandomOrder` instead of `orderByRaw` in the Discover page.

Using `orderByRaw('rand()')` generates an exception when using SQLite as a database engine because `RAND()` does not exist in SQLite - it is instead called `RANDOM()`. 