### PR TITLE
allow post-component to shrink to fit media

### DIFF
--- a/resources/assets/js/components/PostComponent.vue
+++ b/resources/assets/js/components/PostComponent.vue
@@ -390,11 +390,6 @@
   .postPresenterContainer {
     background: #fff;
   }
-  @media(min-width: 720px) {
-    .postPresenterContainer {
-      min-height: 600px;
-    }
-  }
   ::-webkit-scrollbar {
       width: 0px;
       background: transparent;


### PR DESCRIPTION
forcing a min-height causes sizing issues

before | after
--- | ---
![image](https://user-images.githubusercontent.com/10606431/60329395-e254f800-9955-11e9-9730-28224ac2a29b.png) | ![image](https://user-images.githubusercontent.com/10606431/60329429-f4369b00-9955-11e9-8d0f-a428354530ed.png)
