### PR TITLE
Cache status with liked/shared/bookmark state

### DIFF
--- a/app/Http/Controllers/CommentController.php
+++ b/app/Http/Controllers/CommentController.php
@@ -51,7 +51,7 @@ class CommentController extends Controller
         $profile = $user->profile;
         $status = Status::findOrFail($statusId);
 
-        Cache::forget('transform:status:'.$status->url());
+        Cache::tags($status->cache_tags())->flush();
 
         $reply = new Status();
         $reply->profile_id = $profile->id;

--- a/app/Http/Controllers/LikeController.php
+++ b/app/Http/Controllers/LikeController.php
@@ -26,7 +26,7 @@ class LikeController extends Controller
         $profile = Auth::user()->profile;
         $status = Status::withCount('likes')->findOrFail($request->input('item'));
 
-        Cache::forget('transform:status:'.$status->url());
+        Cache::tags($status->cache_tags())->flush();
 
         $count = $status->likes_count;
 

--- a/app/Http/Controllers/StatusController.php
+++ b/app/Http/Controllers/StatusController.php
@@ -218,7 +218,7 @@ class StatusController extends Controller
         $profile = Auth::user()->profile;
         $status = Status::withCount('shares')->findOrFail($request->input('item'));
 
-        Cache::forget('transform:status:'.$status->url());
+        Cache::tags($status->cache_tags())->flush();
 
         $count = $status->shares_count;
 

--- a/app/Status.php
+++ b/app/Status.php
@@ -108,6 +108,29 @@ class Status extends Model
         return url($path);
     }
 
+    public function cache_tags()
+    {
+        // allows flushing of
+        // - all cached statuses
+        // - every cached status of a user
+        // - single status with all states
+        return [
+            'status',
+            'username:' . $this->profile->username,
+            'status_id:' . (string) $this->id,
+        ];
+    }
+
+    public function cache_key()
+    {
+        // encode both individual status and it's liked/shared/bookmarked state for a user
+        return 'username:' . $this->profile->username .
+               ':status_id:' . (string) $this->id .
+               ':shared:'. (string) $this->shared() .
+               ':liked:' . (string) $this->liked() .
+               ':bookmarked:' . (string) $this->bookmarked();
+    }
+
     public function editUrl()
     {
         return $this->url().'/edit';

--- a/app/Transformer/Api/StatusTransformer.php
+++ b/app/Transformer/Api/StatusTransformer.php
@@ -17,7 +17,7 @@ class StatusTransformer extends Fractal\TransformerAbstract
 
     public function transform(Status $status)
     {
-        return Cache::remember('transform:status:'. $status->url(), 60, function() use($status) {
+        return Cache::tags($status->cache_tags())->remember($status->cache_key(), 60, function() use($status) {
             return [
                 'id'                        => (string) $status->id,
                 'uri'                       => $status->url(),

--- a/app/Transformer/Api/StatusTransformer.php
+++ b/app/Transformer/Api/StatusTransformer.php
@@ -17,33 +17,34 @@ class StatusTransformer extends Fractal\TransformerAbstract
 
     public function transform(Status $status)
     {
-        return [
-            'id'                        => (string) $status->id,
-            'uri'                       => $status->url(),
-            'url'                       => $status->url(),
-            'in_reply_to_id'            => $status->in_reply_to_id,
-            'in_reply_to_account_id'    => $status->in_reply_to_profile_id,
-            'reblog'                    => $status->reblog_of_id || $status->in_reply_to_id ? $this->transform($status->parent()) : null,
-            'content'                   => $status->rendered ?? $status->caption,
-            'created_at'                => $status->created_at->format('c'),
-            'emojis'                    => [],
-            'reblogs_count'             => $status->shares()->count(),
-            'favourites_count'          => $status->likes()->count(),
-            'reblogged'                 => $status->shared(),
-            'favourited'                => $status->liked(),
-            'muted'                     => null,
-            'sensitive'                 => (bool) $status->is_nsfw,
-            'spoiler_text'              => $status->cw_summary,
-            'visibility'                => $status->visibility,
-            'application'               => [
-                'name'      => 'web',
-                'website'   => null
-             ],
-            'language'                  => null,
-            'pinned'                    => null,
-
-            'pf_type'          => $status->type ?? $status->setType(),
-        ];
+        return Cache::tags($status->cache_tags())->remember($status->cache_key(), 60, function() use($status) {
+            return [
+                'id'                        => (string) $status->id,
+                'uri'                       => $status->url(),
+                'url'                       => $status->url(),
+                'in_reply_to_id'            => $status->in_reply_to_id,
+                'in_reply_to_account_id'    => $status->in_reply_to_profile_id,
+                'reblog'                    => $status->reblog_of_id || $status->in_reply_to_id ? $this->transform($status->parent()) : null,
+                'content'                   => $status->rendered ?? $status->caption,
+                'created_at'                => $status->created_at->format('c'),
+                'emojis'                    => [],
+                'reblogs_count'             => $status->shares()->count(),
+                'favourites_count'          => $status->likes()->count(),
+                'reblogged'                 => $status->shared(),
+                'favourited'                => $status->liked(),
+                'muted'                     => null,
+                'sensitive'                 => (bool) $status->is_nsfw,
+                'spoiler_text'              => $status->cw_summary,
+                'visibility'                => $status->visibility,
+                'application'               => [
+                    'name'      => 'web',
+                    'website'   => null
+                 ],
+                'language'                  => null,
+                'pinned'                    => null,
+                'pf_type'          => $status->type ?? $status->setType(),
+            ];
+        });
     }
 
     public function includeAccount(Status $status)


### PR DESCRIPTION
Each liked/shared/bookmarked state of a status needs to be cached individually, so it's displayed correctly to currently logged in user. One user might see it "liked" another not.

On update all cached status states need to be refreshed, so we are using cache tagging to flush all related cached objects.

This also allows flushing of all cached status objects, if needed.