### PR TITLE
change aspect ratio of status video player

### DIFF
--- a/resources/assets/js/components/presenter/VideoPresenter.vue
+++ b/resources/assets/js/components/presenter/VideoPresenter.vue
@@ -5,7 +5,7 @@
 				<p class="mb-0 lead font-weight-bold">{{ status.spoiler_text ? status.spoiler_text : 'CW / NSFW / Hidden Media'}}</p>
 				<p class="font-weight-light">(click to show)</p>
 			</summary>
-			<div class="embed-responsive embed-responsive-16by9">
+			<div class="embed-responsive embed-responsive-1by1">
 				<video class="video" preload="none" controls loop :poster="status.media_attachments[0].preview_url">
 					<source :src="status.media_attachments[0].url" :type="status.media_attachments[0].mime">
 				</video>


### PR DESCRIPTION
since posts are 1:1 and not 16:9, this allows the player to scale to the entire post container, while the media auto-fits itself within the player.

before | after
--- | ---
![image](https://user-images.githubusercontent.com/10606431/60329035-1f6cba80-9955-11e9-877e-76e35a9c173f.png) | ![image](https://user-images.githubusercontent.com/10606431/60329061-2f849a00-9955-11e9-89c0-05bed1ebd579.png)
