### PR TITLE
Allow new posts without captions

### DIFF
--- a/app/Http/Controllers/StatusController.php
+++ b/app/Http/Controllers/StatusController.php
@@ -69,7 +69,7 @@ class StatusController extends Controller
 
         $this->validate($request, [
           'photo.*'   => 'required|mimes:jpeg,png,gif|max:' . config('pixelfed.max_photo_size'),
-          'caption' => 'string|max:' . config('pixelfed.max_caption_length'),
+          'caption' => 'nullable|string|max:' . config('pixelfed.max_caption_length'),
           'cw'      => 'nullable|string',
           'filter_class' => 'nullable|string',
           'filter_name' => 'nullable|string',

--- a/resources/views/status/show.blade.php
+++ b/resources/views/status/show.blade.php
@@ -96,10 +96,12 @@
         <div class="d-flex flex-md-column flex-column-reverse h-100">
           <div class="card-body status-comments">
             <div class="status-comment">
+              @unless (empty($status->caption))
               <p class="mb-1">
                 <span class="font-weight-bold pr-1">{{$status->profile->username}}</span>
                 <span class="comment-text" v-pre>{!! $status->rendered ?? e($status->caption) !!}</span>
               </p>
+              @endunless
               <p class="mb-1"><a href="{{$status->url()}}/c" class="text-muted">View all comments</a></p>
               <div class="comments">
                 @foreach($replies as $item)


### PR DESCRIPTION
Fixes #110

- [x] Posting a new item
- [ ] Atom feed item titles
- [ ] Alt text on carousel items (multi-photo statuses)
- [ ] OpenGraph description
- [ ] Comment sidebar

Would it make sense to use some sort of default caption for accessibility and metadata, _Photo by X on Y_ or something?