### PR TITLE
mariadb works from 10.2.7 onward

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ testing and development.
 
 ## Requirements
  - PHP >= 7.1.3 < 7.3 (7.2.x recommended for stable version)
- - MySQL >= 5.7 (Postgres, MariaDB and sqlite are not supported)
+ - MySQL >= 5.7 or MariaDB >= 10.2.7 (Postgres and sqlite are not supported)
  - Redis
  - Composer
  - GD or ImageMagick


### PR DESCRIPTION
I assume the not supported status of MariaDB was due to missing JSON Data Type. That got introduced in 10.2.7 according to the docs[1] so it might make sense to update the README accordingly.

[1] https://mariadb.com/kb/en/library/json-data-type/