### PR TITLE
Fix invalid value for attributes of 'img' tag

### DIFF
--- a/resources/assets/js/components/Activity.vue
+++ b/resources/assets/js/components/Activity.vue
@@ -15,7 +15,7 @@
 			<div class="row my-5">
 				<div class="col-12 col-md-8 offset-md-2">
 					<div v-if="notifications.length > 0" class="media mb-3 align-items-center px-3 border-bottom pb-3" v-for="(n, index) in notifications">
-						<img class="mr-2 rounded-circle" style="border:1px solid #ccc" :src="n.account.avatar" alt="" width="32px" height="32px">
+						<img class="mr-2 rounded-circle" style="border:1px solid #ccc" :src="n.account.avatar" alt="" width="32" height="32">
 						<div class="media-body font-weight-light">
 							<div v-if="n.type == 'favourite'">
 								<p class="my-0">
@@ -64,17 +64,17 @@
 						<div>
 							<div v-if="n.status && n.status && n.status.media_attachments && n.status.media_attachments.length">
 								<a :href="n.status.url">
-									<img :src="n.status.media_attachments[0].preview_url" width="32px" height="32px">
+									<img :src="n.status.media_attachments[0].preview_url" width="32" height="32">
 								</a>
 							</div>
 							<div v-else-if="n.status && n.status.parent && n.status.parent.media_attachments && n.status.parent.media_attachments.length">
 								<a :href="n.status.parent.url">
-									<img :src="n.status.parent.media_attachments[0].preview_url" width="32px" height="32px">
+									<img :src="n.status.parent.media_attachments[0].preview_url" width="32" height="32">
 								</a>
 							</div>
 							<!-- <div v-else-if="n.status && n.status.parent && n.status.parent.media_attachments && n.status.parent.media_attachments.length">
 								<a :href="n.status.parent.url">
-									<img :src="n.status.parent.media_attachments[0].preview_url" width="32px" height="32px">
+									<img :src="n.status.parent.media_attachments[0].preview_url" width="32" height="32">
 								</a>
 							</div> -->
 

--- a/resources/assets/js/components/ComposeClassic.vue
+++ b/resources/assets/js/components/ComposeClassic.vue
@@ -4,7 +4,7 @@
 	<div class="timeline">
 		<div class="card status-card card-md-rounded-0">
 			<div class="card-header d-inline-flex align-items-center bg-white">
-				<img v-bind:src="profile.avatar" width="32px" height="32px" style="border-radius: 32px;" class="box-shadow">
+				<img v-bind:src="profile.avatar" width="32" height="32" style="border-radius: 32px;" class="box-shadow">
 				<a class="username font-weight-bold pl-2 text-dark" v-bind:href="profile.url">
 					{{profile.username}}
 				</a>
@@ -65,13 +65,13 @@
 						<ul class="nav media-drawer-filters text-center">
 							<li class="nav-item">
 								<div class="p-1 pt-3">
-									<img :src="media[carouselCursor].url" width="100px" height="60px" v-on:click.prevent="toggleFilter($event, null)" class="cursor-pointer">
+									<img :src="media[carouselCursor].url" width="100" height="60" v-on:click.prevent="toggleFilter($event, null)" class="cursor-pointer">
 								</div>
 								<a :class="[media[carouselCursor].filter_class == null ? 'nav-link text-white active' : 'nav-link text-muted']" href="#" v-on:click.prevent="toggleFilter($event, null)">No Filter</a>
 							</li>
 							<li class="nav-item" v-for="(filter, index) in filters">
 								<div class="p-1 pt-3">
-									<img :src="media[carouselCursor].url" width="100px" height="60px" :class="filter[1]" v-on:click.prevent="toggleFilter($event, filter[1])">
+									<img :src="media[carouselCursor].url" width="100" height="60" :class="filter[1]" v-on:click.prevent="toggleFilter($event, filter[1])">
 								</div>
 								<a :class="[media[carouselCursor].filter_class == filter[1] ? 'nav-link text-white active' : 'nav-link text-muted']" href="#" v-on:click.prevent="toggleFilter($event, filter[1])">{{filter[0]}}</a>
 							</li>

--- a/resources/assets/js/components/ComposeModal.vue
+++ b/resources/assets/js/components/ComposeModal.vue
@@ -175,13 +175,13 @@
 								<ul class="nav media-drawer-filters text-center">
 									<li class="nav-item">
 										<div class="p-1 pt-3">
-											<img :src="media[carouselCursor].url" width="100px" height="60px" v-on:click.prevent="toggleFilter($event, null)" class="cursor-pointer">
+											<img :src="media[carouselCursor].url" width="100" height="60" v-on:click.prevent="toggleFilter($event, null)" class="cursor-pointer">
 										</div>
 										<a :class="[media[carouselCursor].filter_class == null ? 'nav-link text-primary active' : 'nav-link text-muted']" href="#" v-on:click.prevent="toggleFilter($event, null)">No Filter</a>
 									</li>
 									<li class="nav-item" v-for="(filter, index) in filters">
 										<div class="p-1 pt-3">
-											<img :src="media[carouselCursor].url" width="100px" height="60px" :class="filter[1]" v-on:click.prevent="toggleFilter($event, filter[1])">
+											<img :src="media[carouselCursor].url" width="100" height="60" :class="filter[1]" v-on:click.prevent="toggleFilter($event, filter[1])">
 										</div>
 										<a :class="[media[carouselCursor].filter_class == filter[1] ? 'nav-link text-primary active' : 'nav-link text-muted']" href="#" v-on:click.prevent="toggleFilter($event, filter[1])">{{filter[0]}}</a>
 									</li>
@@ -212,13 +212,13 @@
 								<ul class="nav media-drawer-filters text-center">
 									<li class="nav-item">
 										<div class="p-1 pt-3">
-											<img :src="media[carouselCursor].url" width="100px" height="60px" v-on:click.prevent="toggleFilter($event, null)" class="cursor-pointer">
+											<img :src="media[carouselCursor].url" width="100" height="60" v-on:click.prevent="toggleFilter($event, null)" class="cursor-pointer">
 										</div>
 										<a :class="[media[carouselCursor].filter_class == null ? 'nav-link text-primary active' : 'nav-link text-muted']" href="#" v-on:click.prevent="toggleFilter($event, null)">No Filter</a>
 									</li>
 									<li class="nav-item" v-for="(filter, index) in filters">
 										<div class="p-1 pt-3">
-											<img :src="media[carouselCursor].url" width="100px" height="60px" :class="filter[1]" v-on:click.prevent="toggleFilter($event, filter[1])">
+											<img :src="media[carouselCursor].url" width="100" height="60" :class="filter[1]" v-on:click.prevent="toggleFilter($event, filter[1])">
 										</div>
 										<a :class="[media[carouselCursor].filter_class == filter[1] ? 'nav-link text-primary active' : 'nav-link text-muted']" href="#" v-on:click.prevent="toggleFilter($event, filter[1])">{{filter[0]}}</a>
 									</li>
@@ -233,7 +233,7 @@
 					<div v-if="page == 3" class="w-100 h-100">
 						<div class="border-bottom mt-2">
 							<div class="media px-3">
-								<img :src="media[0].url" width="42px" height="42px" :class="[media[0].filter_class?'mr-2 ' + media[0].filter_class:'mr-2']">
+								<img :src="media[0].url" width="42" height="42" :class="[media[0].filter_class?'mr-2 ' + media[0].filter_class:'mr-2']">
 								<div class="media-body">
 									<div class="form-group">
 										<label class="font-weight-bold text-muted small d-none">Caption</label>
@@ -309,7 +309,7 @@
 						<div class="list-group">
 							<div v-for="(tag, index) in taggedUsernames" class="list-group-item d-flex justify-content-between">
 								<div class="media">
-									<img class="mr-2 rounded-circle border" :src="tag.avatar" width="24px" height="24px">
+									<img class="mr-2 rounded-circle border" :src="tag.avatar" width="24" height="24">
 									<div class="media-body">
 										<span class="font-weight-bold">{{tag.name}}</span>
 									</div>
@@ -416,7 +416,7 @@
 					<div v-if="page == 'altText'" class="w-100 h-100 p-3">
 						<div v-for="(m, index) in media">
 							<div class="media">
-								<img :src="m.preview_url" class="mr-3" width="50px" height="50px">
+								<img :src="m.preview_url" class="mr-3" width="50" height="50">
 								<div class="media-body">
 									<textarea class="form-control" v-model="m.alt" placeholder="Add a media description here..."></textarea>
 									<p class="help-text small text-right text-muted mb-0">{{m.alt ? m.alt.length : 0}}/140</p>
