### PR TITLE
Fix IG Import

### DIFF
--- a/app/Http/Controllers/Import/Instagram.php
+++ b/app/Http/Controllers/Import/Instagram.php
@@ -69,8 +69,9 @@ trait Instagram
 
     public function instagramStepOneStore(Request $request, $uuid)
     {
+        $max = 'max:' . config('pixelfed.import.instagram.limits.size');
     	$this->validate($request, [
-    		'media.*' => 'required|mimes:bin,jpeg,png,gif|max:500',
+    		'media.*' => 'required|mimes:bin,jpeg,png,gif|'.$max,
     		//'mediajson' => 'required|file|mimes:json'
     	]);
     	$media = $request->file('media');

--- a/config/pixelfed.php
+++ b/config/pixelfed.php
@@ -239,7 +239,7 @@ return [
             'enabled' => env('IMPORT_INSTAGRAM', false),
             'limits' => [
                 'posts' => (int) env('IMPORT_INSTAGRAM_POST_LIMIT', 100),
-                'size' => (int) env('IMPORT_INSTAGRAM_SIZE_LIMIT', 250)
+                'size' => (int) env('IMPORT_INSTAGRAM_SIZE_LIMIT', 5000)
             ]
         ]
     ],


### PR DESCRIPTION
Removes hardcoded media size limit of 500 KB, new default is 5 MB.

To change the limit, add ```IMPORT_INSTAGRAM_SIZE_LIMIT``` to .env with a value in KB.