### PR TITLE
docker: update horizon command for laravel 7.x

### DIFF
--- a/contrib/docker/start.apache.sh
+++ b/contrib/docker/start.apache.sh
@@ -6,10 +6,10 @@ chown -R www-data:www-data storage/ bootstrap/
 
 # Refresh the environment
 php artisan storage:link
-php artisan horizon:assets
+php artisan horizon:publish
 php artisan route:cache
 php artisan view:cache
 php artisan config:cache
 
 # Finally run Apache
-exec apache2-foreground
+apache2-foreground

--- a/contrib/docker/start.fpm.sh
+++ b/contrib/docker/start.fpm.sh
@@ -6,10 +6,10 @@ chown -R www-data:www-data storage/ bootstrap/
 
 # Refresh the environment
 php artisan storage:link
-php artisan horizon:assets
+php artisan horizon:publish
 php artisan route:cache
 php artisan view:cache
 php artisan config:cache
 
 # Finally run FPM
-exec php-fpm
+php-fpm


### PR DESCRIPTION
I don't see it listed in the [changelog](https://github.com/laravel/horizon/blob/4.x/CHANGELOG.md), but the command for republishing assets changed from `assets` to `publish`: https://laravel.com/docs/7.x/horizon#upgrading-horizon