### PR TITLE
Add Finnish translations

### DIFF
--- a/resources/lang/fi/auth.php
+++ b/resources/lang/fi/auth.php
@@ -1,0 +1,19 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Authentication Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used during authentication for various
+    | messages that we need to display to the user. You are free to modify
+    | these language lines according to your application's requirements.
+    |
+    */
+
+    'failed' => 'Nämä kirjautumistiedot eivät vastaa tallennettuja',
+    'throttle' => 'Liian monta kirjautumisyritystä. Yrityä uudelleen :seconds sekuntin kuluttua.',
+
+];

--- a/resources/lang/fi/notification.php
+++ b/resources/lang/fi/notification.php
@@ -1,0 +1,8 @@
+<?php
+
+return [
+
+  'likedPhoto' => 'tykkäsi kuvastasi.',
+  'startedFollowingYou' => 'alkoi seuraamaan sinua.',
+
+];

--- a/resources/lang/fi/pagination.php
+++ b/resources/lang/fi/pagination.php
@@ -1,0 +1,19 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Pagination Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used by the paginator library to build
+    | the simple pagination links. You are free to change them to anything
+    | you want to customize your views to better match your application.
+    |
+    */
+
+    'previous' => '&laquo; Edellinen',
+    'next' => 'Seuraava &raquo;',
+
+];

--- a/resources/lang/fi/passwords.php
+++ b/resources/lang/fi/passwords.php
@@ -1,0 +1,22 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Password Reset Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are the default lines which match reasons
+    | that are given by the password broker for a password update attempt
+    | has failed, such as for an invalid token or invalid new password.
+    |
+    */
+
+    'password' => 'Salasanan täytyy olla vähintään kuusi merkkiä ja vastata vahvistusta.',
+    'reset' => 'Salasanasi on nollattu!',
+    'sent' => 'Olemme lähettäneet salasanan nollauslinkin sähköpostitse!',
+    'token' => 'Tämä salasanan nollauslinkki ei ole toimiva.',
+    'user' => "Emme löydä käyttäjää tuolla sähköpostiosoitteella.",
+
+];

--- a/resources/lang/fi/profile.php
+++ b/resources/lang/fi/profile.php
@@ -1,0 +1,9 @@
+<?php
+
+return [
+  'emptyTimeline' => 'Tällä käyttäjällä ei ole vielä päivityksiä!',
+  'emptyFollowers' => 'Tällä käyttäjällä ei ole vielä seuraajia!',
+  'emptyFollowing' => 'Tämä käyttäjä ei vielä seuraa ketään!',
+  'savedWarning'  => 'Only you can see what you\'ve saved',
+  'savedWarning'  => 'Vain sinä voit nähdä, mitä olet tallentanut',
+];

--- a/resources/lang/fi/timeline.php
+++ b/resources/lang/fi/timeline.php
@@ -1,0 +1,7 @@
+<?php
+
+return [
+
+  'emptyPersonalTimeline' => 'Aikajanasi on tyhjä.'
+
+];


### PR DESCRIPTION
I added Finnish translations for the user-facing parts of the app. The language is probably not perfect, but should be understandable and close to what the users expect from a service like this.

I don't think developers would like the error messages translated (most programmers I know use their tools in English), but I can also add those, if you want them.