### PR TITLE
Token→"token" and one forgotten word to translate

### DIFF
--- a/resources/lang/es/passwords.php
+++ b/resources/lang/es/passwords.php
@@ -14,9 +14,9 @@ return [
     */
 
     'password' => 'La contraseña debe tener al menos seis caracteres y coincidir con la de confirmación.',
-    'reset' => '¡Tu password se ha cambiado!',
+    'reset' => '¡Tu contraseña se ha cambiado!',
     'sent' => 'Te hemos enviado a tu correo un enlace para cambiar tu contraseña.',
-    'token' => 'El token para canbiar la contraseña no es válido.',
+    'token' => 'El "token" para canbiar la contraseña no es válido.',
     'user' => "No hemos podido encontrar a ningún usuario con esa contraseña.",
 
 ];


### PR DESCRIPTION
password wasn't translated and token is not a Spanish word, so it should go between quotation marks