### PR TITLE
Show language names in their language

### DIFF
--- a/resources/views/site/language.blade.php
+++ b/resources/views/site/language.blade.php
@@ -11,7 +11,7 @@
   <p class="font-weight-light">{{__('site.selectLocale')}}:</p>
   <ul class="list-group">
     @foreach(App\Util\Localization\Localization::languages() as $lang)
-    <a class="list-group-item font-weight-bold" href="/i/lang/{{$lang}}">{{locale_get_display_language($lang)}}</a>
+    <a class="list-group-item font-weight-bold" href="/i/lang/{{$lang}}">{{locale_get_display_language($lang, $lang)}}</a>
     @endforeach
   </ul>
 @endsection


### PR DESCRIPTION
So I'm not really sure if this works, but I think it should. See https://secure.php.net/manual/en/locale.getdisplaylanguage.php
This should make the language names on `/site/language` show up in the respective language. E. g. Czech should appear as "Čeština", German as "Deutsch", Russian as "Русский" etc.