### PR TITLE
Add Instagram Import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Thai translations ([74cd536](https://github.com/pixelfed/pixelfed/commit/74cd536))
 - Added Bookmarks to v1 api ([99cb48c5](https://github.com/pixelfed/pixelfed/commit/99cb48c5))
 - Added New Post notification to Timeline ([a0e7c4d5](https://github.com/pixelfed/pixelfed/commit/a0e7c4d5))
+- Add Instagram Import ([e2a6bdd0](https://github.com/pixelfed/pixelfed/commit/e2a6bdd0))
 
 ### Updated
 - Updated PostComponent, fix remote urls ([42716ccc](https://github.com/pixelfed/pixelfed/commit/42716ccc))

--- a/app/Http/Controllers/Import/Instagram.php
+++ b/app/Http/Controllers/Import/Instagram.php
@@ -27,7 +27,7 @@ trait Instagram
             ->whereNotNull('completed_at')
             ->exists();
         if($completed == true) {
-            return redirect(route('settings'))->with(['errors' => ['You can only import from Instagram once.']]);
+            return redirect(route('settings'))->with(['error' => 'You can only import from Instagram once during the beta. Please report any issues!']);
         }
     	$job = $this->instagramRedirectOrNew();
     	return redirect($job->url());
@@ -160,7 +160,6 @@ trait Instagram
     {
         $profile = Auth::user()->profile;
 
-
         try {
         $import = ImportJob::whereProfileId($profile->id)
             ->where('uuid', $uuid)
@@ -173,8 +172,6 @@ trait Instagram
             \Log::info($e);
         }
 
-        return redirect(route('settings'))->with(['status' => [
-            'Import successful! It may take a few minutes to finish.'
-        ]]);
+        return redirect(route('settings'))->with(['status' => 'Import successful! It may take a few minutes to finish.']);
     }
 }

--- a/app/Http/Controllers/ImportController.php
+++ b/app/Http/Controllers/ImportController.php
@@ -6,15 +6,15 @@ use Illuminate\Http\Request;
 
 class ImportController extends Controller
 {
-    use Import\Instagram, Import\Mastodon;
+	use Import\Instagram, Import\Mastodon;
 
-    public function __construct()
-    {
-        $this->middleware('auth');
+	public function __construct()
+	{
+		$this->middleware('auth');
 
-        if(config('pixelfed.import.instagram.enabled') != true) {
-        	abort(404, 'Feature not enabled');
-        }
-    }
+		if(config('pixelfed.import.instagram.enabled') != true) {
+			abort(404, 'Feature not enabled');
+		}
+	}
 
 }

--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -172,7 +172,7 @@ class ProfileController extends Controller
         abort_if(!config('federation.activitypub.enabled'), 404);
         abort_if($user->domain, 404);
         $key = 'profile:ap:' . $user->id;
-        $ttl = now()->addHours(6);
+        $ttl = now()->addMinutes(15);
 
         return Cache::remember($key, $ttl, function() use($user) {
             $fractal = new Fractal\Manager();

--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -171,15 +171,11 @@ class ProfileController extends Controller
     {
         abort_if(!config('federation.activitypub.enabled'), 404);
         abort_if($user->domain, 404);
-        $key = 'profile:ap:' . $user->id;
-        $ttl = now()->addMinutes(15);
 
-        return Cache::remember($key, $ttl, function() use($user) {
-            $fractal = new Fractal\Manager();
-            $resource = new Fractal\Resource\Item($user, new ProfileTransformer);
-            $res = $fractal->createData($resource)->toArray();
-            return response(json_encode($res['data']))->header('Content-Type', 'application/activity+json');
-        });
+        $fractal = new Fractal\Manager();
+        $resource = new Fractal\Resource\Item($user, new ProfileTransformer);
+        $res = $fractal->createData($resource)->toArray();
+        return response(json_encode($res['data']))->header('Content-Type', 'application/activity+json');
     }
 
     public function showAtomFeed(Request $request, $user)

--- a/app/Http/Controllers/PublicApiController.php
+++ b/app/Http/Controllers/PublicApiController.php
@@ -567,9 +567,8 @@ class PublicApiController extends Controller
           ->whereIn('type', $scope)
           ->where('id', $dir, $id)
           ->whereIn('visibility', $visibility)
-          ->latest()
           ->limit($limit)
-          ->orderByDesc('created_at')
+          ->orderByDesc('id')
           ->get();
 
         $resource = new Fractal\Resource\Collection($timeline, new StatusTransformer());

--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -77,11 +77,13 @@ class SettingsController extends Controller
 
     public function dataImport()
     {
+        abort_if(!config('pixelfed.import.instagram.enabled'), 404);
         return view('settings.import.home');
     }
 
     public function dataImportInstagram()
     {
+        abort_if(!config('pixelfed.import.instagram.enabled'), 404);
         return view('settings.import.instagram.home');
     }
 

--- a/app/Jobs/ImportPipeline/ImportInstagram.php
+++ b/app/Jobs/ImportPipeline/ImportInstagram.php
@@ -11,7 +11,6 @@ use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use App\Jobs\ImageOptimizePipeline\ImageOptimize;
-use App\Jobs\StatusPipeline\NewStatusPipeline;
 use App\{
     ImportJob,
     ImportData,
@@ -56,11 +55,12 @@ class ImportInstagram implements ShouldQueue
 
         $job = ImportJob::findOrFail($this->import->id);
         $profile = Profile::findOrFail($job->profile_id);
+        $user = $profile->user;
         $json = $job->mediaJson();
-        $collection = $json['photos'];
+        $collection = array_reverse($json['photos']);
         $files = $job->files;
         $monthHash = hash('sha1', date('Y').date('m'));
-        $userHash = hash('sha1', $profile->id . (string) $profile->created_at);
+        $userHash = hash('sha1', $user->id . (string) $user->created_at);
         $fs = new Filesystem;
 
         foreach($collection as $import)
@@ -118,7 +118,6 @@ class ImportInstagram implements ShouldQueue
                 $media->order = 1;
                 $media->save();
                 ImageOptimize::dispatch($media);
-                NewStatusPipeline::dispatch($status);
             });
         }
 

--- a/config/pixelfed.php
+++ b/config/pixelfed.php
@@ -236,7 +236,7 @@ return [
 
     'import' => [
         'instagram' => [
-            'enabled' => false,
+            'enabled' => env('IMPORT_INSTAGRAM', false),
             'limits' => [
                 'posts' => (int) env('IMPORT_INSTAGRAM_POST_LIMIT', 100),
                 'size' => (int) env('IMPORT_INSTAGRAM_SIZE_LIMIT', 250)

--- a/resources/views/settings/import/home.blade.php
+++ b/resources/views/settings/import/home.blade.php
@@ -7,11 +7,10 @@
   </div>
   <hr>
   <section>
-    <p class="lead">Account Import allows you to import your data from a supported service.</p>
-    <p class="alert alert-warning"><strong>Warning: </strong> This is an experimental beta feature. Use at your own risk!</p>
+    <p class="lead">Account Import allows you to import your data from a supported service. <a href="#">Learn more.</a></p>
     <p class="alert alert-warning"><strong>Warning: </strong> Imported posts will not appear on timelines or be delivered to followers.</p>
   </section>
-  <section class="mt-5">
+  <section class="mt-4">
     <p class="small text-muted font-weight-bold text-uppercase mb-3">Supported Services</p>
     <p class="">
       <a class="btn btn-outline-primary font-weight-bold" href="{{route('settings.import.ig')}}">Import from Instagram</a>
@@ -19,10 +18,10 @@
     <hr>
     <p class="small text-muted font-weight-bold text-uppercase mb-3">Coming Soon</p>
     <p class="">
-      <a class="btn btn-outline-secondary font-weight-bold disabled" href="#">Import from Mastodon</a>
+      <a class="btn btn-outline-secondary font-weight-bold disabled" href="#">Import from Pixelfed</a>
     </p>
     <p class="">
-      <a class="btn btn-outline-secondary font-weight-bold disabled" href="#">Import from Tumblr</a>
+      <a class="btn btn-outline-secondary font-weight-bold disabled" href="#">Import from Mastodon</a>
     </p>
   </section>
 @endsection

--- a/resources/views/settings/import/instagram/home.blade.php
+++ b/resources/views/settings/import/instagram/home.blade.php
@@ -19,7 +19,7 @@
     <ol class="lead mb-4">
       <li>Upload media.json file</li>      
       <li>Upload photos directory</li>      
-      <li>Confirm each post</li>      
+      {{-- <li>Confirm each post</li> --}}
       <li>Import Data</li>      
     </ol>
     <form method="post">

--- a/resources/views/settings/partial/sidebar.blade.php
+++ b/resources/views/settings/partial/sidebar.blade.php
@@ -39,9 +39,9 @@
       <li class="nav-item">
         <hr>
       </li>
-      {{-- <li class="nav-item pl-3 {{request()->is('*import*')?'active':''}}">
+      <li class="nav-item pl-3 {{request()->is('*import*')?'active':''}}">
         <a class="nav-link font-weight-light text-muted" href="{{route('settings.import')}}">Import</a>
-      </li> --}}
+      </li>
       <li class="nav-item pl-3 {{request()->is('settings/data-export')?'active':''}}">
         <a class="nav-link font-weight-light text-muted" href="{{route('settings.dataexport')}}">Data Export</a>
       </li>

--- a/resources/views/settings/partial/sidebar.blade.php
+++ b/resources/views/settings/partial/sidebar.blade.php
@@ -39,9 +39,11 @@
       <li class="nav-item">
         <hr>
       </li>
+      @if(config('pixelfed.import.instagram.enabled'))
       <li class="nav-item pl-3 {{request()->is('*import*')?'active':''}}">
         <a class="nav-link font-weight-light text-muted" href="{{route('settings.import')}}">Import</a>
       </li>
+      @endif
       <li class="nav-item pl-3 {{request()->is('settings/data-export')?'active':''}}">
         <a class="nav-link font-weight-light text-muted" href="{{route('settings.dataexport')}}">Data Export</a>
       </li>

--- a/routes/web.php
+++ b/routes/web.php
@@ -265,6 +265,15 @@ Route::domain(config('pixelfed.domain.app'))->middleware(['validemail', 'twofact
         Route::get('my/story', 'StoryController@iRedirect');
         Route::get('web/profile/_/{id}', 'InternalApiController@remoteProfile');
         Route::get('web/post/_/{profileId}/{statusid}', 'InternalApiController@remoteStatus');
+
+        Route::group(['prefix' => 'import', 'middleware' => 'dangerzone'], function() {
+            Route::get('job/{uuid}/1', 'ImportController@instagramStepOne');
+            Route::post('job/{uuid}/1', 'ImportController@instagramStepOneStore');
+            Route::get('job/{uuid}/2', 'ImportController@instagramStepTwo');
+            Route::post('job/{uuid}/2', 'ImportController@instagramStepTwoStore');
+            Route::get('job/{uuid}/3', 'ImportController@instagramStepThree');
+            Route::post('job/{uuid}/3', 'ImportController@instagramStepThreeStore');
+        });
     });
 
     Route::group(['prefix' => 'account'], function () {
@@ -362,6 +371,16 @@ Route::domain(config('pixelfed.domain.app'))->middleware(['validemail', 'twofact
         Route::get('invites', 'UserInviteController@show')->name('settings.invites');
         // Route::get('sponsor', 'SettingsController@sponsor')->name('settings.sponsor');
         // Route::post('sponsor', 'SettingsController@sponsorStore');
+        Route::prefix('import')->group(function() {
+          Route::get('/', 'SettingsController@dataImport')->name('settings.import');
+          Route::prefix('instagram')->group(function() {
+            Route::get('/', 'ImportController@instagram')->name('settings.import.ig');
+            Route::post('/', 'ImportController@instagramStart');
+          });
+          Route::prefix('mastodon')->group(function() {
+            Route::get('/', 'ImportController@mastodon')->name('settings.import.mastodon');
+          });
+        });
     });
 
     Route::group(['prefix' => 'site'], function () {


### PR DESCRIPTION
## Adds Instagram Import 🎉 🥳

Edit .env and add ```IMPORT_INSTAGRAM=true``` to enable.

Default limit is 100 posts, to change edit ```IMPORT_INSTAGRAM_POST_LIMIT``` .env variable with an integer.

Users can only perform one import during the beta, admins will be able to clear previous imports to allow them to try again if any issues arrise.