### PR TITLE
Set session locale fallback using global locale config

### DIFF
--- a/app/Listeners/AuthLogin.php
+++ b/app/Listeners/AuthLogin.php
@@ -136,6 +136,6 @@ class AuthLogin
 
     protected function userLanguage($user)
     {
-        session()->put('locale', $user->language ?? 'en');
+        session()->put('locale', $user->language ?? config('app.locale'));
     }
 }


### PR DESCRIPTION
When users don't set their locales the default is a constant `"en"`. I think set default using the global locale config is better. Let me know if it is not a good way to do that.