### PR TITLE
Improve error messages for username and email restricted on register page

### DIFF
--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -58,7 +58,6 @@ class RegisterController extends Controller
             $data['email'] = strtolower($data['email']);
         }
 
-        $this->validateUsername($data['username']);
         $this->validateEmail($data['email']);
 
         $usernameRules = [
@@ -86,6 +85,11 @@ class RegisterController extends Controller
                 $val = str_replace(['_', '.', '-'], '', $value);
                 if(!ctype_alnum($val)) {
                     return $fail('Username is invalid. Username must be alpha-numeric and may contain dashes (-), periods (.) and underscores (_).');
+                }
+
+                $restricted = RestrictedNames::get();
+                if (in_array($value, $restricted)) {
+                    return $fail('Username cannot be used.');
                 }
             },
         ];
@@ -121,15 +125,6 @@ class RegisterController extends Controller
             'email'    => $data['email'],
             'password' => Hash::make($data['password']),
         ]);
-    }
-
-    public function validateUsername($username)
-    {
-        $restricted = RestrictedNames::get();
-
-        if (in_array($username, $restricted)) {
-            return abort(403);
-        }
     }
 
     public function validateEmail($email)


### PR DESCRIPTION
When users try to register using restricted username or email the response is a default 403 "Sorry, this page isn't available".

I changed to use the same structures already used for others validations. Then the response will return to the form displaying a clear error message. Let me known if it is not a good way to do that.