@@ -434,7 +434,7 @@
 						<div class="list-group mb-3">
 							<div class="list-group-item cursor-pointer compose-action border" @click="goBack()">
 								<div class="media">
-								  <img src="" class="mr-3" alt="" width="50px" height="50px">
+								  <img src="" class="mr-3" alt="" width="50" height="50">
 								  <div class="media-body">
 								    <h5 class="mt-0">collection title</h5>
 								    <p class="mb-0 text-muted small">3 Photos - Created 2h ago</p>
@@ -462,7 +462,7 @@
 
 					<div v-if="page == 'editMedia'" class="w-100 h-100 p-3">
 						<div class="media">
-							<img :src="media[carouselCursor].preview_url" class="mr-3" width="50px" height="50px">
+							<img :src="media[carouselCursor].preview_url" class="mr-3" width="50" height="50">
 							<div class="media-body">
 								<div class="form-group">
 									<label class="font-weight-bold text-muted small">Media Description</label>

--- a/resources/assets/js/components/FollowSuggestions.vue
+++ b/resources/assets/js/components/FollowSuggestions.vue
@@ -16,7 +16,7 @@
         </div>
         <div v-for="(user, index) in results">
           <div class="media " style="width:100%">
-            <img class="mr-3" :src="user.avatar" width="40px">
+            <img class="mr-3" :src="user.avatar" width="40">
             <div class="media-body" style="width:70%">
               <p class="my-0 font-weight-bold text-truncate" style="text-overflow: hidden">{{user.acct}} <span class="text-muted font-weight-normal">&commat;{{user.username}}</span></p>
               <a class="btn btn-outline-primary px-3 py-0" :href="user.url" style="border-radius:20px;">Follow</a>

--- a/resources/assets/js/components/NotificationCard.vue
+++ b/resources/assets/js/components/NotificationCard.vue
@@ -16,7 +16,7 @@
 					</div>
 				</div>
 				<div v-if="notifications.length > 0" class="media align-items-center px-3 py-2 border-bottom border-light" v-for="(n, index) in notifications">
-					<img class="mr-2 rounded-circle" style="border:1px solid #ccc" :src="n.account.avatar" alt="" width="32px" height="32px" onerror="this.onerror=null;this.src='/storage/avatars/default.png';">
+					<img class="mr-2 rounded-circle" style="border:1px solid #ccc" :src="n.account.avatar" alt="" width="32" height="32" onerror="this.onerror=null;this.src='/storage/avatars/default.png';">
 					<div class="media-body font-weight-light small">
 						<div v-if="n.type == 'favourite'">
 							<p class="my-0">
@@ -24,7 +24,7 @@
 								<span v-if="n.status.hasOwnProperty('media_attachments')">
 									<a class="font-weight-bold" v-bind:href="n.status.url" :id="'fvn-' + n.id">post</a>.
 									<b-popover :target="'fvn-' + n.id" title="" triggers="hover" placement="top" boundary="window">
-										<img :src="notificationPreview(n)" width="100px" height="100px" style="object-fit: cover;">
+										<img :src="notificationPreview(n)" width="100" height="100" style="object-fit: cover;">
 									</b-popover>
 								</span>
 								<span v-else>

--- a/resources/assets/js/components/PostComponent.vue
+++ b/resources/assets/js/components/PostComponent.vue
@@ -16,7 +16,7 @@
         <div class="d-flex d-md-none align-items-center justify-content-between card-header bg-white w-100">
           <div class="d-flex">
             <div class="status-avatar mr-2" @click="redirect(statusProfileUrl)">
-              <img :src="statusAvatar" width="24px" height="24px" style="border-radius:12px;" class="cursor-pointer">
+              <img :src="statusAvatar" width="24" height="24" style="border-radius:12px;" class="cursor-pointer">
             </div>
             <div class="username">
               <span class="username-link font-weight-bold text-dark cursor-pointer" @click="redirect(statusProfileUrl)">{{ statusUsername }}</span>
@@ -89,7 +89,7 @@
             <div class="d-md-flex d-none align-items-center justify-content-between card-header py-3 bg-white">
               <div class="d-flex align-items-center status-username text-truncate">
                 <div class="status-avatar mr-2" @click="redirect(statusProfileUrl)">
-                  <img :src="statusAvatar" width="24px" height="24px" style="border-radius:12px;" class="cursor-pointer">
+                  <img :src="statusAvatar" width="24" height="24" style="border-radius:12px;" class="cursor-pointer">
                 </div>
                 <div class="username">
                   <span class="username-link font-weight-bold text-dark cursor-pointer" @click="redirect(statusProfileUrl)">{{ statusUsername }}</span>
@@ -166,7 +166,7 @@
                       </p>
                       <div class="comments mt-3">
                         <div v-for="(reply, index) in results" class="pb-4 media" :key="'tl' + reply.id + '_' + index">
-                          <img :src="reply.account.avatar" class="rounded-circle border mr-3" width="42px" height="42px">
+                          <img :src="reply.account.avatar" class="rounded-circle border mr-3" width="42" height="42">
                           <div class="media-body">
                             <div v-if="reply.sensitive == true">
                               <span class="py-3">
@@ -199,7 +199,7 @@
                               </div>
                               <div v-if="reply.thread == true" class="comment-thread">
                                 <div v-for="(s, sindex) in reply.replies" class="pb-3 media" :key="'cr' + s.id + '_' + index">
-                                  <img :src="s.account.avatar" class="rounded-circle border mr-3" width="25px" height="25px">
+                                  <img :src="s.account.avatar" class="rounded-circle border mr-3" width="25" height="25">
                                   <div class="media-body">
                                     <p class="d-flex justify-content-between align-items-top read-more" style="overflow-y: hidden;">
                                       <span>
@@ -363,7 +363,7 @@
                     </span>
                   </p>
                 </div>
-                <a :href="statusProfileUrl" :title="statusUsername"><img :src="statusAvatar" class="rounded-circle border mr-3" alt="avatar" width="72px" height="72px"></a>
+                <a :href="statusProfileUrl" :title="statusUsername"><img :src="statusAvatar" class="rounded-circle border mr-3" alt="avatar" width="72" height="72"></a>
               </div>
               <div v-else class="media align-items-center mt-3">
                 <div class="media-body">
@@ -376,7 +376,7 @@
                     <a class="font-weight-bold small" href="#">Follow</a> -->
                   </p>
                 </div>
-                <a :href="statusProfileUrl" :title="statusUsername"><img :src="statusAvatar" class="rounded-circle border mr-3" alt="avatar" width="72px" height="72px"></a>
+                <a :href="statusProfileUrl" :title="statusUsername"><img :src="statusAvatar" class="rounded-circle border mr-3" alt="avatar" width="72" height="72"></a>
               </div>
               <hr>
               <div>
@@ -431,7 +431,7 @@
               </div>
               <div class="comment mt-4" style="max-height: 500px; overflow-y: auto;">
                 <div v-for="(reply, index) in results" :key="'tl' + reply.id + '_' + index" class="media mb-3 mt-2">
-                  <a :href="reply.account.url" :title="reply.account.username"><img :src="reply.account.avatar" class="rounded-circle border mr-3" alt="avatar" width="32px" height="32px"></a>
+                  <a :href="reply.account.url" :title="reply.account.username"><img :src="reply.account.avatar" class="rounded-circle border mr-3" alt="avatar" width="32" height="32"></a>
                   <div class="media-body">
                     <div class="d-flex justify-content-between">
                       <span>
@@ -484,7 +484,7 @@
       <div class="list-group-item border-0 py-1" v-for="(user, index) in likes" :key="'modal_likes_'+index">
         <div class="media">
           <a :href="user.url">
-            <img class="mr-3 rounded-circle box-shadow" :src="user.avatar" :alt="user.username + '’s avatar'" width="30px">
+            <img class="mr-3 rounded-circle box-shadow" :src="user.avatar" :alt="user.username + '’s avatar'" width="30">
           </a>
           <div class="media-body">
             <p class="mb-0" style="font-size: 14px">
@@ -517,7 +517,7 @@
       <div class="list-group-item border-0" v-for="(user, index) in shares" :key="'modal_shares_'+index">
         <div class="media">
           <a :href="user.url">
