### PR TITLE
Make NSFW shade the same size as its container

### DIFF
--- a/resources/assets/sass/custom.scss
+++ b/resources/assets/sass/custom.scss
@@ -306,11 +306,19 @@ details summary::-webkit-details-marker {
 }
 
 .details-animated > summary {
-  display: block;
+  display: flex;
+  flex-flow: column;
+  justify-content: center;
   background-color: #ECF0F1;
   padding-top: 50px;
   padding-bottom: 50px;
   text-align: center;
+}
+
+@media (min-width: 720px) {
+  .details-animated > summary {
+    min-height: 600px;
+  }
 }
 
 .details-animated[open] > summary {


### PR DESCRIPTION
Before | After
--- | ---
![image](https://user-images.githubusercontent.com/10606431/50991484-63205480-14da-11e9-8017-cd2d0dc89e4b.png) | ![image](https://user-images.githubusercontent.com/10606431/50991456-4ab03a00-14da-11e9-815c-810a2c1033dd.png)

https://pixelfed.social/p/trwnh/30939

Potential next step would be to generate blurred thumbnails server-side and apply them as `background-image`.