### PR TITLE
fix Redis notification exception

### DIFF
--- a/app/Services/NotificationService.php
+++ b/app/Services/NotificationService.php
@@ -2,7 +2,8 @@
 
 namespace App\Services;
 
-use Cache, Redis;
+use Cache;
+use Illuminate\Support\Facades\Redis;
 use App\{
 	Notification,
 	Profile


### PR DESCRIPTION
Hi,

Without this change the request to `api/v1/notifications` fails for me.

```json
{
    "message": "Non-static method Redis::zRangeByScore() cannot be called statically",
    "exception": "Symfony\\Component\\Debug\\Exception\\FatalThrowableError",
    "file": "/var/www/pixelfed/app/Services/NotificationService.php",
    "line": 24,
    "trace": [
    ]
}
```

I'm using PHP 7.3.4-2 with the php-redis module.