-            <img class="mr-3 rounded-circle box-shadow" :src="user.avatar" :alt="user.username + '’s avatar'" width="30px">
+            <img class="mr-3 rounded-circle box-shadow" :src="user.avatar" :alt="user.username + '’s avatar'" width="30">
           </a>
           <div class="media-body">
             <div class="d-inline-block">
@@ -600,7 +600,7 @@
       <div class="list-group-item border-0 py-1" v-for="(taguser, index) in status.taggedPeople" :key="'modal_taggedpeople_'+index">
         <div class="media">
           <a :href="'/'+taguser.username">
-            <img class="mr-3 rounded-circle box-shadow" :src="taguser.avatar" :alt="taguser.username + '’s avatar'" width="30px">
+            <img class="mr-3 rounded-circle box-shadow" :src="taguser.avatar" :alt="taguser.username + '’s avatar'" width="30">
           </a>
           <div class="media-body">
             <p class="pt-1 d-flex justify-content-between" style="font-size: 14px">

--- a/resources/assets/js/components/Profile.vue
+++ b/resources/assets/js/components/Profile.vue
@@ -36,10 +36,10 @@
 									<div class="row">
 										<div class="col-4">
 											<div v-if="hasStory" class="has-story cursor-pointer shadow-sm" @click="storyRedirect()">
-												<img :alt="profileUsername + '\'s profile picture'" class="rounded-circle" :src="profile.avatar" width="77px" height="77px">
+												<img :alt="profileUsername + '\'s profile picture'" class="rounded-circle" :src="profile.avatar" width="77" height="77">
 											</div>
 											<div v-else>
-												<img :alt="profileUsername + '\'s profile picture'" class="rounded-circle border" :src="profile.avatar" width="77px" height="77px">
+												<img :alt="profileUsername + '\'s profile picture'" class="rounded-circle border" :src="profile.avatar" width="77" height="77">
 											</div>
 										</div>
 										<div class="col-8">
@@ -78,10 +78,10 @@
 								<!-- DESKTOP PROFILE PICTURE -->
 								<div class="d-none d-md-block pb-3">
 									<div v-if="hasStory" class="has-story-lg cursor-pointer shadow-sm" @click="storyRedirect()">
-										<img :alt="profileUsername + '\'s profile picture'" class="rounded-circle box-shadow cursor-pointer" :src="profile.avatar" width="150px" height="150px">
+										<img :alt="profileUsername + '\'s profile picture'" class="rounded-circle box-shadow cursor-pointer" :src="profile.avatar" width="150" height="150">
 									</div>
 									<div v-else>
-										<img :alt="profileUsername + '\'s profile picture'" class="rounded-circle box-shadow" :src="profile.avatar" width="150px" height="150px">
+										<img :alt="profileUsername + '\'s profile picture'" class="rounded-circle box-shadow" :src="profile.avatar" width="150" height="150">
 									</div>
 									<p v-if="sponsorList.patreon || sponsorList.liberapay || sponsorList.opencollective" class="text-center mt-3">
 										<button type="button" @click="showSponsorModal" class="btn btn-outline-secondary font-weight-bold py-0">
@@ -293,10 +293,10 @@
 							</div>
 							<div class="col-4 text-center">
 								<div class="d-block d-md-none">
-									<img class="rounded-circle box-shadow" :src="profile.avatar" width="110px" height="110px" style="margin-top:-60px; border: 5px solid #fff">
+									<img class="rounded-circle box-shadow" :src="profile.avatar" width="110" height="110" style="margin-top:-60px; border: 5px solid #fff">
 								</div>
 								<div class="d-none d-md-block">
-									<img class="rounded-circle box-shadow" :src="profile.avatar" width="172px" height="172px" style="margin-top:-90px; border: 5px solid #fff">
+									<img class="rounded-circle box-shadow" :src="profile.avatar" width="172" height="172" style="margin-top:-90px; border: 5px solid #fff">
 								</div>
 							</div>
 							<div class="col-4 text-right mt-2">
@@ -397,7 +397,7 @@
 			<div class="list-group-item border-0 py-1" v-for="(user, index) in following" :key="'following_'+index">
 				<div class="media">
 					<a :href="user.url">
-						<img class="mr-3 rounded-circle box-shadow" :src="user.avatar" :alt="user.username + '’s avatar'" width="30px" loading="lazy">
+						<img class="mr-3 rounded-circle box-shadow" :src="user.avatar" :alt="user.username + '’s avatar'" width="30" loading="lazy">
 					</a>
 					<div class="media-body text-truncate">
 						<p class="mb-0" style="font-size: 14px">
@@ -444,7 +444,7 @@
 			<div class="list-group-item border-0 py-1" v-for="(user, index) in followers" :key="'follower_'+index">
 				<div class="media mb-0">
 					<a :href="user.url">
-						<img class="mr-3 rounded-circle box-shadow" :src="user.avatar" :alt="user.username + '’s avatar'" width="30px" height="30px" loading="lazy">
+						<img class="mr-3 rounded-circle box-shadow" :src="user.avatar" :alt="user.username + '’s avatar'" width="30" height="30" loading="lazy">
 					</a>
 					<div class="media-body mb-0">
 						<p class="mb-0" style="font-size: 14px">

--- a/resources/assets/js/components/ProfileDirectory.vue
+++ b/resources/assets/js/components/ProfileDirectory.vue
@@ -7,7 +7,7 @@
 				<div class="col-12 col-md-6 p-1" v-for="(profile, index) in profiles">
 					<div class="card card-body border shadow-none py-2">
 						<div class="media">
-							<a :href="profile.url"><img :src="profile.avatar" class="rounded-circle border mr-3" alt="..." width="40px" height="40px"></a>
+							<a :href="profile.url"><img :src="profile.avatar" class="rounded-circle border mr-3" alt="..." width="40" height="40"></a>
 							<div class="media-body">
 								<p class="mt-0 mb-0 font-weight-bold">
 									<a :href="profile.url" class="text-dark">{{profile.username}}</a>
@@ -23,7 +23,7 @@
 								<p class="mb-1">
 									<span v-for="(post, i) in profile.posts" class="shadow-sm" :key="'profile_posts_'+i">
 										<a :href="post.url" class="text-decoration-none mr-1">
-											<img :src="thumbUrl(post)" width="62.3px" height="62.3px" class="border rounded">
+											<img :src="thumbUrl(post)" width="62.3" height="62.3" class="border rounded">
 										</a>
 									</span>
 								</p>

--- a/resources/assets/js/components/RemotePost.vue
+++ b/resources/assets/js/components/RemotePost.vue
@@ -16,7 +16,7 @@
         <div class="d-flex d-md-none align-items-center justify-content-between card-header bg-white w-100">
           <div class="d-flex">
             <div class="status-avatar mr-2" @click="redirect(profileUrl)">
-              <img :src="statusAvatar" width="24px" height="24px" style="border-radius:12px;" class="cursor-pointer">
+              <img :src="statusAvatar" width="24" height="24" style="border-radius:12px;" class="cursor-pointer">
             </div>
             <div class="username">
               <span class="username-link font-weight-bold text-dark cursor-pointer" @click="redirect(profileUrl)">{{ statusUsername }}</span>
@@ -82,7 +82,7 @@
             <div class="d-md-flex d-none align-items-center justify-content-between card-header py-3 bg-white">
               <div class="d-flex align-items-center status-username text-truncate" data-toggle="tooltip" data-placement="bottom" :title="statusUsername">
                 <div class="status-avatar mr-2" @click="redirect(profileUrl)">
-                  <img :src="statusAvatar" width="24px" height="24px" style="border-radius:12px;" class="cursor-pointer">
+                  <img :src="statusAvatar" width="24" height="24" style="border-radius:12px;" class="cursor-pointer">
                 </div>
                 <div class="username">
                   <span class="username-link font-weight-bold text-dark cursor-pointer" @click="redirect(profileUrl)">{{ statusUsername }}</span>
@@ -147,7 +147,7 @@
                       </p>
                       <div class="comments">
                         <div v-for="(reply, index) in results" class="pb-4 media" :key="'tl' + reply.id + '_' + index">
-                          <img :src="reply.account.avatar" class="rounded-circle border mr-3" width="42px" height="42px">
+                          <img :src="reply.account.avatar" class="rounded-circle border mr-3" width="42" height="42">
                           <div class="media-body">
                             <div v-if="reply.sensitive == true">
                               <span class="py-3">
