### PR TITLE
2FA verification page issues

### DIFF
--- a/app/Http/Middleware/TwoFactorAuth.php
+++ b/app/Http/Middleware/TwoFactorAuth.php
@@ -21,7 +21,7 @@ class TwoFactorAuth
             $enabled = (bool) $user->{'2fa_enabled'};
             if($enabled != false) {
                 $checkpoint = 'i/auth/checkpoint';
-                if($request->session()->has('2fa.session.active') !== true && !$request->is($checkpoint))
+                if($request->session()->has('2fa.session.active') !== true && !$request->is($checkpoint) && !$request->is('logout'))
                 {
                     return redirect('/i/auth/checkpoint');
                 } elseif($request->session()->has('2fa.attempts') && (int) $request->session()->get('2fa.attempts') > 3) {

--- a/resources/views/auth/checkpoint.blade.php
+++ b/resources/views/auth/checkpoint.blade.php
@@ -41,7 +41,7 @@
                 </div>
             </div>
             <div class="d-flex justify-content-between pt-4 small">
-                <a class="text-lighter text-decoration-none" href="/{{Auth::user()->username}}">Logged in as: <span class="font-weight-bold text-muted">{{Auth::user()->username}}</span></a>
+                <span class="text-lighter text-decoration-none">Logged in as: <span class="font-weight-bold text-muted">{{Auth::user()->username}}</span></span>
                 <span>
                     <a class="text-decoration-none text-muted font-weight-bold" href="{{ route('logout') }}" onclick="event.preventDefault();document.getElementById('logout-form').submit();">Logout</a>
                     <form id="logout-form" action="{{ route('logout') }}" method="POST" style="display: none;">


### PR DESCRIPTION
Fixing two minor issues on 2FA verification page (the step after the login page):

1. The logout button was not working properly because the logout page redirect you back to the 2FA page.

2. The link to the profile of the logged user is useless since you cannot access anything without complete the 2FA process or logout.