### PR TITLE
Cache the results of profileFetch for 1 minute

### DIFF
--- a/app/Util/ActivityPub/Helpers.php
+++ b/app/Util/ActivityPub/Helpers.php
@@ -452,7 +452,14 @@ class Helpers {
 
 	public static function profileFetch($url)
 	{
-		return self::profileFirstOrNew($url);
+        $profile = Cache::remember('profile:external:'.$url, now()->addMinutes(1), function() use ($url) {
+            return self::profileFirstOrNew($url) || false;
+        });
+        if($profile != false) {
+            return $profile;
+        } else {
+            return;
+        }
 	}
 
 	public static function sendSignedObject($profile, $url, $body)


### PR DESCRIPTION
This should address #2202 where account suspensions on other ActivityPub implementations (Mastodon in this case) causes Pixelfed to attempt to fetch the user per Status that was deleted due to account suspensions.

I don't have a PHP environment so I can't test this myself unfortunately. I assume `Cache::remember` cannot store nulls.