@@ -180,7 +180,7 @@
                               </div>
                               <div v-if="reply.thread == true" class="comment-thread">
                                 <div v-for="(s, sindex) in reply.replies" class="pb-3 media" :key="'cr' + s.id + '_' + index">
-                                  <img :src="s.account.avatar" class="rounded-circle border mr-3" width="25px" height="25px">
+                                  <img :src="s.account.avatar" class="rounded-circle border mr-3" width="25" height="25">
                                   <div class="media-body">
                                     <p class="d-flex justify-content-between align-items-top read-more" style="overflow-y: hidden;">
                                       <span>
@@ -261,7 +261,7 @@
       <div class="list-group-item border-0 py-1" v-for="(user, index) in likes" :key="'modal_likes_'+index">
         <div class="media">
           <a :href="user.url">
-            <img class="mr-3 rounded-circle box-shadow" :src="user.avatar" :alt="user.username + '’s avatar'" width="30px">
+            <img class="mr-3 rounded-circle box-shadow" :src="user.avatar" :alt="user.username + '’s avatar'" width="30">
           </a>
           <div class="media-body">
             <p class="mb-0" style="font-size: 14px">
@@ -294,7 +294,7 @@
       <div class="list-group-item border-0" v-for="(user, index) in shares" :key="'modal_shares_'+index">
         <div class="media">
           <a :href="user.url">
-            <img class="mr-3 rounded-circle box-shadow" :src="user.avatar" :alt="user.username + '’s avatar'" width="30px">
+            <img class="mr-3 rounded-circle box-shadow" :src="user.avatar" :alt="user.username + '’s avatar'" width="30">
           </a>
           <div class="media-body">
             <div class="d-inline-block">

--- a/resources/assets/js/components/RemoteProfile.vue
+++ b/resources/assets/js/components/RemoteProfile.vue
@@ -19,7 +19,7 @@
 					</div>
 					<div class="card-body pb-0">
 						<div class="mt-n5 mb-3">
-							<img class="rounded-circle p-1 border mt-n4 bg-white shadow" :src="profile.avatar" width="90px" height="90px;">
+							<img class="rounded-circle p-1 border mt-n4 bg-white shadow" :src="profile.avatar" width="90" height="90">
 							<span class="float-right mt-n1">
 								<span>
 									<button v-if="relationship && relationship.following == false" class="btn btn-outline-light py-0 px-3 mt-n1" style="font-size:13px; font-weight: 500;" @click="followProfile();">Follow</button>
@@ -63,7 +63,7 @@
 					<div class="col-12 mb-2" v-for="(status, index) in feed" :key="'remprop' + index">
 						<div class="card mb-sm-4 status-card card-md-rounded-0 shadow-none border cursor-pointer">
 								<div class="card-header d-inline-flex align-items-center bg-white">
-									<img v-bind:src="profile.avatar" width="38px" height="38px" style="border-radius: 38px;" onerror="this.onerror=null;this.src='/storage/avatars/default.png?v=2'">
+									<img v-bind:src="profile.avatar" width="38" height="38" style="border-radius: 38px;" onerror="this.onerror=null;this.src='/storage/avatars/default.png?v=2'">
 									<div class="pl-2">
 										<span class="username font-weight-bold text-dark">{{profile.username}}
 										</span>

--- a/resources/assets/js/components/SearchResults.vue
+++ b/resources/assets/js/components/SearchResults.vue
@@ -97,7 +97,7 @@
 					<a v-for="(profile, index) in results.profiles" class="mb-2 result-card" :href="buildUrl('profile', profile)">
 						<div class="pb-3">
 							<div class="media align-items-center py-2 pr-3">
-								<img class="mr-3 rounded-circle border" :src="profile.avatar" width="50px" height="50px">
+								<img class="mr-3 rounded-circle border" :src="profile.avatar" width="50" height="50">
 								<div class="media-body">
 									<p class="mb-0 text-truncate text-dark font-weight-bold" data-toggle="tooltip" :title="profile.value">
 										{{profile.value}}
@@ -124,7 +124,7 @@
 				</div>
 				<div v-if="results.statuses.length">
 					<a v-for="(status, index) in results.statuses" class="mr-2 result-card" :href="buildUrl('status', status)">
-						<img :src="status.thumb" width="90px" height="90px" class="mb-2">
+						<img :src="status.thumb" width="90" height="90" class="mb-2">
 					</a>
 				</div>
 				<div v-else>
@@ -181,7 +181,7 @@
 						</div>
 						<div class="card-body">
 							<div class="text-center mt-n5 mb-4">
-								<img class="rounded-circle p-1 border mt-n4 bg-white shadow" :src="profile.entity.thumb" width="90px" height="90px;" onerror="this.onerror=null;this.src='/storage/avatars/default.png';">
+								<img class="rounded-circle p-1 border mt-n4 bg-white shadow" :src="profile.entity.thumb" width="90" height="90" onerror="this.onerror=null;this.src='/storage/avatars/default.png';">
 							</div>
 							<p class="text-center lead font-weight-bold mb-1">{{profile.value}}</p>
 							<p class="text-center text-muted small text-uppercase mb-4"><!-- 2 followers --></p>
@@ -208,7 +208,7 @@
 						</div>
 						<div class="card-body">
 							<div class="text-center mt-n5 mb-4">
-								<img class="rounded-circle p-1 border mt-n4 bg-white shadow" :src="profile.entity.thumb" width="90px" height="90px;" onerror="this.onerror=null;this.src='/storage/avatars/default.png';">
+								<img class="rounded-circle p-1 border mt-n4 bg-white shadow" :src="profile.entity.thumb" width="90" height="90" onerror="this.onerror=null;this.src='/storage/avatars/default.png';">
 							</div>
 							<p class="text-center lead font-weight-bold mb-1">{{profile.value}}</p>
 							<p class="text-center text-muted small text-uppercase mb-4"><!-- 2 followers --></p>
@@ -231,7 +231,7 @@
 				<a v-for="(profile, index) in results.profiles" class="mb-2 result-card" :href="buildUrl('profile', profile)">
 					<div class="pb-3">
 						<div class="media align-items-center py-2 pr-3">
-							<img class="mr-3 rounded-circle border" :src="profile.entity.thumb" width="50px" height="50px" onerror="this.onerror=null;this.src='/storage/avatars/default.png';">
+							<img class="mr-3 rounded-circle border" :src="profile.entity.thumb" width="50" height="50" onerror="this.onerror=null;this.src='/storage/avatars/default.png';">
 							<div class="media-body">
 								<p class="mb-0 text-truncate text-dark font-weight-bold" data-toggle="tooltip" :title="profile.value">
 									{{profile.value}}
@@ -250,7 +250,7 @@
 			</div>
 			<div v-if="results.statuses.length" class="col-md-6 offset-3">
 				<a v-for="(status, index) in results.statuses" class="mr-2 result-card" :href="buildUrl('status', status)">
-					<img :src="status.thumb" width="90px" height="90px" class="mb-2" onerror="this.onerror=null;this.src='/storage/no-preview.png';">
+					<img :src="status.thumb" width="90" height="90" class="mb-2" onerror="this.onerror=null;this.src='/storage/no-preview.png';">
 				</a>
 			</div>
 		</div>
@@ -273,7 +273,7 @@
 							<div class="mt-n4 mb-2">
 								<div class="media">
 									
-									<img class="rounded-circle p-1 mr-2 border mt-n3 bg-white shadow" src="/storage/avatars/default.png" width="70px" height="70px;" onerror="this.onerror=null;this.src='/storage/avatars/default.png';">
+									<img class="rounded-circle p-1 mr-2 border mt-n3 bg-white shadow" src="/storage/avatars/default.png" width="70" height="70" onerror="this.onerror=null;this.src='/storage/avatars/default.png';">
 									<div class="media-body pt-3">
 										<p class="font-weight-bold mb-0">{{status.username}}</p>
 									</div>

--- a/resources/assets/js/components/StoryCompose.vue
+++ b/resources/assets/js/components/StoryCompose.vue
@@ -7,7 +7,7 @@
 			<!-- LANDING -->
 			<div v-if="page == 'landing'" class="card card-body bg-transparent border-0 shadow-none d-flex justify-content-center" style="height: 90vh;">
 				<div class="text-center flex-fill mt-5 pt-5">
-					<img src="/img/pixelfed-icon-grey.svg" width="60px" height="60px">
+					<img src="/img/pixelfed-icon-grey.svg" width="60" height="60">
 					<p class="font-weight-bold lead text-lighter mt-1">Stories</p>
 					<!-- <p v-if="loaded" class="font-weight-bold small text-uppercase text-muted">
 						<span>{{stories.length}} Active</span>
