### PR TITLE
Fix breaking docker build & Optimize docker build time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Updated StatusController, restrict edits to 24 hours ([ae24433b](https://github.com/pixelfed/pixelfed/commit/ae24433b))
 - Updated RateLimit, add max post edits per hour and day ([51fbfcdc](https://github.com/pixelfed/pixelfed/commit/51fbfcdc))
 - Updated Timeline.vue, move announcements from sidebar to top of timeline ([228f5044](https://github.com/pixelfed/pixelfed/commit/228f5044))
+- Updated lexer autolinker and extractor, add support for mentioned usernames containing dashes, periods and underscore characters ([f911c96d](https://github.com/pixelfed/pixelfed/commit/f911c96d))
 
 ## [v0.10.8 (2020-01-29)](https://github.com/pixelfed/pixelfed/compare/v0.10.7...v0.10.8)
 ### Added

--- a/app/Services/ActivityPubDeliveryService.php
+++ b/app/Services/ActivityPubDeliveryService.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Services;
+
+use App\Profile;
+use App\Util\ActivityPub\Helpers;
+use App\Util\ActivityPub\HttpSignature;
+
+class ActivityPubDeliveryService {
+
+	public $sender;
+	public $to;
+	public $payload;
+
+	public static function queue()
+	{
+		return new self;
+	}
+
+	public function from($profile)
+	{
+		$this->sender = $profile;
+		return $this;
+	}
+
+	public function to(string $url)
+	{
+		$this->to = $url;
+		return $this;
+	}
+
+	public function payload($payload)
+	{
+		$this->payload = $payload;
+		return $this;
+	}
+
+	public function send()
+	{
+		return $this->queueDelivery();
+	}
+
+	protected function queueDelivery()
+	{
+		abort_if(!$this->sender || !$this->to || !$this->payload, 400);
+		abort_if(!Helpers::validateUrl($this->to), 400);
+		abort_if($this->sender->domain != null || $this->sender->status != null, 400);
+
+		$body = $this->payload;
+		$payload = json_encode($body);
+		$headers = HttpSignature::sign($this->sender, $this->to, $body);
+
+		$ch = curl_init($this->to);
+		curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+		curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
+		curl_setopt($ch, CURLOPT_POSTFIELDS, $payload);
+		curl_setopt($ch, CURLOPT_HEADER, true);
+		curl_exec($ch);
+	}
+
+}

--- a/app/Util/ActivityPub/Helpers.php
+++ b/app/Util/ActivityPub/Helpers.php
@@ -23,6 +23,7 @@ use App\Jobs\ImageOptimizePipeline\{ImageOptimize,ImageThumbnail};
 use App\Jobs\StatusPipeline\NewStatusPipeline;
 use App\Util\ActivityPub\HttpSignature;
 use Illuminate\Support\Str;
+use App\Services\ActivityPubDeliveryService;
 
 class Helpers {
 
@@ -435,35 +436,12 @@ class Helpers {
 		return self::profileFirstOrNew($url);
 	}
 
-	public static function sendSignedObject($senderProfile, $url, $body)
+	public static function sendSignedObject($profile, $url, $body)
 	{
-		abort_if(!self::validateUrl($url), 400);
-
-		$payload = json_encode($body);
-		$headers = HttpSignature::sign($senderProfile, $url, $body);
-
-		$ch = curl_init($url);
-		curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-		curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
-		curl_setopt($ch, CURLOPT_POSTFIELDS, $payload);
-		curl_setopt($ch, CURLOPT_HEADER, true);
-		$response = curl_exec($ch);
-		return;
-	}
-
-	public static function apSignedPostRequest($senderProfile, $url, $body)
-	{
-		abort_if(!self::validateUrl($url), 400);
-
-		$payload = json_encode($body);
-		$headers = HttpSignature::sign($senderProfile, $url, $body);
-
-		$ch = curl_init($url);
-		curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-		curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
-		curl_setopt($ch, CURLOPT_POSTFIELDS, $payload);
-		curl_setopt($ch, CURLOPT_HEADER, true);
-		$response = curl_exec($ch);
-		return;
+		ActivityPubDeliveryService::queue()
+			->from($profile)
+			->to($url)
+			->payload($body)
+			->send();
 	}
 }

--- a/app/Util/Lexer/Regex.php
+++ b/app/Util/Lexer/Regex.php
@@ -162,9 +162,9 @@ abstract class Regex
         //      look-ahead capture here and don't append $after when we return.
         $tmp['valid_mention_preceding_chars'] = '([^a-zA-Z0-9_!#\$%&*@＠\/]|^|(?:^|[^a-z0-9_+~.-])RT:?)';
 
-        $re['valid_mentions_or_lists'] = '/'.$tmp['valid_mention_preceding_chars'].'(['.$tmp['at_signs'].'])([a-z0-9_]{1,20})((\/[a-z][a-z0-9_\-]{0,24})?(?=(.*|$))(?:@[a-z0-9\.\-]+[a-z0-9]+)?)/i';
+        $re['valid_mentions_or_lists'] = '/'.$tmp['valid_mention_preceding_chars'].'(['.$tmp['at_signs'].'])([a-z0-9_\-.]{1,20})((\/[a-z][a-z0-9_\-]{0,24})?(?=(.*|$))(?:@[a-z0-9\.\-]+[a-z0-9]+)?)/i';
 
-        $re['valid_reply'] = '/^(?:['.$tmp['spaces'].'])*['.$tmp['at_signs'].']([a-z0-9_]{1,20})(?=(.*|$))/iu';
+        $re['valid_reply'] = '/^(?:['.$tmp['spaces'].'])*['.$tmp['at_signs'].']([a-z0-9_\-.]{1,20})(?=(.*|$))/iu';
         $re['end_mention_match'] = '/\A(?:['.$tmp['at_signs'].']|['.$tmp['latin_accents'].']|:\/\/)/iu';
 
         // URL related hash regex collection

--- a/contrib/docker/Dockerfile.apache
+++ b/contrib/docker/Dockerfile.apache
@@ -43,7 +43,9 @@ COPY . /var/www/
 WORKDIR /var/www/
 RUN cp -r storage storage.skel \
  && cp contrib/docker/php.ini /usr/local/etc/php/conf.d/pixelfed.ini \
+ && composer global require hirak/prestissimo --no-interaction --no-suggest --prefer-dist \
  && composer install --prefer-dist --no-interaction \
+ && composer global remove hirak/prestissimo \
  && rm -rf html && ln -s public html
 
 VOLUME /var/www/storage /var/www/bootstrap

--- a/contrib/docker/Dockerfile.fpm
+++ b/contrib/docker/Dockerfile.fpm
@@ -1,3 +1,4 @@
+FROM php:7.4-fpm-buster
 ARG COMPOSER_VERSION="1.9.1"
 ARG COMPOSER_CHECKSUM="1f210b9037fcf82670d75892dfc44400f13fe9ada7af9e787f93e50e3b764111"
 
@@ -32,7 +33,9 @@ COPY . /var/www/
 WORKDIR /var/www/
 RUN cp -r storage storage.skel \
  && cp contrib/docker/php.ini /usr/local/etc/php/conf.d/pixelfed.ini \
+ && composer global require hirak/prestissimo --no-interaction --no-suggest --prefer-dist \
  && composer install --prefer-dist --no-interaction \
+ && composer global remove hirak/prestissimo \
  && rm -rf html && ln -s public html
 
 VOLUME /var/www/storage /var/www/bootstrap

--- a/contrib/docker/Dockerfile.fpm
+++ b/contrib/docker/Dockerfile.fpm
@@ -1,7 +1,5 @@
-FROM php:7.3-fpm-buster
-
-ARG COMPOSER_VERSION="1.8.5"
-ARG COMPOSER_CHECKSUM="4e4c1cd74b54a26618699f3190e6f5fc63bb308b13fa660f71f2a2df047c0e17"
+ARG COMPOSER_VERSION="1.9.1"
+ARG COMPOSER_CHECKSUM="1f210b9037fcf82670d75892dfc44400f13fe9ada7af9e787f93e50e3b764111"
 
 RUN apt-get update \
  && apt-get install -y --no-install-recommends apt-utils \
@@ -13,13 +11,12 @@ RUN apt-get update \
  && locale-gen && update-locale \
  && docker-php-source extract \
  && docker-php-ext-configure gd \
-      --enable-freetype \
-      --with-jpeg-dir=/usr/lib/x86_64-linux-gnu/ \
-      --with-xpm-dir=/usr/lib/x86_64-linux-gnu/ \
-      --with-webp-dir=/usr/lib/x86_64-linux-gnu/ \
+      --with-freetype \
+      --with-jpeg \
+      --with-webp \
+      --with-xpm \
  && docker-php-ext-install pdo_mysql pdo_pgsql pdo_sqlite pcntl gd exif bcmath intl zip curl \
- && pecl install imagick \
- && docker-php-ext-enable imagick pcntl imagick gd exif zip curl \
+ && docker-php-ext-enable pcntl gd exif zip curl \
  && curl -LsS https://getcomposer.org/download/${COMPOSER_VERSION}/composer.phar -o /usr/bin/composer \
  && echo "${COMPOSER_CHECKSUM}  /usr/bin/composer" | sha256sum -c - \
  && chmod 755 /usr/bin/composer \
@@ -33,7 +30,7 @@ ENV PATH="~/.composer/vendor/bin:./vendor/bin:${PATH}"
 COPY . /var/www/
 
 WORKDIR /var/www/
-RUN mkdir public.ext && cp -r storage storage.skel \
+RUN cp -r storage storage.skel \
  && cp contrib/docker/php.ini /usr/local/etc/php/conf.d/pixelfed.ini \
  && composer install --prefer-dist --no-interaction \
  && rm -rf html && ln -s public html

--- a/contrib/docker/Dockerfile.fpm
+++ b/contrib/docker/Dockerfile.fpm
@@ -59,7 +59,6 @@ ENV APP_ENV=production \
     ACTIVITY_PUB=false
 
 CMD cp -r storage.skel/* storage/ \
- && cp -r public/* public.ext/ \
  && chown -R www-data:www-data storage/ \
  && php artisan storage:link \
  && php artisan migrate --force \

--- a/tests/Unit/Lexer/UsernameTest.php
+++ b/tests/Unit/Lexer/UsernameTest.php
@@ -1,0 +1,179 @@
+<?php
+
+namespace Tests\Unit\Lexer;
+
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\WithFaker;
+use App\Util\Lexer\Autolink;
+use App\Util\Lexer\Extractor;
+
+class UsernameTest extends TestCase
+{
+	/** @test **/
+	public function genericUsername()
+	{
+		$username = '@dansup';
+		$entities = Extractor::create()->extract($username);
+		$autolink = Autolink::create()->autolink($username);
+		$expectedAutolink = '<a class="u-url mention" href="https://pixelfed.dev/dansup" rel="external nofollow noopener" target="_blank">@dansup</a>';
+		$expectedEntity = [
+			"hashtags" => [],
+			"urls" => [],
+			"mentions" => [
+				"dansup",
+			],
+			"replyto" => "dansup",
+			"hashtags_with_indices" => [],
+			"urls_with_indices" => [],
+			"mentions_with_indices" => [
+				[
+					"screen_name" => "dansup",
+					"indices" => [
+						0,
+						7,
+					],
+				],
+			],
+		];
+		$this->assertEquals($expectedAutolink, $autolink);
+		$this->assertEquals($expectedEntity, $entities);
+	}
+
+	/** @test **/
+	public function usernameWithPeriod()
+	{
+		$username = '@dansup.two';
+		$autolink = Autolink::create()->autolink($username);
+		$entities = Extractor::create()->extract($username);
+		$expectedAutolink = '<a class="u-url mention" href="https://pixelfed.dev/dansup.two" rel="external nofollow noopener" target="_blank">@dansup.two</a>';
+		$expectedEntity = [
+			"hashtags" => [],
+			"urls" => [],
+			"mentions" => [
+				"dansup.two",
+			],
+			"replyto" => "dansup.two",
+			"hashtags_with_indices" => [],
+			"urls_with_indices" => [],
+			"mentions_with_indices" => [
+				[
+					"screen_name" => "dansup.two",
+					"indices" => [
+						0,
+						11,
+					],
+				],
+			],
+		];
+		$this->assertEquals($expectedAutolink, $autolink);
+		$this->assertEquals($expectedEntity, $entities);
+	}
+
+	/** @test **/
+	public function usernameWithDash()
+	{
+		$username = '@dansup-too';
+		$autolink = Autolink::create()->autolink($username);
+		$entities = Extractor::create()->extract($username);
+		$expectedAutolink = '<a class="u-url mention" href="https://pixelfed.dev/dansup-too" rel="external nofollow noopener" target="_blank">@dansup-too</a>';
+		$expectedEntity = [
+			"hashtags" => [],
+			"urls" => [],
+			"mentions" => [
+				"dansup-too",
+			],
+			"replyto" => "dansup-too",
+			"hashtags_with_indices" => [],
+			"urls_with_indices" => [],
+			"mentions_with_indices" => [
+				[
+					"screen_name" => "dansup-too",
+					"indices" => [
+						0,
+						11,
+					],
+				],
+			],
+		];
+		$this->assertEquals($expectedAutolink, $autolink);
+		$this->assertEquals($expectedEntity, $entities);
+	}
+
+	/** @test **/
+	public function usernameWithUnderscore()
+	{
+		$username = '@dansup_too';
+		$autolink = Autolink::create()->autolink($username);
+		$entities = Extractor::create()->extract($username);
+		$expectedAutolink = '<a class="u-url mention" href="https://pixelfed.dev/dansup_too" rel="external nofollow noopener" target="_blank">@dansup_too</a>';
+		$expectedEntity = [
+			"hashtags" => [],
+			"urls" => [],
+			"mentions" => [
+				"dansup_too",
+			],
+			"replyto" => "dansup_too",
+			"hashtags_with_indices" => [],
+			"urls_with_indices" => [],
+			"mentions_with_indices" => [
+				[
+					"screen_name" => "dansup_too",
+					"indices" => [
+						0,
+						11,
+					],
+				],
+			],
+		];
+		$this->assertEquals($expectedAutolink, $autolink);
+		$this->assertEquals($expectedEntity, $entities);
+	}
+
+	/** @test **/
+	public function multipleMentions()
+	{
+		$text = 'hello @dansup and @pixelfed.team from @username_underscore';
+		$autolink = Autolink::create()->autolink($text);
+		$entities = Extractor::create()->extract($text);
+		$expectedAutolink = 'hello <a class="u-url mention" href="https://pixelfed.dev/dansup" rel="external nofollow noopener" target="_blank">@dansup</a> and <a class="u-url mention" href="https://pixelfed.dev/pixelfed.team" rel="external nofollow noopener" target="_blank">@pixelfed.team</a> from <a class="u-url mention" href="https://pixelfed.dev/username_underscore" rel="external nofollow noopener" target="_blank">@username_underscore</a>';
+		$expectedEntity = [
+			"hashtags" => [],
+			"urls" => [],
+			"mentions" => [
+				"dansup",
+				"pixelfed.team",
+				"username_underscore",
+			],
+			"replyto" => null,
+			"hashtags_with_indices" => [],
+			"urls_with_indices" => [],
+			"mentions_with_indices" => [
+				[
+					"screen_name" => "dansup",
+					"indices" => [
+						6,
+						13,
+					],
+				],
+				[
+					"screen_name" => "pixelfed.team",
+					"indices" => [
+						18,
+						32,
+					],
+				],
+				[
+					"screen_name" => "username_underscore",
+					"indices" => [
+						38,
+						58,
+					],
+				],
+			],
+		];
+
+		$this->assertEquals($expectedAutolink, $autolink);
+		$this->assertEquals($expectedEntity, $entities);
+	}
+
+}


### PR DESCRIPTION
# Fix breaking docker build
The Dockerfile.apache has been updated recently, but Dockerfile.fpm not. Due to this, the docker build is failing with the following error:
```
configure: error: unrecognized options: --enable-freetype
The command '/bin/sh -c apt-get update  && apt-get install -y --no-install-recommends apt-utils  && apt-get install -y --no-install-recommends git gosu       optipng pngquant jpegoptim gifsicle libpq-dev libsqlite3-dev locales zip unzip libzip-dev libcurl4-openssl-dev       libfreetype6 libicu-dev libjpeg62-turbo libpng16-16 libxpm4 libwebp6 libmagickwand-6.q16-6       libfreetype6-dev libjpeg62-turbo-dev libpng-dev libxpm-dev libwebp-dev libmagickwand-dev mariadb-client && sed -i '/en_US/s/^#//g' /etc/locale.gen  && locale-gen && update-locale  && docker-php-source extract  && docker-php-ext-configure gd       --enable-freetype       --with-jpeg-dir=/usr/lib/x86_64-linux-gnu/       --with-xpm-dir=/usr/lib/x86_64-linux-gnu/       --with-webp-dir=/usr/lib/x86_64-linux-gnu/  && docker-php-ext-install pdo_mysql pdo_pgsql pdo_sqlite pcntl gd exif bcmath intl zip curl  && pecl install imagick  && docker-php-ext-enable imagick pcntl imagick gd exif zip curl  && curl -LsS https://getcomposer.org/download/${COMPOSER_VERSION}/composer.phar -o /usr/bin/composer  && echo "${COMPOSER_CHECKSUM}  /usr/bin/composer" | sha256sum -c -  && chmod 755 /usr/bin/composer  && apt-get autoremove --purge -y        libfreetype6-dev libjpeg62-turbo-dev libpng-dev libxpm-dev libvpx-dev libmagickwand-dev  && rm -rf /var/cache/apt  && docker-php-source delete' returned a non-zero code: 1
```

This change updates Dockerfile.fpm to equal the Dockerfile.apache variant. (Except the fpm or apache specific settings)

# Optimize docker build time
Added https://github.com/hirak/prestissimo to optimize composer install during the docker build. The package is removed afterwards.