### PR TITLE
Fix WebP support in Apache Docker image

### DIFF
--- a/contrib/docker/Dockerfile.apache
+++ b/contrib/docker/Dockerfile.apache
@@ -6,14 +6,14 @@ ARG COMPOSER_CHECKSUM="67bebe9df9866a795078bb2cf21798d8b0214f2e0b2fd81f2e907a8ef
 RUN apt-get update \
  && apt-get install -y --no-install-recommends git \
       optipng pngquant jpegoptim gifsicle \
-      libfreetype6 libjpeg62-turbo libpng16-16 libxpm4 libvpx4 libmagickwand-6.q16-3 \
-      libfreetype6-dev libjpeg62-turbo-dev libpng-dev libxpm-dev libvpx-dev libmagickwand-dev \
+      libfreetype6 libjpeg62-turbo libpng16-16 libxpm4 libwebp6 libmagickwand-6.q16-3 \
+      libfreetype6-dev libjpeg62-turbo-dev libpng-dev libxpm-dev libwebp-dev libmagickwand-dev \
  && docker-php-source extract \
  && docker-php-ext-configure gd \
       --with-freetype-dir=/usr/lib/x86_64-linux-gnu/ \
       --with-jpeg-dir=/usr/lib/x86_64-linux-gnu/ \
       --with-xpm-dir=/usr/lib/x86_64-linux-gnu/ \
-      --with-vpx-dir=/usr/lib/x86_64-linux-gnu/ \
+      --with-webp-dir=/usr/lib/x86_64-linux-gnu/ \
  && docker-php-ext-install pdo_mysql pcntl gd exif bcmath \
  && pecl install imagick \
  && docker-php-ext-enable imagick pcntl imagick gd exif \


### PR DESCRIPTION
With PHP 7, WebP support is now provided by libwebp instead of libvpx.

Reference: http://php.net/manual/en/image.installation.php

Fixes #556.