@@ -43,7 +43,7 @@
 						<button class="btn btn-outline-lighter btn-sm py-0 px-md-3"><i class="pr-2 fas fa-chevron-left fa-sm"></i> Delete</button>
 					</div>
 					<div class="d-flex align-items-center">
-						<img class="d-inline-block mr-2" src="/img/pixelfed-icon-grey.svg" width="30px" height="30px">
+						<img class="d-inline-block mr-2" src="/img/pixelfed-icon-grey.svg" width="30" height="30">
 						<span class="font-weight-bold lead text-lighter">Stories</span>
 					</div>
 					<div>
@@ -94,7 +94,7 @@
 
 			<div v-if="page == 'edit'" class="card card-body bg-transparent border-0 shadow-none d-flex justify-content-center" style="height: 90vh;">
 				<div class="text-center flex-fill mt-5 pt-5">
-					<img src="/img/pixelfed-icon-grey.svg" width="60px" height="60px">
+					<img src="/img/pixelfed-icon-grey.svg" width="60" height="60">
 					<p class="font-weight-bold lead text-lighter mt-1">Stories</p>
 				</div>
 				<div class="flex-fill py-5">
@@ -103,7 +103,7 @@
 							<div v-for="(story, index) in stories" class="list-group-item text-center text-dark" href="#">
 								<div class="media align-items-center">
 									<div class="mr-3 cursor-pointer" @click="showLightbox(story)">
-										<img :src="story.src" class="img-fluid" width="70px" height="70px">
+										<img :src="story.src" class="img-fluid" width="70" height="70">
 										<p class="small text-muted text-center mb-0">(expand)</p>
 									</div>
 									<div class="media-body">

--- a/resources/assets/js/components/Timeline.vue
+++ b/resources/assets/js/components/Timeline.vue
@@ -48,7 +48,7 @@
 									<div class="card-body text-center pt-3">
 										<p class="mb-0">
 											<a :href="'/'+rec.username">
-												<img :src="rec.avatar" class="img-fluid rounded-circle cursor-pointer" width="45px" height="45px" onerror="this.onerror=null;this.src='/storage/avatars/default.png?v=2'" alt="avatar">
+												<img :src="rec.avatar" class="img-fluid rounded-circle cursor-pointer" width="45" height="45" onerror="this.onerror=null;this.src='/storage/avatars/default.png?v=2'" alt="avatar">
 											</a>
 										</p>
 										<div class="py-3">
@@ -97,13 +97,13 @@
 
 					<div class="card mb-sm-4 status-card card-md-rounded-0 shadow-none border">
 						<div v-if="!modes.distractionFree && status" class="card-header d-inline-flex align-items-center bg-white">
-							<!-- <img v-bind:src="status.account.avatar" width="38px" height="38px" class="cursor-pointer" style="border-radius: 38px;" @click="profileUrl(status)" onerror="this.onerror=null;this.src='/storage/avatars/default.png?v=2'"> -->
+							<!-- <img v-bind:src="status.account.avatar" width="38" height="38" class="cursor-pointer" style="border-radius: 38px;" @click="profileUrl(status)" onerror="this.onerror=null;this.src='/storage/avatars/default.png?v=2'"> -->
 							<!-- <div v-if="hasStory" class="has-story has-story-sm cursor-pointer shadow-sm" @click="profileUrl(status)">
-								<img class="rounded-circle box-shadow" :src="status.account.avatar" width="32px" height="32px" onerror="this.onerror=null;this.src='/storage/avatars/default.png?v=2'">
+								<img class="rounded-circle box-shadow" :src="status.account.avatar" width="32" height="32" onerror="this.onerror=null;this.src='/storage/avatars/default.png?v=2'">
 							</div>
 							<div v-else> -->
 							<div>
-								<img class="rounded-circle box-shadow" :src="status.account.avatar" width="32px" height="32px" onerror="this.onerror=null;this.src='/storage/avatars/default.png?v=2'" alt="avatar">
+								<img class="rounded-circle box-shadow" :src="status.account.avatar" width="32" height="32" onerror="this.onerror=null;this.src='/storage/avatars/default.png?v=2'" alt="avatar">
 							</div>
 							<div class="pl-2">
 								<!-- <a class="d-block username font-weight-bold text-dark" v-bind:href="status.account.url" style="line-height:0.5;"> -->
@@ -173,7 +173,7 @@
 										<i class="far fa-user" data-toggle="tooltip" title="Tagged People"></i>
 										<span v-for="(tag, index) in status.taggedPeople" class="mr-n2">
 											<a :href="'/'+tag.username">
-												<img :src="tag.avatar" width="20px" height="20px" class="border rounded-circle" data-toggle="tooltip" :title="'@'+tag.username" alt="Avatar">
+												<img :src="tag.avatar" width="20" height="20" class="border rounded-circle" data-toggle="tooltip" :title="'@'+tag.username" alt="Avatar">
 											</a>
 										</span>
 									</span>
@@ -271,12 +271,12 @@
 						<div class="pb-2">
 							<div class="media d-flex align-items-center">
 								<a :href="!userStory ? profile.url : '/stories/' + profile.acct" class="mr-3">
-									<!-- <img class="mr-3 rounded-circle box-shadow" :src="profile.avatar || '/storage/avatars/default.png'" alt="avatar" width="64px" height="64px" onerror="this.onerror=null;this.src='/storage/avatars/default.png?v=2'"> -->
+									<!-- <img class="mr-3 rounded-circle box-shadow" :src="profile.avatar || '/storage/avatars/default.png'" alt="avatar" width="64" height="64" onerror="this.onerror=null;this.src='/storage/avatars/default.png?v=2'"> -->
 									<div v-if="userStory" class="has-story cursor-pointer shadow-sm" @click="storyRedirect()">
-										<img class="rounded-circle box-shadow" :src="profile.avatar" width="64px" height="64px" onerror="this.onerror=null;this.src='/storage/avatars/default.png?v=2'" alt="avatar">
+										<img class="rounded-circle box-shadow" :src="profile.avatar" width="64" height="64" onerror="this.onerror=null;this.src='/storage/avatars/default.png?v=2'" alt="avatar">
 									</div>
 									<div v-else>
-										<img class="rounded-circle box-shadow" :src="profile.avatar" width="64px" height="64px" onerror="this.onerror=null;this.src='/storage/avatars/default.png?v=2'" alt="avatar">
+										<img class="rounded-circle box-shadow" :src="profile.avatar" width="64" height="64" onerror="this.onerror=null;this.src='/storage/avatars/default.png?v=2'" alt="avatar">
 									</div>
 								</a>
 								<div class="media-body d-flex justify-content-between word-break" >
@@ -326,7 +326,7 @@
 						<div class="card-body pt-0">
 							<div v-for="(rec, index) in suggestions" class="media align-items-center mt-3">
 								<a :href="'/'+rec.username">
-									<img :src="rec.avatar" width="32px" height="32px" class="rounded-circle mr-3" onerror="this.onerror=null;this.src='/storage/avatars/default.png?v=2'" alt="avatar">
+									<img :src="rec.avatar" width="32" height="32" class="rounded-circle mr-3" onerror="this.onerror=null;this.src='/storage/avatars/default.png?v=2'" alt="avatar">
 								</a>
 								<div class="media-body">
 									<p class="mb-0 font-weight-bold small">
@@ -402,7 +402,7 @@
 						</div>
 					</a>
 					<div class="py-3 media align-items-center">
-						<a class="text-decoration-none" :href="s.account.url"><img :src="s.account.avatar" class="mr-3 rounded-circle shadow-sm" :alt="s.account.username + ' \'s avatar'" width="30px" height="30px" onerror="this.onerror=null;this.src='/storage/avatars/default.png?v=2'"></a>
+						<a class="text-decoration-none" :href="s.account.url"><img :src="s.account.avatar" class="mr-3 rounded-circle shadow-sm" :alt="s.account.username + ' \'s avatar'" width="30" height="30" onerror="this.onerror=null;this.src='/storage/avatars/default.png?v=2'"></a>
 						<div class="media-body">
 							<p class="mb-0 font-weight-bold small"><a class="text-dark" :href="s.account.url">{{s.account.username}}</a></p>
 							<p class="mb-0" style="line-height: 0.7;">

