### PR TITLE
composer prefer-dist instead of source

### DIFF
--- a/contrib/docker/Dockerfile.apache
+++ b/contrib/docker/Dockerfile.apache
@@ -44,7 +44,7 @@ COPY . /var/www/
 WORKDIR /var/www/
 RUN cp -r storage storage.skel \
  && cp contrib/docker/php.ini /usr/local/etc/php/conf.d/pixelfed.ini \
- && composer install --prefer-source --no-interaction \
+ && composer install --prefer-dist --no-interaction \
  && rm -rf html && ln -s public html
 
 VOLUME /var/www/storage /var/www/bootstrap


### PR DESCRIPTION
Use `--prefer-dist` option when creating docker (apache) image.

 `--prefer-source` may need too many time, and it not using in Dockefile.fpm.