### PR TITLE
Add support for configurable OAuth tokens and refresh tokens lifetime

### DIFF
--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -28,8 +28,8 @@ class AuthServiceProvider extends ServiceProvider
 
         if(config('pixelfed.oauth_enabled')) {
             Passport::routes(null, ['middleware' => ['twofactor', \Fruitcake\Cors\HandleCors::class]]);
-            Passport::tokensExpireIn(now()->addDays(15));
-            Passport::refreshTokensExpireIn(now()->addDays(30));
+            Passport::tokensExpireIn(now()->addDays(config('instance.oauth.token_expiration')));
+            Passport::refreshTokensExpireIn(now()->addDays(config('instance.oauth.refresh_expiration')));
             Passport::enableImplicitGrant();
             if(config('instance.oauth.pat.enabled')) {
                 Passport::personalAccessClientId(config('instance.oauth.pat.id'));

--- a/config/instance.php
+++ b/config/instance.php
@@ -55,6 +55,8 @@ return [
 	],
 
 	'oauth' => [
+		'token_expiration' => env('OAUTH_TOKEN_DAYS', 15),
+		'refresh_expiration' => env('OAUTH_REFRESH_DAYS', 30),
 		'pat' => [
 			'enabled' => env('OAUTH_PAT_ENABLED', false),
 			'id' 	  => env('OAUTH_PAT_ID'),


### PR DESCRIPTION
Previously, the lifetime of tokens and refresh tokens was hardcoded at
15 and 30 days.

Some instances administrators may wish to change these values.

This makes these two values configurable with the two .env variables:
OAUTH_TOKEN_DAYS and OAUTH_REFRESH_DAYS which are the lifetime in days
for these two tokens and refresh tokens.