--- a/resources/views/account/circles/home.blade.php
+++ b/resources/views/account/circles/home.blade.php
@@ -19,7 +19,7 @@
 								</div>
 								<div class="col-md-4 text-center">
 									@foreach($circle->members()->orderByDesc('created_at')->take(8)->get() as $member)
-										<a href="{{$member->url()}}"><img src="{{$member->avatarUrl()}}" class="box-shadow rounded-circle ml-n3" width="40px" style="border:3px solid #fff;"></a>
+										<a href="{{$member->url()}}"><img src="{{$member->avatarUrl()}}" class="box-shadow rounded-circle ml-n3" width="40" style="border:3px solid #fff;"></a>
 									@endforeach
 								</div>
 								<div class="col-md-4 text-right">

--- a/resources/views/account/follow-requests.blade.php
+++ b/resources/views/account/follow-requests.blade.php
@@ -18,7 +18,7 @@
       @foreach($followers as $follow)
       <li class="list-group-item notification border-0">
           <span class="notification-icon pr-3">
-            <img src="{{$follow->follower->avatarUrl()}}" width="32px" class="rounded-circle">
+            <img src="{{$follow->follower->avatarUrl()}}" width="32" class="rounded-circle">
           </span>
           <span class="notification-text">
             <a class="font-weight-bold text-dark" href="{{$follow->follower->url()}}">{{$follow->follower->username}}</a> {{__('wants to follow you')}}

--- a/resources/views/account/following.blade.php
+++ b/resources/views/account/following.blade.php
@@ -41,7 +41,7 @@
         @case('like')
           <span class="notification-icon pr-3">
             <img src="{{optional($notification->actor, function($actor) {
-              return $actor->avatarUrl(); }) }}" width="32px" class="rounded-circle">
+              return $actor->avatarUrl(); }) }}" width="32" class="rounded-circle">
           </span>
           <span class="notification-text">
             <a class="font-weight-bold text-dark" href="{{$notification->actor->url()}}">{{$notification->actor->username}}</a>
@@ -54,14 +54,14 @@
           </span>
           <span class="float-right notification-action">
             @if($notification->item_id && $notification->item_type == 'App\Status')
-              <a href="{{$notification->status->url()}}"><img src="{{$notification->status->thumb()}}" width="32px" height="32px"></a>
+              <a href="{{$notification->status->url()}}"><img src="{{$notification->status->thumb()}}" width="32" height="32"></a>
             @endif
           </span>
         @break
 
         @case('follow')
           <span class="notification-icon pr-3">
-            <img src="{{$notification->actor->avatarUrl()}}" width="32px" class="rounded-circle">
+            <img src="{{$notification->actor->avatarUrl()}}" width="32" class="rounded-circle">
           </span>
           <span class="notification-text">
             <a class="font-weight-bold text-dark" href="{{$notification->actor->url()}}">{{$notification->actor->username}}</a>

--- a/resources/views/admin/discover/home.blade.php
+++ b/resources/views/admin/discover/home.blade.php
@@ -16,7 +16,7 @@
 			<div>
 				<a class="font-weight-lighter small mr-3" href="/i/admin/media/show/{{$category->id}}">{{$category->id}}</a>
 				<a href="{{$category->url()}}">
-					<img class="" src="{{$category->thumb()}}" width="60px" height="60px">
+					<img class="" src="{{$category->thumb()}}" width="60" height="60">
 				</a>
 			</div>
 			<div>

--- a/resources/views/admin/messages/show.blade.php
+++ b/resources/views/admin/messages/show.blade.php
@@ -30,7 +30,7 @@
 		<div class="card shadow-none border">
 			<div class="card-header bg-white">
 				<div class="media">
-					<img src="{{$message->user->profile->avatarUrl()}}" class="mr-3 rounded-circle" width="40px" height="40px">
+					<img src="{{$message->user->profile->avatarUrl()}}" class="mr-3 rounded-circle" width="40" height="40">
 					<div class="media-body">
 						<h5 class="my-0">&commat;{{$message->user->username}}</h5>
 						<span class="text-muted">{{$message->user->email}}</span>

--- a/resources/views/admin/users/home.blade.php
+++ b/resources/views/admin/users/home.blade.php
@@ -36,7 +36,7 @@
 					<span class="text-danger" class="text-monospace">{{$user->id}}</span>
 				</th>
 				<td class="text-left">
-					<img src="/storage/avatars/default.png?v=3" width="28px" class="rounded-circle mr-2" style="border:1px solid #ccc">
+					<img src="/storage/avatars/default.png?v=3" width="28" class="rounded-circle mr-2" style="border:1px solid #ccc">
 					<span title="{{$user->username}}" data-toggle="tooltip" data-placement="bottom">
 						<span class="text-danger">{{$user->username}}</span>
 					</span>
@@ -53,7 +53,7 @@
 					<span class="text-monospace">{{$user->id}}</span>
 				</th>
 				<td class="text-left">
-					<img src="{{$user->profile->avatarUrl()}}" width="28px" class="rounded-circle mr-2" style="border:1px solid #ccc">
+					<img src="{{$user->profile->avatarUrl()}}" width="28" class="rounded-circle mr-2" style="border:1px solid #ccc">
 					<span title="{{$user->username}}" data-toggle="tooltip" data-placement="bottom">
 						<span>{{$user->username}}</span>
 						@if($user->is_admin)

--- a/resources/views/admin/users/modlogs.blade.php
+++ b/resources/views/admin/users/modlogs.blade.php
@@ -82,7 +82,7 @@
 						@if($log->message != null)
 						<div class="d-flex justify-content-between">
 							<div class="mr-3">
-								<img src="{{$log->admin->profile->avatarUrl()}}" width="40px" height="40px" class="border p-1 rounded-circle">
+								<img src="{{$log->admin->profile->avatarUrl()}}" width="40" height="40" class="border p-1 rounded-circle">
 							</div>
 							<div style="flex-grow: 1;">
 								@if($log->user_id != Auth::id())
@@ -118,7 +118,7 @@
 						@else
 						<div class="d-flex justify-content-between align-items-center">
 							<div class="mr-3">
-								<img src="{{$log->admin->profile->avatarUrl()}}" width="40px" height="40px" class="border p-1 rounded-circle">
+								<img src="{{$log->admin->profile->avatarUrl()}}" width="40" height="40" class="border p-1 rounded-circle">
 							</div>
 							<div style="flex-grow: 1;">
 								<p class="small text-muted font-weight-bold mb-0">{{$log->created_at->diffForHumans()}}</p>

--- a/resources/views/admin/users/show.blade.php
+++ b/resources/views/admin/users/show.blade.php
@@ -49,7 +49,7 @@
 	<div class="col-12 col-md-4">
 		<div class="card shadow-none border">
 			<div class="card-body text-center">
-				<img src="{{$profile->avatarUrl()}}" class="box-shadow rounded-circle" width="128px" height="128px">
+				<img src="{{$profile->avatarUrl()}}" class="box-shadow rounded-circle" width="128" height="128">
 				<p class="mt-3 mb-0 lead">
 					<span class="font-weight-bold">{{$profile->name}}</span>
 				</p>
@@ -103,7 +103,7 @@
 			@foreach($profile->statuses()->whereHas('media')->latest()->take(9)->get() as $item)
 			<div class="col-12 col-md-4 col-sm-6 px-0" style="margin-bottom: 1px;">
 				<a href="{{$item->url()}}">
-					<img src="{{$item->thumb(true)}}" width="200px" height="200px">
+					<img src="{{$item->thumb(true)}}" width="200" height="200">
 				</a>
 			</div>
 			@endforeach

--- a/resources/views/auth/checkpoint.blade.php
+++ b/resources/views/auth/checkpoint.blade.php
@@ -5,7 +5,7 @@
     <div class="row justify-content-center">
         <div class="col-lg-5">
             <div class="text-center">
-                <img src="/img/pixelfed-icon-color.svg" height="60px">
+                <img src="/img/pixelfed-icon-color.svg" height="60">
                 <p class="font-weight-light h3 py-4">Verify Two Factor Code</p>
             </div>
             <div class="alert alert-info small">

--- a/resources/views/auth/sudo.blade.php
+++ b/resources/views/auth/sudo.blade.php
@@ -5,7 +5,7 @@
     <div class="row justify-content-center">
         <div class="col-lg-5">
             <div class="text-center">
-                <img src="/img/pixelfed-icon-color.svg" height="60px">
+                <img src="/img/pixelfed-icon-color.svg" height="60">
                 <p class="font-weight-light h3 py-4">Confirm password to continue</p>
             </div>
             <div class="card">

