### PR TITLE
Block username of known spammer

### DIFF
--- a/app/Util/Lexer/RestrictedNames.php
+++ b/app/Util/Lexer/RestrictedNames.php
@@ -6,6 +6,7 @@ class RestrictedNames
 {
     public static $blacklist = [
      'autoconfig',
+     'bedpage',
      'blog',
      'broadcasthost',
      'copyright',


### PR DESCRIPTION
This user is going through the list at https://fediverse.network/pixelfed looking for instances with open registration and spamming using this account.

Related Issue: #1601