### PR TITLE
Use correct ID when Accepting an activity

### DIFF
--- a/app/Util/ActivityPub/Inbox.php
+++ b/app/Util/ActivityPub/Inbox.php
@@ -197,7 +197,7 @@ class Inbox
                 'type'     => 'Accept',
                 'actor'    => $target->permalink(),
                 'object'   => [
-                    'id'        => $actor->permalink('#follows/' . $follower->id),
+                    'id'        => $this->payload['id'],
                     'actor'     => $actor->permalink(),
                     'type'      => 'Follow',
                     'object'    => $target->permalink()


### PR DESCRIPTION
see #1710 -- needs testing though bc idk if the syntax is right