--- a/resources/views/discover/tags/category.blade.php
+++ b/resources/views/discover/tags/category.blade.php
@@ -7,7 +7,7 @@
     <div class="row">
       <div class="col-12 col-md-3">
         <div class="profile-avatar">
-          <img class="rounded-circle card" src="{{$tag->thumb()}}" width="172px" height="172px">
+          <img class="rounded-circle card" src="{{$tag->thumb()}}" width="172" height="172">
         </div>
       </div>
       <div class="col-12 col-md-9 d-flex align-items-center">

--- a/resources/views/profile/embed-removed.blade.php
+++ b/resources/views/profile/embed-removed.blade.php
@@ -34,7 +34,7 @@
 	<div class="embed-card">
 		<div class="card  status-card-embed card-md-rounded-0 border card-body border shadow-none rounded-0 d-flex justify-content-center align-items-center">
 			<div class="text-center p-5">
-				<img src="/img/pixelfed-icon-color.svg" width="40px" height="40px">
+				<img src="/img/pixelfed-icon-color.svg" width="40" height="40">
 				<p class="h2 py-3 font-weight-bold">Pixelfed</p>
 				<p style="font-size:14px;font-weight: 500;" class="px-2 py-4">Cannot display profile embed, it may be deleted or set to private.</p>
 				<p><a href="{{config('app.url')}}" class="font-weight-bold" target="_blank">Visit Pixelfed</a></p>

--- a/resources/views/profile/embed.blade.php
+++ b/resources/views/profile/embed.blade.php
@@ -37,14 +37,14 @@
   <div class="card status-card-embed card-md-rounded-0 border">
     <div class="card-header d-inline-flex align-items-center justify-content-between bg-white">
       <div>
-        <img src="{{$profile->avatarUrl()}}" width="32px" height="32px" target="_blank" style="border-radius: 32px;">
+        <img src="{{$profile->avatarUrl()}}" width="32" height="32" target="_blank" style="border-radius: 32px;">
         <a class="username font-weight-bold pl-2 text-dark" target="_blank" href="{{$profile->url()}}">
           {{$profile->username}}
         </a>
       </div>
       <div>
         <a class="small font-weight-bold text-muted pr-1" href="{{config('app.url')}}" target="_blank">{{config('pixelfed.domain.app')}}</a>
-        <img src="/img/pixelfed-icon-color.svg" width="26px">
+        <img src="/img/pixelfed-icon-color.svg" width="26">
       </div>
     </div>
     <div class="card-body pb-1">

--- a/resources/views/profile/partial/private-info.blade.php
+++ b/resources/views/profile/partial/private-info.blade.php
@@ -3,7 +3,7 @@
     <div class="row">
       <div class="col-12 col-md-4 d-flex">
         <div class="profile-avatar mx-auto">
-          <img class="rounded-circle box-shadow" src="{{$user->avatarUrl()}}" width="172px" height="172px">
+          <img class="rounded-circle box-shadow" src="{{$user->avatarUrl()}}" width="172" height="172">
         </div>
       </div>
       <div class="col-12 col-md-8 d-flex align-items-center">

--- a/resources/views/profile/partial/user-info.blade.php
+++ b/resources/views/profile/partial/user-info.blade.php
@@ -3,7 +3,7 @@
     <div class="row">
       <div class="col-12 col-md-4 d-flex">
         <div class="profile-avatar mx-auto">
-          <img class="rounded-circle box-shadow" src="{{$user->avatarUrl()}}" width="172px" height="172px">
+          <img class="rounded-circle box-shadow" src="{{$user->avatarUrl()}}" width="172" height="172">
         </div>
       </div>
       <div class="col-12 col-md-8 d-flex align-items-center">

--- a/resources/views/settings/home.blade.php
+++ b/resources/views/settings/home.blade.php
@@ -8,7 +8,7 @@
   <hr>
   <div class="form-group row">
     <div class="col-sm-3">
-      <img src="{{Auth::user()->profile->avatarUrl()}}" width="38px" height="38px" class="rounded-circle float-right">
+      <img src="{{Auth::user()->profile->avatarUrl()}}" width="38" height="38" class="rounded-circle float-right">
     </div>
     <div class="col-sm-9">
       <p class="lead font-weight-bold mb-0">{{Auth::user()->username}}</p>

--- a/resources/views/settings/privacy/blocked.blade.php
+++ b/resources/views/settings/privacy/blocked.blade.php
@@ -19,7 +19,7 @@
     @foreach($users as $user)
     <li class="list-group-item">
       <div class="d-flex justify-content-between align-items-center font-weight-bold">
-        <span><a href="{{$user->url()}}" class="text-decoration-none text-dark"><img class="rounded-circle mr-3" src="{{$user->avatarUrl()}}" width="32px">{{$user->username}}</a></span>
+        <span><a href="{{$user->url()}}" class="text-decoration-none text-dark"><img class="rounded-circle mr-3" src="{{$user->avatarUrl()}}" width="32">{{$user->username}}</a></span>
         <span class="btn-group">
           <form method="post">
             @csrf

--- a/resources/views/settings/privacy/muted.blade.php
+++ b/resources/views/settings/privacy/muted.blade.php
@@ -19,7 +19,7 @@
     @foreach($users as $user)
     <li class="list-group-item">
       <div class="d-flex justify-content-between align-items-center font-weight-bold">
-        <span><a href="{{$user->url()}}" class="text-decoration-none text-dark"><img class="rounded-circle mr-3" src="{{$user->avatarUrl()}}" width="32px">{{$user->username}}</a></span>
+        <span><a href="{{$user->url()}}" class="text-decoration-none text-dark"><img class="rounded-circle mr-3" src="{{$user->avatarUrl()}}" width="32">{{$user->username}}</a></span>
         <span class="btn-group">
           <form method="post">
             @csrf

--- a/resources/views/settings/security/2fa/setup.blade.php
+++ b/resources/views/settings/security/2fa/setup.blade.php
@@ -45,7 +45,7 @@
 	  		<div class="card-body text-center">
 	  			<div class="pb-3">
 	  				<p class="font-weight-bold">QR Code</p>
-	  				<img src="{{$qrcode}}" class="img-fluid" width="200px">
+	  				<img src="{{$qrcode}}" class="img-fluid" width="200">
 	  			</div>
 	  			<div>
 	  				<p class="font-weight-bold">OTP Secret</p>

--- a/resources/views/site/about.blade.php
+++ b/resources/views/site/about.blade.php
@@ -11,7 +11,7 @@
 	<div class="container d-flex justify-content-center">
 		<div class="card mr-3" style="width:500px;margin-top:-30px;">
 			<div class="card-header d-inline-flex align-items-center bg-white">
-				<img src="/storage/avatars/default.png" width="32px" height="32px" style="border-radius: 32px; border: 1px solid #ccc">
+				<img src="/storage/avatars/default.png" width="32" height="32" style="border-radius: 32px; border: 1px solid #ccc">
 				<span class="username font-weight-bold pl-2 text-dark">
 					username
 				</span>

--- a/resources/views/site/index.blade.php
+++ b/resources/views/site/index.blade.php
@@ -56,7 +56,7 @@
                 <div class="col-12 col-md-5 offset-md-1">
                     <div>
                         <div class="pt-md-3 d-flex justify-content-center align-items-center">
-                            <img src="/img/pixelfed-icon-color.svg" loading="lazy" width="50px" height="50px">
+                            <img src="/img/pixelfed-icon-color.svg" loading="lazy" width="50" height="50">
                             <span class="font-weight-bold h3 ml-2 pt-2">Pixelfed</span>
                         </div>
                         <div class="d-block d-md-none">
@@ -140,47 +140,47 @@
                         <div class="row mt-4 mb-1">
                             <div class="col-4 mt-2 px-0">
                                 <div class="px-1 shadow-none">
-                                    <img src="/_landing/1.jpeg" class="img-fluid" loading="lazy" width="640px" height="640px">
+                                    <img src="/_landing/1.jpeg" class="img-fluid" loading="lazy" width="640" height="640">
                                 </div>
                             </div>
                             <div class="col-4 mt-2 px-0">
                                 <div class="px-1 shadow-none">
-                                    <img src="/_landing/2.jpeg" class="img-fluid" loading="lazy" width="640px" height="640px">
+                                    <img src="/_landing/2.jpeg" class="img-fluid" loading="lazy" width="640" height="640">
                                 </div>
                             </div>
                             <div class="col-4 mt-2 px-0">
                                 <div class="px-1 shadow-none">
