### PR TITLE
Add COSTAR

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -65,3 +65,7 @@ HORIZON_DARKMODE=true
 #   php artisan optimize
 ACTIVITY_PUB=false
 REMOTE_FOLLOW=false
+
+CS_BLOCKED_DOMAINS='example.org,example.net,example.com'
+CS_CW_DOMAINS='example.org,example.net,example.com'
+CS_UNLISTED_DOMAINS='example.org,example.net,example.com'

--- a/.env.testing
+++ b/.env.testing
@@ -56,3 +56,7 @@ MIX_API_SEARCH="${API_SEARCH}"
 
 TELESCOPE_ENABLED=false
 PF_MAX_USERS=1000
+
+CS_BLOCKED_DOMAINS='example.org,example.net,example.com'
+CS_CW_DOMAINS='example.org,example.net,example.com'
+CS_UNLISTED_DOMAINS='example.org,example.net,example.com'

--- a/app/Util/ActivityPub/Helpers.php
+++ b/app/Util/ActivityPub/Helpers.php
@@ -148,7 +148,10 @@ class Helpers {
 		$host = parse_url($valid, PHP_URL_HOST);
 
 		if(config('costar.enabled') == true) {
-			if(in_array($host, config('costar.domain.block')) == true) {
+			if(
+				(config('costar.domain.block') != null && in_array($host, config('costar.domain.block')) == true) || 
+				(config('costar.actor.block') != null && in_array($url, config('costar.actor.block')) == true)
+			) {
 				return false;
 			}
 		}
@@ -163,7 +166,7 @@ class Helpers {
 	public static function validateLocalUrl($url)
 	{
 		$url = self::validateUrl($url);
-		if($url) {
+		if($url == true) {
 			$domain = config('pixelfed.domain.app');
 			$host = parse_url($url, PHP_URL_HOST);
 			$url = $domain === $host ? $url : false;

--- a/app/Util/ActivityPub/Helpers.php
+++ b/app/Util/ActivityPub/Helpers.php
@@ -141,7 +141,19 @@ class Helpers {
 
 		$valid = filter_var($url, FILTER_VALIDATE_URL);
 
-		if(in_array(parse_url($valid, PHP_URL_HOST), $localhosts)) {
+		if(!$valid) {
+			return false;
+		}
+
+		$host = parse_url($valid, PHP_URL_HOST);
+
+		if(config('costar.enabled') == true) {
+			if(in_array($host, config('costar.domain.block')) == true) {
+				return false;
+			}
+		}
+
+		if(in_array($host, $localhosts)) {
 			return false;
 		}
 

--- a/config/costar.php
+++ b/config/costar.php
@@ -1,0 +1,21 @@
+<?php
+
+/* 
+ * COSTAR - Confirm Object Sentiment Transform and Reduce
+ *
+ * v 0.1
+ *
+ */
+
+
+
+return [
+	'enabled' => env('PF_COSTAR_ENABLED', true),
+
+	'domain' => [
+		'block' => env('CS_BLOCKED_DOMAINS', null) ? explode(',', env('CS_BLOCKED_DOMAINS')) : null,
+		'cw' => env('CS_CW_DOMAINS', null) ? explode(',', env('CS_CW_DOMAINS')) : null,
+		'unlisted' => env('CS_UNLISTED_DOMAINS', null) ? explode(',', env('CS_UNLISTED_DOMAINS')) : null,
+	],
+
+];

--- a/config/costar.php
+++ b/config/costar.php
@@ -18,4 +18,16 @@ return [
 		'unlisted' => env('CS_UNLISTED_DOMAINS', null) ? explode(',', env('CS_UNLISTED_DOMAINS')) : null,
 	],
 
+	'keyword' => [
+		'block' => env('CS_BLOCKED_KEYWORDS', null) ? explode(',', env('CS_BLOCKED_KEYWORDS')) : null,
+		'cw' => env('CS_CW_KEYWORDS', null) ? explode(',', env('CS_CW_KEYWORDS')) : null,
+		'unlisted' => env('CS_UNLISTED_KEYWORDS', null) ? explode(',', env('CS_UNLISTED_KEYWORDS')) : null,
+	],
+
+	'actor' => [
+		'block' => env('CS_BLOCKED_ACTOR', null) ? explode(',', env('CS_BLOCKED_ACTOR')) : null,
+		'cw' => env('CS_CW_ACTOR', null) ? explode(',', env('CS_CW_ACTOR')) : null,
+		'unlisted' => env('CS_UNLISTED_ACTOR', null) ? explode(',', env('CS_UNLISTED_ACTOR')) : null,
+	]
+
 ];

--- a/tests/Unit/CostarTest.php
+++ b/tests/Unit/CostarTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Util\ActivityPub\Helpers;
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+class CostarTest extends TestCase
+{
+    /** @test */
+    public function blockedDomain()
+    {
+    	$domains = config('costar.domain.block');
+        $this->assertTrue(in_array('example.net', $domains));
+
+        $blockedDomain = 'https://example.org/user/replyGuy';
+        $this->assertFalse(Helpers::validateUrl($blockedDomain));
+
+        $unblockedDomain = 'https://pixelfed.org/user/pixelfed';
+        $this->assertEquals(Helpers::validateUrl($unblockedDomain), $unblockedDomain);
+    }
+}


### PR DESCRIPTION
COSTAR (Confirm Object Sentiment Transform and Reduce) is a filter system for pixelfed inspired by the MRF (Message Rewrite Facility) feature in Pleroma. 

This PR adds basic COSTAR support with the following features:
- [x] Block instances 
Block instances at the AP level, preventing users from following users on blocked instances or from remote content from being stored

- [x] Auto CW instances
Apply a content warning to every post from this instance

- [x] Un-list instances from timelines
Remove posts from network timeline

- [x] Keyword filter
Block posts containing a specific keyword

- [x] Actor block
Block a specific remote actor/profile