### PR TITLE
[700] Output image description in alt tags; expose editing for image descriptions from compose/edit screens

### DIFF
--- a/app/Http/Controllers/StatusController.php
+++ b/app/Http/Controllers/StatusController.php
@@ -103,6 +103,7 @@ class StatusController extends Controller
         $status->save();
 
         $photos = $request->file('photo');
+        $descriptions = $request->descriptions;
         $order = 1;
         $mimes = [];
         $medias = 0;
@@ -125,6 +126,7 @@ class StatusController extends Controller
             $media->original_sha256 = $hash;
             $media->size = $v->getSize();
             $media->mime = $v->getMimeType();
+            $media->caption = $descriptions[$k];
             $media->filter_class = $request->input('filter_class');
             $media->filter_name = $request->input('filter_name');
             $media->order = $order;
@@ -172,7 +174,7 @@ class StatusController extends Controller
     public function storeShare(Request $request)
     {
         $this->authCheck();
-        
+
         $this->validate($request, [
           'item'    => 'required|integer',
         ]);

--- a/resources/assets/js/components/presenter/PhotoPresenter.vue
+++ b/resources/assets/js/components/presenter/PhotoPresenter.vue
@@ -6,13 +6,13 @@
 				<p class="font-weight-light">(click to show)</p>
 			</summary>
 			<a class="max-hide-overflow" :href="status.url" :class="status.media_attachments[0].filter_class">
-				<img class="card-img-top" :src="status.media_attachments[0].url">
+				<img class="card-img-top" :src="status.media_attachments[0].url" :alt="status.media_attachments[0].caption">
 			</a>
 		</details>
 	</div>
 	<div v-else>
 		<div :class="status.media_attachments[0].filter_class">
-			<img class="card-img-top" :src="status.media_attachments[0].url">
+			<img class="card-img-top" :src="status.media_attachments[0].url" :alt="status.media_attachments[0].caption">
 		</div>
 	</div>
 </template>

--- a/resources/assets/js/components/statusform.js
+++ b/resources/assets/js/components/statusform.js
@@ -8,56 +8,59 @@ $(document).ready(function() {
     pixelfed.create.currentFilterClass = false;
 
     pixelfed.filters.list = [
-        ['1977','filter-1977'], 
-        ['Aden','filter-aden'], 
-        ['Amaro','filter-amaro'], 
-        ['Ashby','filter-ashby'], 
-        ['Brannan','filter-brannan'], 
-        ['Brooklyn','filter-brooklyn'], 
-        ['Charmes','filter-charmes'], 
-        ['Clarendon','filter-clarendon'], 
-        ['Crema','filter-crema'], 
-        ['Dogpatch','filter-dogpatch'], 
-        ['Earlybird','filter-earlybird'], 
-        ['Gingham','filter-gingham'], 
-        ['Ginza','filter-ginza'], 
-        ['Hefe','filter-hefe'], 
-        ['Helena','filter-helena'], 
-        ['Hudson','filter-hudson'], 
-        ['Inkwell','filter-inkwell'], 
-        ['Kelvin','filter-kelvin'], 
-        ['Kuno','filter-juno'], 
-        ['Lark','filter-lark'], 
-        ['Lo-Fi','filter-lofi'], 
-        ['Ludwig','filter-ludwig'], 
-        ['Maven','filter-maven'], 
-        ['Mayfair','filter-mayfair'], 
-        ['Moon','filter-moon'], 
-        ['Nashville','filter-nashville'], 
-        ['Perpetua','filter-perpetua'], 
-        ['Poprocket','filter-poprocket'], 
-        ['Reyes','filter-reyes'], 
-        ['Rise','filter-rise'], 
-        ['Sierra','filter-sierra'], 
-        ['Skyline','filter-skyline'], 
-        ['Slumber','filter-slumber'], 
-        ['Stinson','filter-stinson'], 
-        ['Sutro','filter-sutro'], 
-        ['Toaster','filter-toaster'], 
-        ['Valencia','filter-valencia'], 
-        ['Vesper','filter-vesper'], 
-        ['Walden','filter-walden'], 
-        ['Willow','filter-willow'], 
+        ['1977','filter-1977'],
+        ['Aden','filter-aden'],
+        ['Amaro','filter-amaro'],
+        ['Ashby','filter-ashby'],
+        ['Brannan','filter-brannan'],
+        ['Brooklyn','filter-brooklyn'],
+        ['Charmes','filter-charmes'],
+        ['Clarendon','filter-clarendon'],
+        ['Crema','filter-crema'],
+        ['Dogpatch','filter-dogpatch'],
+        ['Earlybird','filter-earlybird'],
+        ['Gingham','filter-gingham'],
+        ['Ginza','filter-ginza'],
+        ['Hefe','filter-hefe'],
+        ['Helena','filter-helena'],
+        ['Hudson','filter-hudson'],
+        ['Inkwell','filter-inkwell'],
+        ['Kelvin','filter-kelvin'],
+        ['Kuno','filter-juno'],
+        ['Lark','filter-lark'],
+        ['Lo-Fi','filter-lofi'],
+        ['Ludwig','filter-ludwig'],
+        ['Maven','filter-maven'],
+        ['Mayfair','filter-mayfair'],
+        ['Moon','filter-moon'],
+        ['Nashville','filter-nashville'],
+        ['Perpetua','filter-perpetua'],
+        ['Poprocket','filter-poprocket'],
+        ['Reyes','filter-reyes'],
+        ['Rise','filter-rise'],
+        ['Sierra','filter-sierra'],
+        ['Skyline','filter-skyline'],
+        ['Slumber','filter-slumber'],
+        ['Stinson','filter-stinson'],
+        ['Sutro','filter-sutro'],
+        ['Toaster','filter-toaster'],
+        ['Valencia','filter-valencia'],
+        ['Vesper','filter-vesper'],
+        ['Walden','filter-walden'],
+        ['Willow','filter-willow'],
         ['X-Pro II','filter-xpro-ii']
     ];
 
     function previewImage(input) {
         if (input.files && input.files[0]) {
           var reader = new FileReader();
+          $('.filterContainer').empty();
           reader.onload = function(e) {
-            $('.filterPreview').attr('src', e.target.result);
+            $('.filterContainer').append('<img class="filterPreview img-fluid" src="' + e.target.result + '" /><label for="description[]" class="font-weight-bold text-muted small">Description</label><input type="text" name="description[]" value="" class="form-control" />');
           }
-          reader.readAsDataURL(input.files[0]);
+          for (var i = 0; i < input.files.length; i++) {
+            reader.readAsDataURL(input.files[i]);
+          }
         }
     }
 

--- a/resources/views/status/edit.blade.php
+++ b/resources/views/status/edit.blade.php
@@ -14,7 +14,7 @@
           @csrf
           <div class="form-group mb-0">
             <label class="font-weight-bold text-muted small">Caption</label>
-            <input type="text" class="form-control" name="caption" id="caption" value="{{$status->caption}}" />
+            <input type="text" class="form-control" name="caption" id="caption" value="{{$status->caption}}"  //>
           </div>
           <div class="form-group mb-0">
             <label class="font-weight-bold text-muted small">CW/NSFW</label>

--- a/resources/views/status/edit.blade.php
+++ b/resources/views/status/edit.blade.php
@@ -13,6 +13,10 @@
       <div class="card-body">
           @csrf
           <div class="form-group mb-0">
+            <label class="font-weight-bold text-muted small">Caption</label>
+            <input type="text" class="form-control" name="caption" id="caption" value="{{$status->caption}}" />
+          </div>
+          <div class="form-group mb-0">
             <label class="font-weight-bold text-muted small">CW/NSFW</label>
             <div class="switch switch-sm">
               <input type="checkbox" class="switch" id="cw-switch" name="cw" {{$status->is_nsfw==true?'checked=""':''}} disabled="">
@@ -47,7 +51,7 @@
           <div class="form-group d-flex justify-content-between align-items-center mb-0">
             <p class="text-muted font-weight-bold mb-0 small">Last Updated: {{$media->updated_at->diffForHumans()}}</p>
             <button type="submit" class="btn btn-primary btn-sm font-weight-bold px-4">Update</button>
-          </div>  
+          </div>
         </div>
       </form>
       </div>
@@ -60,7 +64,7 @@
 
 @push('scripts')
 <script type="text/javascript">
-  
+
   $('.form-filters').each(function(i,d) {
     let el = $(d);
     let filter = el.data('filter');


### PR DESCRIPTION
Closes #700.

Exposes image descriptions in alt tags, as preferred by WCAG accessibility standards. Also adds description fields to the default compose screen. Also added a caption field to the edit screen to edit the overall caption.

(n.b. my local dev environment is a little janky right now, so this PR could use a close eye in testing.)