-                                    <img src="/_landing/3.jpeg" class="img-fluid" loading="lazy" width="640px" height="640px">
+                                    <img src="/_landing/3.jpeg" class="img-fluid" loading="lazy" width="640" height="640">
                                 </div>
                             </div>
                             <div class="col-4 mt-2 px-0">
                                 <div class="px-1 shadow-none">
-                                    <img src="/_landing/4.jpeg" class="img-fluid" loading="lazy" width="640px" height="640px">
+                                    <img src="/_landing/4.jpeg" class="img-fluid" loading="lazy" width="640" height="640">
                                 </div>
                             </div>
                             <div class="col-4 mt-2 px-0">
                                 <div class="px-1 shadow-none">
-                                    <img src="/_landing/5.jpeg" class="img-fluid" loading="lazy" width="640px" height="640px">
+                                    <img src="/_landing/5.jpeg" class="img-fluid" loading="lazy" width="640" height="640">
                                 </div>
                             </div>
                             <div class="col-4 mt-2 px-0">
                                 <div class="px-1 shadow-none">
-                                    <img src="/_landing/6.jpeg" class="img-fluid" loading="lazy" width="640px" height="640px">
+                                    <img src="/_landing/6.jpeg" class="img-fluid" loading="lazy" width="640" height="640">
                                 </div>
                             </div>
                             <div class="col-4 mt-2 px-0">
                                 <div class="px-1 shadow-none">
-                                    <img src="/_landing/7.jpeg" class="img-fluid" loading="lazy" width="640px" height="640px">
+                                    <img src="/_landing/7.jpeg" class="img-fluid" loading="lazy" width="640" height="640">
                                 </div>
                             </div>
                             <div class="col-4 mt-2 px-0">
                                 <div class="px-1 shadow-none">
-                                    <img src="/_landing/8.jpeg" class="img-fluid" loading="lazy" width="640px" height="640px">
+                                    <img src="/_landing/8.jpeg" class="img-fluid" loading="lazy" width="640" height="640">
                                 </div>
                             </div>
                             <div class="col-4 mt-2 px-0">
                                 <div class="px-1 shadow-none">
-                                    <img src="/_landing/9.jpeg" class="img-fluid" loading="lazy" width="640px" height="640px">
+                                    <img src="/_landing/9.jpeg" class="img-fluid" loading="lazy" width="640" height="640">
                                 </div>
                             </div>
                         </div>

--- a/resources/views/site/intents/follow.blade.php
+++ b/resources/views/site/intents/follow.blade.php
@@ -11,7 +11,7 @@
 				</div>
 				<div class="card-body">
 					<div class="text-center mt-n5 mb-4">
-						<img class="rounded-circle p-1 border mt-n4 bg-white shadow" src="{{$profile->avatarUrl()}}" width="90px" height="90px;">
+						<img class="rounded-circle p-1 border mt-n4 bg-white shadow" src="{{$profile->avatarUrl()}}" width="90" height="90">
 					</div>
 					<p class="text-center lead font-weight-bold mb-1">{{$profile->username}}</p>
 					<p class="text-center text-muted small text-uppercase mb-4">{{$profile->followers->count()}} followers</p>

--- a/resources/views/status/embed-removed.blade.php
+++ b/resources/views/status/embed-removed.blade.php
@@ -34,7 +34,7 @@
 	<div class="embed-card">
 		<div class="card  status-card-embed card-md-rounded-0 border card-body border shadow-none rounded-0 d-flex justify-content-center align-items-center">
 			<div class="text-center p-5">
-				<img src="/img/pixelfed-icon-color.svg" width="40px" height="40px">
+				<img src="/img/pixelfed-icon-color.svg" width="40" height="40">
 				<p class="h2 py-3 font-weight-bold">Pixelfed</p>
 				<p style="font-size:14px;font-weight: 500;" class="p-2">The link to this photo or video may be broken, or the post may have been removed.</p>
 				<p><a href="{{config('app.url')}}" class="font-weight-bold" target="_blank">Visit Pixelfed</a></p>

--- a/resources/views/status/embed.blade.php
+++ b/resources/views/status/embed.blade.php
@@ -37,7 +37,7 @@
   @php($item = $status)
   <div class="card status-card-embed card-md-rounded-0 border">
     <div class="card-header d-inline-flex align-items-center bg-white">
-      <img src="{{$item->profile->avatarUrl()}}" width="32px" height="32px" target="_blank" style="border-radius: 32px;">
+      <img src="{{$item->profile->avatarUrl()}}" width="32" height="32" target="_blank" style="border-radius: 32px;">
       <a class="username font-weight-bold pl-2 text-dark" target="_blank" href="{{$item->profile->url()}}">
         {{$item->profile->username}}
       </a>
@@ -163,7 +163,7 @@
       </div>
       <div>
         <a class="small font-weight-bold text-muted pr-1" href="{{config('app.url')}}" target="_blank">{{config('pixelfed.domain.app')}}</a>
-        <img src="/img/pixelfed-icon-color.svg" width="26px">
+        <img src="/img/pixelfed-icon-color.svg" width="26">
       </div>
     </div>
   </div>

--- a/resources/views/status/reply.blade.php
+++ b/resources/views/status/reply.blade.php
@@ -7,11 +7,11 @@
       <div class="card">
         <div class="card-body p-0 m-0 bg-light">
           <div class="d-flex p-0 m-0 align-items-center">
-            <img src="{{$status->parent()->thumb()}}" width="150px" height="150px" class="post-thumbnail">
+            <img src="{{$status->parent()->thumb()}}" width="150" height="150" class="post-thumbnail">
             <div class="p-4 w-100">
               <div class="d-flex justify-content-between align-items-center">
                 <div>
-                  <img src="{{$status->parent()->profile->avatarUrl()}}" class="rounded-circle img-thumbnail mb-1 mr-1" width="30px">
+                  <img src="{{$status->parent()->profile->avatarUrl()}}" class="rounded-circle img-thumbnail mb-1 mr-1" width="30">
                   <span class="h5 font-weight-bold" v-pre>{{$status->parent()->profile->username}}</span>
                 </div>
                 <div>
@@ -31,7 +31,7 @@
               <p class="py-5 mb-0 text-center">This comment may contain sensitive content. <span class="float-right font-weight-bold text-primary">Show</span></p>
             </summary>
             <div class="media py-5">
-              <img class="mr-3 rounded-circle img-thumbnail" src="{{$status->profile->avatarUrl()}}" width="60px">
+              <img class="mr-3 rounded-circle img-thumbnail" src="{{$status->profile->avatarUrl()}}" width="60">
               <div class="media-body">
                 <h5 class="mt-0 font-weight-bold" v-pre>{{$status->profile->username}}</h5>
                 <p class="mb-1" v-pre>{!! $status->rendered !!}</p>
@@ -45,7 +45,7 @@
           </details>
           @else
           <div class="media py-5">
-            <img class="mr-3 rounded-circle img-thumbnail" src="{{$status->profile->avatarUrl()}}" width="60px">
+            <img class="mr-3 rounded-circle img-thumbnail" src="{{$status->profile->avatarUrl()}}" width="60">
             <div class="media-body">
               <h5 class="mt-0 font-weight-bold" v-pre>{{$status->profile->username}}</h5>
               <p class="mb-1" v-pre>{!! $status->rendered !!}</p>

--- a/resources/views/status/template.blade.php
+++ b/resources/views/status/template.blade.php
@@ -1,6 +1,6 @@
 <div class="card mb-4 status-card card-md-rounded-0" data-id="{{$item->id}}" data-comment-max-id="0" data-profile-username="{{$item->profile->username}}" data-profile-name="{{$item->profile->name}}" data-timestamp="{{$item->created_at}}">
   <div class="card-header d-inline-flex align-items-center bg-white">
-    <img src="{{$item->profile->avatarUrl()}}" width="32px" height="32px" style="border-radius: 32px;">
+    <img src="{{$item->profile->avatarUrl()}}" width="32" height="32" style="border-radius: 32px;">
     <a class="username font-weight-bold pl-2 text-dark" href="{{$item->profile->url()}}">
       {{$item->profile->username}}
     </a>


### PR DESCRIPTION
The value of the attributes "width" and "height" for the tag "img" is not supposed to have the suffix "px".

This could probably lead to UI bugs on some browsers.