### PR TITLE
Provide at least a major version of redis for the docker image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,7 +46,7 @@ services:
       - "mysql-data:/var/lib/mysql"
 
   redis:
-    image: redis:alpine
+    image: redis:4-alpine
     volumes:
       - "redis-data:/data"
     networks:


### PR DESCRIPTION
Considering Redis 5 is currently in RC, it would be safer to provide at least a major version of Redis, even if there is not compatibility issue yet.