### PR TITLE
read IMAGE_DRIVER from env ('gd' or 'imagick')

### DIFF
--- a/config/image.php
+++ b/config/image.php
@@ -15,6 +15,6 @@ return [
     |
     */
 
-    'driver' => 'gd',
+    'driver' => env('IMAGE_DRIVER', 'gd'),
 
 ];


### PR DESCRIPTION
Remove hardcoded `gd` and allow setting `imagick`

i didn't update .env.example yet because i think it needs a more thorough update