### PR TITLE
Update StatusLabelService.php

### DIFF
--- a/app/Services/StatusLabelService.php
+++ b/app/Services/StatusLabelService.php
@@ -20,7 +20,7 @@ class StatusLabelService
 		
 		return Cache::remember(self::CACHE_KEY . $status->id, now()->addDays(7), function() use($status) {
 			return [
-				'covid' => Str::of(strtolower($status->caption))->contains(['covid','corona', 'coronavirus', 'vaccine', 'vaxx', 'vaccination', 'plandemic'])
+				'covid' => Str::of(strtolower($status->caption))->contains(['covid', 'covid19', 'coronavirus','vaccine', 'vaxx', 'vaccination', 'pandemic'])
 			];
 		});
 	}


### PR DESCRIPTION
Fixes https://github.com/pixelfed/pixelfed/issues/2606

removed corona to avoid adding WHO link to posts that contains beer
removed typo for pandemic
added covid19