### PR TITLE
fix info overlay on small layouts

### DIFF
--- a/resources/assets/sass/custom.scss
+++ b/resources/assets/sass/custom.scss
@@ -124,6 +124,14 @@ body, button, input, textarea {
 
 .info-overlay:hover .info-overlay-text {
     display: flex;
+    h5 {
+        display: flex;
+        flex-flow: column;
+        justify-content: center;
+        align-items: center;
+        width: 100%;
+        height: 100%;
+    }
 }
 
 .info-overlay-text {


### PR DESCRIPTION
one row is not enough space; use flex column instead

Partial fix for #567 

First image is fixed, all other images are not fixed.
![image](https://user-images.githubusercontent.com/10606431/57008460-f7abe100-6bb5-11e9-9956-15bb0f8dc348.png)