### PR TITLE
Use json_decode in bookmarks api response

### DIFF
--- a/app/Http/Controllers/Api/ApiV1Controller.php
+++ b/app/Http/Controllers/Api/ApiV1Controller.php
@@ -49,11 +49,12 @@ use App\Services\{
     NotificationService,
     MediaPathService,
     SearchApiV2Service,
-    MediaBlocklistService
+    MediaBlocklistService,
+    StatusService
 };
 
 
-class ApiV1Controller extends Controller 
+class ApiV1Controller extends Controller
 {
 	protected $fractal;
 
@@ -1920,7 +1921,7 @@ class ApiV1Controller extends Controller
 
         $res = [];
         foreach($bookmarks as $id) {
-            $res[] = \App\Services\StatusService::get($id);
+            $res[] = json_decode(StatusService::get($id));
         }
         return $res;
     }


### PR DESCRIPTION
Because now, the json is double encoded, see https://github.com/pixelfed/pixelfed/issues/2317 for more background