### PR TITLE
Extract database calls from status show blade file

### DIFF
--- a/app/Http/Controllers/StatusController.php
+++ b/app/Http/Controllers/StatusController.php
@@ -12,8 +12,21 @@ class StatusController extends Controller
 {
     public function show(Request $request, $username, int $id)
     {
-      $user = Profile::whereUsername($username)->firstOrFail();
-      $status = Status::whereProfileId($user->id)->findOrFail($id);
+      /*
+       * Load all required data
+       */
+      $user = Profile::whereUsername($username)->with('avatar')->firstOrFail();
+      $status = Status::whereProfileId($user->id)->with(['firstMedia', 'comments', 'comments.profile'])->findOrFail($id);
+
+      // avoid calling the same profile in the blade template
+      $status->profile = $user;
+
+      // load a count non-relationship; this seems to be the most sane solution.
+      $status->likesCount;
+      /*
+       * End load all required data
+       */
+
       if(!$status->media_path && $status->in_reply_to_id) {
         return view('status.reply', compact('user', 'status'));
       }
@@ -23,8 +36,8 @@ class StatusController extends Controller
     public function store(Request $request)
     {
       if(Auth::check() == false)
-      { 
-        abort(403); 
+      {
+        abort(403);
       }
 
       $user = Auth::user();
@@ -57,7 +70,7 @@ class StatusController extends Controller
 
       // TODO: Parse Caption
       // TODO: Send to subscribers
-      
+
       return redirect($status->url());
     }
 }

--- a/app/Status.php
+++ b/app/Status.php
@@ -20,7 +20,7 @@ class Status extends Model
 
     public function firstMedia()
     {
-      return $this->hasOne(Media::class)->orderBy('order', 'asc');
+      return $this->hasOne(Media::class)->orderBy('order', 'asc')->limit(1);
     }
 
     public function thumb()

--- a/app/Status.php
+++ b/app/Status.php
@@ -20,7 +20,7 @@ class Status extends Model
 
     public function firstMedia()
     {
-      return $this->hasMany(Media::class)->orderBy('order', 'asc')->first();
+      return $this->hasOne(Media::class)->orderBy('order', 'asc');
     }
 
     public function thumb()
@@ -37,7 +37,7 @@ class Status extends Model
 
     public function mediaUrl()
     {
-      $path = $this->firstMedia()->media_path;
+      $path = $this->firstMedia->media_path;
       $url = Storage::url($path);
       return url($url);
     }
@@ -45,6 +45,15 @@ class Status extends Model
     public function likes()
     {
       return $this->hasMany(Like::class);
+    }
+
+    public function getLikesCountAttribute()
+    {
+        if(isset($this->likesCountNumber)) {
+            return $this->likesCountNumber;
+        }
+
+        return $this->likesCountNumber = $this->likes()->count();
     }
 
     public function comments()

--- a/app/Status.php
+++ b/app/Status.php
@@ -25,7 +25,7 @@ class Status extends Model
 
     public function thumb()
     {
-      return url(Storage::url($this->firstMedia()->thumbnail_path));
+      return url(Storage::url($this->firstMedia->thumbnail_path));
     }
 
     public function url()

--- a/app/Transformer/ActivityPub/ProfileOutbox.php
+++ b/app/Transformer/ActivityPub/ProfileOutbox.php
@@ -56,8 +56,8 @@ class ProfileOutbox extends Fractal\TransformerAbstract
               // TODO: support more than 1 attachment
               [
                 'type' => 'Document',
-                'mediaType' => $i->firstMedia()->mime,
-                'url' => $i->firstMedia()->url(),
+                'mediaType' => $i->firstMedia->mime,
+                'url' => $i->firstMedia->url(),
                 'name' => null
               ]
             ],

--- a/resources/views/admin/statuses/home.blade.php
+++ b/resources/views/admin/statuses/home.blade.php
@@ -30,7 +30,7 @@
         @if(!$status->media_path)
         <td class="font-weight-bold">0</td>
         @else
-        <td><div class="human-size" data-bytes="{{$status->firstMedia()->size}}">{{$status->firstMedia()->size}}</div></td>
+        <td><div class="human-size" data-bytes="{{$status->firstMedia->size}}">{{$status->firstMedia->size}}</div></td>
         @endif
         <td class="font-weight-bold">{{$status->created_at->diffForHumans(null, true, true, true)}}</td>
       </tr>

--- a/resources/views/status/show.blade.php
+++ b/resources/views/status/show.blade.php
@@ -4,8 +4,7 @@
 
 <div class="container">
   <div class="col-12 mt-4">
-    
-    <div class="card status-container orientation-{{$status->firstMedia()->orientation ?? 'unknown'}}">
+    <div class="card status-container orientation-{{$status->firstMedia->orientation ?? 'unknown'}}">
       <div class="card-body p-0">
         <div class="row">
           <div class="col-12 col-md-8 status-photo">
@@ -50,7 +49,7 @@
               </span>
             </div>
             <div class="likes font-weight-bold mb-0">
-              <span class="like-count">{{$status->likes()->count()}}</span> likes
+              <span class="like-count">{{$status->likesCount}}</span> likes
             </div>
             <div class="timestamp mb-0">
               <p class="small text-uppercase mb-0"><a href="{{$status->url()}}" class="text-muted">{{$status->created_at->diffForHumans()}}</a></p>


### PR DESCRIPTION
I've removed all database calls from `status/show.blade.php`. All of those calls are now done in `StatusController`. instead.

This makes it easier to cache the status much easier if that is ever needed.