### PR TITLE
Fix stacking icon from being on top of the header

### DIFF
--- a/resources/assets/js/components/Profile.vue
+++ b/resources/assets/js/components/Profile.vue
@@ -250,7 +250,7 @@
 		color: #fff;
 		position:relative;
 		margin-top: 10px;
-		z-index: 999999;
+		z-index: 10;
 		opacity: 0.6;
 		text-shadow: 3px 3px 16px #272634;
 	}


### PR DESCRIPTION
Hi there,
If you scroll with a post containing more than one pic, you can see the stacking icon being on top of the header. This commit fix that.
Have a nice day.