### PR TITLE
Hide webkit scrollbar only on touch-only devices (fix #1285)

### DIFF
--- a/resources/assets/js/components/ComposeModal.vue
+++ b/resources/assets/js/components/ComposeModal.vue
@@ -214,9 +214,11 @@
 		color: #fff;
 		font-weight: bold;
 	}
-	.media-drawer-filters::-webkit-scrollbar {
-	    display: none;
-	}
+    @media (hover: none) and (pointer: coarse) {
+	    .media-drawer-filters::-webkit-scrollbar {
+	        display: none;
+	    }
+    }
 </style>
 <script type="text/javascript">
 export default {


### PR DESCRIPTION
on nontouch or hybrid devices, the scrollbar is needed to navigate filters. Fix #1285