### PR TITLE
Remove hover text-decoration for icon-only links

### DIFF
--- a/resources/assets/sass/custom.scss
+++ b/resources/assets/sass/custom.scss
@@ -550,3 +550,9 @@ details summary::-webkit-details-marker {
 .tooltip-notification .tooltip.bs-tooltip-auto[x-placement^=top] .arrow::before, .tooltip.bs-tooltip-top .arrow::before {
     border-top-color: #dc3545; 
 }
+
+a:empty:hover {
+  &.fa, &.fab, &.fal, &.far, &.fas {
+    text-decoration: none;
+  }
+}


### PR DESCRIPTION
This might just be personal taste, but here's a proposed change to remove text-decoration for links that are Font Awesome icons only (no text).

Mouse over on cog-icon before:
![Screenshot 2019-04-02 at 10 06 09](https://user-images.githubusercontent.com/4582134/55386153-2b500880-552f-11e9-9dc8-4ed24eb990e3.png)

Mouse over on cog-icon after:
![Screenshot 2019-04-02 at 10 10 20](https://user-images.githubusercontent.com/4582134/55386333-91d52680-552f-11e9-8459-98acfaf60468.png)
