### PR TITLE
Speed up docker build times and decrease image size

### DIFF
--- a/contrib/docker/Dockerfile.fpm
+++ b/contrib/docker/Dockerfile.fpm
@@ -32,7 +32,7 @@ COPY . /var/www/
 WORKDIR /var/www/
 RUN cp -r storage storage.skel \
  && cp contrib/docker/php.ini /usr/local/etc/php/conf.d/pixelfed.ini \
- && composer install --prefer-source --no-interaction \
+ && composer install --prefer-dist --no-interaction \
  && rm -rf html && ln -s public html
 
 VOLUME ["/var/www/storage", "/var/www/public.ext"]


### PR DESCRIPTION
I was able to decrease build times significantly, and image size from ~1GB down to ~200MB with this change.

Contributing this back in-case it is helpful for others.