### PR TITLE
Override font-weight-lighter to 300

### DIFF
--- a/resources/assets/sass/_variables.scss
+++ b/resources/assets/sass/_variables.scss
@@ -5,6 +5,7 @@ $body-bg: #f5f8fa;
 // Typography
 $font-family-sans-serif:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
 $font-size-base: 0.9rem;
+$font-weight-lighter: 300;
 $line-height-base: 1.6;
 
 $font-size-lg: ($font-size-base * 1.25);

--- a/resources/assets/sass/custom.scss
+++ b/resources/assets/sass/custom.scss
@@ -132,6 +132,10 @@ body, button, input, textarea {
     background-color: rgba(0,0,0,0.5);
 }
 
+.font-weight-lighter {
+    font-weight: 300 !important
+}
+
 .font-weight-ultralight {
     font-weight: 200 !important;
 }


### PR DESCRIPTION
200 is unreadable. Also future refactoring (for v0.12) should rely less on bootstrap styling and more on locally-scoped vue components

Before | After
--- | ---
![image](https://user-images.githubusercontent.com/10606431/56780258-356acd00-67a4-11e9-8b52-9708a560eb4a.png) | ![image](https://user-images.githubusercontent.com/10606431/56780245-27b54780-67a4-11e9-8024-8e1d15f42fa6.png)
