### PR TITLE
v0.10.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 # Release Notes
 
-## [Unreleased](https://github.com/pixelfed/pixelfed/compare/v0.10.3...dev)
+## [Unreleased](https://github.com/pixelfed/pixelfed/compare/v0.10.4...dev)
 
 ### Added
+- Added ```software``` back to AccountTransformer [93c687c7](https://github.com/pixelfed/pixelfed/commit/93c687c7)
 
 ### Fixed
+- Fixed cache bug in privacy and terms pages [#1712](https://github.com/pixelfed/pixelfed/commit/fe522da8db7a8b0d7c18d405abcb885f8678f35c)
 
 ### Changed
     

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 ## [Unreleased](https://github.com/pixelfed/pixelfed/compare/v0.10.3...dev)
 
 ### Added
+
+### Fixed
+
+### Changed
+    
+    
+## [v0.10.4 (2019-09-24)](https://github.com/pixelfed/pixelfed/compare/v0.10.3...v0.10.4)
+
+### Added
 - Added Welsh translations [#1706](https://github.com/pixelfed/pixelfed/pull/1706)
 - Added Api v1 controller [85835f5a](https://github.com/pixelfed/pixelfed/commit/85835f5a6712dea0562df4be897087de5305750f)
 - Added database migration that adds a language column to the users table [c87d8c16](https://github.com/pixelfed/pixelfed/commit/c87d8c16)

--- a/app/Transformer/Api/AccountTransformer.php
+++ b/app/Transformer/Api/AccountTransformer.php
@@ -40,6 +40,7 @@ class AccountTransformer extends Fractal\TransformerAbstract
 			'fields' => [],
 			'bot' => false,
 			'website' => $profile->website,
+			'software' => 'pixelfed',
 			'is_admin' => (bool) $is_admin,
 		];
 	}

--- a/config/pixelfed.php
+++ b/config/pixelfed.php
@@ -23,7 +23,7 @@ return [
     | This value is the version of your Pixelfed instance.
     |
     */
-    'version' => '0.10.3',
+    'version' => '0.10.5',
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
## v0.10.5

### Added
- Added ```software``` back to AccountTransformer [93c687c7](https://github.com/pixelfed/pixelfed/commit/93c687c7)

### Fixed
- Fixed cache bug in privacy and terms pages [#1712](https://github.com/pixelfed/pixelfed/commit/fe522da8db7a8b0d7c18d405abcb885f8678f35c)
