### PR TITLE
Add new api endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Updated InternalApiController, update discoverPosts method to improve performance. ([9862a855](https://github.com/pixelfed/pixelfed/commit/9862a855))
 - Updated DiscoverComponent, add blurhash and like/comment counts. ([a8ebdd2e](https://github.com/pixelfed/pixelfed/commit/a8ebdd2e))
 - Updated DiscoverComponent, add spinner loaders and remove deprecated sections. ([34869247](https://github.com/pixelfed/pixelfed/commit/34869247))
+- Updated AccountController, add mutes and blocks endpoint to pixelfed api. ([1fb7e2b2](https://github.com/pixelfed/pixelfed/commit/1fb7e2b2))
 -  ([](https://github.com/pixelfed/pixelfed/commit/))
 
 ## [v0.10.10 (2021-01-28)](https://github.com/pixelfed/pixelfed/compare/v0.10.9...v0.10.10)

--- a/routes/web.php
+++ b/routes/web.php
@@ -172,6 +172,8 @@ Route::domain(config('pixelfed.domain.app'))->middleware(['validemail', 'twofact
                 Route::get('newsroom/timeline', 'NewsroomController@timelineApi');
                 Route::post('newsroom/markasread', 'NewsroomController@markAsRead');
                 Route::get('favourites', 'Api\BaseApiController@accountLikes');
+                Route::get('mutes', 'AccountController@accountMutes');
+                Route::get('blocks', 'AccountController@accountBlocks');
             });
 
             Route::group(['prefix' => 'v2'], function() {


### PR DESCRIPTION
Adds new api endpoints

- /api/pixelfed/v1/mutes (based on https://docs.joinmastodon.org/methods/accounts/mutes/)
- /api/pixelfed/v1/blocks (based on https://docs.joinmastodon.org/methods/accounts/blocks/)

**Note: the `/api/v1/mutes` and `/api/v1/blocks` endpoints remain unchanged, these new endpoints use session auth not oauth!**