### PR TITLE
Uses hashtag slug to build link

### DIFF
--- a/app/Util/Lexer/Autolink.php
+++ b/app/Util/Lexer/Autolink.php
@@ -676,7 +676,7 @@ class Autolink extends Regex
         $hash = StringUtils::substr($tweet, $entity['indices'][0], 1);
         $linkText = $hash.$entity['hashtag'];
 
-        $attributes['href'] = $this->url_base_hash.$entity['hashtag'].'?src=hash';
+        $attributes['href'] = $this->url_base_hash.str_slug($entity['hashtag']).'?src=hash';
         $attributes['title'] = '#'.$entity['hashtag'];
         if (!empty($this->class_hash)) {
             $class[] = $this->class_hash;


### PR DESCRIPTION
Fixes #895 

The query to fix existing links:
```sql
BEGIN;

CREATE FUNCTION lower_hashtag(rendered varchar) RETURNS varchar
AS $$
DECLARE
    match text;
BEGIN
  FOR match IN (select (REGEXP_MATCHES(rendered, '/tags/(.+)?src=hash', 'g'))[1])
  LOOP
    rendered = replace(rendered, match, lower(match));
  END LOOP;

  RETURN rendered;
END;
$$  LANGUAGE plpgsql;

UPDATE statuses SET rendered = lower_hashtag(rendered);

DROP FUNCTION lower_hashtag;

COMMIT;
```