### PR TITLE
(Lazily) fix #131 by ignoring hashtags that begin with a ampersand in lexer

### DIFF
--- a/app/Util/Lexer/Hashtag.php
+++ b/app/Util/Lexer/Hashtag.php
@@ -7,7 +7,7 @@ class Hashtag {
   public static function getHashtags($status)
   {  
     $hashtags = false;  
-    preg_match_all("/(#\w+)/u", $status, $matches);
+    preg_match_all("/(?<!&)(#\w+)/u", $status, $matches);
     if ($matches) {
         $res = array_count_values($matches[0]);
         $hashtags = array_keys($res);


### PR DESCRIPTION
The Hashtag lexer and some part of the application that is replacing untrusted text with HTML-safe versions are stepping on each other, causing #131 

This PR fixes the issue on the Lexer side, which is likely not the best solution to the problem, as user input such as "#hashtag&#otherhashtag" is within the realm of possibility, and will no longer be linked due to this change.



