### PR TITLE
Fix open collective URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,6 @@
     },
     "collective": {
         "type": "opencollective",
-        "url": "https://opencollective.com/pixelfed-528"
+        "url": "https://opencollective.com/pixelfed"
     }
 }


### PR DESCRIPTION
The current URL is pointing a non existing page