### PR TITLE
actually fix apple mobile icon

### DIFF
--- a/resources/views/layouts/anon.blade.php
+++ b/resources/views/layouts/anon.blade.php
@@ -22,7 +22,8 @@
     <meta name="medium" content="image">
     <meta name="theme-color" content="#10c5f8">
     <meta name="apple-mobile-web-app-capable" content="yes">
-    <link rel="shortcut icon apple-touch-icon" type="image/png" href="/img/favicon.png?v=2">
+    <link rel="shortcut icon" type="image/png" href="/img/favicon.png?v=2">
+    <link rel="apple-touch-icon" type="image/png" href="/img/favicon.png?v=2">
     <link rel="canonical" href="{{request()->url()}}">
     <link href="{{ mix('css/app.css') }}" rel="stylesheet" data-stylesheet="light">
     @stack('styles')

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -21,7 +21,8 @@
     <meta name="medium" content="image">
     <meta name="theme-color" content="#10c5f8">
     <meta name="apple-mobile-web-app-capable" content="yes">
-    <link rel="shortcut icon apple-touch-icon" type="image/png" href="/img/favicon.png?v=2">
+    <link rel="shortcut icon" type="image/png" href="/img/favicon.png?v=2">
+    <link rel="apple-touch-icon" type="image/png" href="/img/favicon.png?v=2">
     <link rel="canonical" href="{{request()->url()}}">
     <link href="{{ mix('css/app.css') }}" rel="stylesheet" data-stylesheet="light">
     @stack('styles')

--- a/resources/views/layouts/blank.blade.php
+++ b/resources/views/layouts/blank.blade.php
@@ -20,7 +20,8 @@
     <meta name="medium" content="image">
     <meta name="theme-color" content="#10c5f8">
     <meta name="apple-mobile-web-app-capable" content="yes">
-    <link rel="shortcut icon apple-touch-icon" type="image/png" href="/img/favicon.png?v=2">
+    <link rel="shortcut icon" type="image/png" href="/img/favicon.png?v=2">
+    <link rel="apple-touch-icon" type="image/png" href="/img/favicon.png?v=2">
     <link rel="canonical" href="{{request()->url()}}">
     <link href="{{ mix('css/app.css') }}" rel="stylesheet" data-stylesheet="light">
     @stack('styles')

--- a/resources/views/layouts/bundle.blade.php
+++ b/resources/views/layouts/bundle.blade.php
@@ -21,7 +21,8 @@
     <meta name="medium" content="image">
     <meta name="theme-color" content="#10c5f8">
     <meta name="apple-mobile-web-app-capable" content="yes">
-    <link rel="shortcut icon apple-touch-icon" type="image/png" href="/img/favicon.png?v=2">
+    <link rel="shortcut icon" type="image/png" href="/img/favicon.png?v=2">
+    <link rel="apple-touch-icon" type="image/png" href="/img/favicon.png?v=2">
     <link rel="canonical" href="{{request()->url()}}">
     <link href="{{ mix('css/app.css') }}" rel="stylesheet" data-stylesheet="light">
     @stack('styles')

--- a/resources/views/site/index.blade.php
+++ b/resources/views/site/index.blade.php
@@ -20,7 +20,8 @@
     <meta name="medium" content="image">
     <meta name="theme-color" content="#10c5f8">
     <meta name="apple-mobile-web-app-capable" content="yes">
-    <link rel="shortcut icon apple-touch-icon" type="image/png" href="/img/favicon.png?v=2">
+    <link rel="shortcut icon" type="image/png" href="/img/favicon.png?v=2">
+    <link rel="apple-touch-icon" type="image/png" href="/img/favicon.png?v=2">
     <link href="{{ mix('css/app.css') }}" rel="stylesheet" data-stylesheet="light">
 </head>
 <body class="">


### PR DESCRIPTION
turns out it has to be defined separately, because safari doesn't recognize their own rel attributes unless they're standalone...