### PR TITLE
Change to pixelfed/pixelfed repo URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ This guide assumes you have NGINX/Apache installed, along with the dependencies.
 Those will not be covered in these early docs.
 
 ```bash
-git clone https://github.com/dansup/pixelfed.git
+git clone https://github.com/pixelfed/pixelfed.git
 cd pixelfed
 composer install
 cp .env.example .env

--- a/resources/views/site/opensource.blade.php
+++ b/resources/views/site/opensource.blade.php
@@ -7,7 +7,7 @@
   </div>
   <hr>
   <section>
-    <p class="lead">The software that powers this website is called <a href="https://pixelfed.org">PixelFed</a> and anyone can <a href="https://github.com/dansup/pixelfed">download</a> the source code and run their own instance!</p>
+    <p class="lead">The software that powers this website is called <a href="https://pixelfed.org">PixelFed</a> and anyone can <a href="https://github.com/pixelfed/pixelfed">download</a> the source code and run their own instance!</p>
   </section>
 @endsection
 


### PR DESCRIPTION
The project was moved under an org, but some URLs were pointing to the old location :)