### PR TITLE
Update HashidService.php

### DIFF
--- a/app/Services/HashidService.php
+++ b/app/Services/HashidService.php
@@ -21,7 +21,7 @@ class HashidService {
 			$shortcode = '';
 			while($id) {
 				$id = ($id - ($r = $id % $base)) / $base;
-				$shortcode = $cmap{$r} . $shortcode;
+				$shortcode = $cmap[$r] . $shortcode;
 			};
 			return $shortcode;
 		});


### PR DESCRIPTION
fix php 7.4 requirement, which causes the error 

`ERROR: Array and string offset access syntax with curly braces is deprecated {"userId":1,"exception":"[object] (ErrorException(code: 0): Array and string offset access syntax with curly braces is deprecated at /var/www/ap
p/Services/HashidService.php:24)`