### PR TITLE
Use same json error format as Mastodon

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -48,6 +48,11 @@ class Handler extends ExceptionHandler
      */
     public function render($request, Throwable $exception)
     {
+        if ($request->wantsJson())
+            return response()->json(
+                ['error' => $exception->getMessage()],
+                method_exists($exception, 'getStatusCode') ? $exception->getStatusCode() : 500
+            );
         return parent::render($request, $exception);
     }
 }


### PR DESCRIPTION
As documented in the Mastodon API ( https://docs.joinmastodon.org/entities/error/ ),   error responses use "error" as the key for the value, instead of Laravel's default (which is "message")