### PR TITLE
Adapt Instagram Import to new data dump format

### DIFF
--- a/app/ImportJob.php
+++ b/app/ImportJob.php
@@ -10,7 +10,7 @@ class ImportJob extends Model
     {
         return $this->belongsTo(Profile::class, 'profile_id');
     }
-    
+
     public function url()
     {
     	return url("/i/import/job/{$this->uuid}/{$this->stage}");
@@ -21,9 +21,9 @@ class ImportJob extends Model
     	return $this->hasMany(ImportData::class, 'job_id');
     }
 
-    public function mediaJson()
+    public function postsJson()
     {
-    	$path = storage_path("app/$this->media_json");
+    	$path = storage_path("app/$this->posts_json");
     	return json_decode(file_get_contents($path), true);
     }
 }

--- a/database/migrations/2021_05_10_134531_rename_media_column_in_import_jobs_table.php
+++ b/database/migrations/2021_05_10_134531_rename_media_column_in_import_jobs_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class RenameMediaColumnInImportJobsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('import_jobs', function (Blueprint $table) {
+            $table->renameColumn('media_json', 'posts_json');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('import_jobs', function (Blueprint $table) {
+            $table->renameColumn('posts_json', 'media_json');
+        });
+    }
+}

--- a/resources/views/settings/import/instagram/home.blade.php
+++ b/resources/views/settings/import/instagram/home.blade.php
@@ -12,15 +12,15 @@
     </div>
     <p class="lead font-weight-bold mb-1">Requirements:</p>
     <ul class="lead mb-4">
-      <li>media.json file</li>      
-      <li>photos directory</li>      
+      <li>media/posts directory</li>
+      <li>content/post_1.json file</li>
     </ul>
     <p class="lead font-weight-bold mb-1">Process:</p>
     <ol class="lead mb-4">
-      <li>Upload media.json file</li>      
-      <li>Upload photos directory</li>      
+      <li>Upload posts directory</li>
+      <li>Upload posts_1.json file</li>
       {{-- <li>Confirm each post</li> --}}
-      <li>Import Data</li>      
+      <li>Import Data</li>
     </ol>
     <form method="post">
       @csrf

--- a/resources/views/settings/import/instagram/step-one.blade.php
+++ b/resources/views/settings/import/instagram/step-one.blade.php
@@ -13,13 +13,13 @@
   <section class="mt-5 col-md-8 offset-md-2">
     <div class="card mb-3 step-one">
       <div class="card-body text-center">
-        <p class="h5 font-weight-bold">Import <b>photos</b> directory</p>
-        <p class="text-muted">250mb limit, if your photos directory exceeds that amount, you will have to wait until we support larger imports.</p>
+        <p class="h5 font-weight-bold">Import <b>posts</b> directory</p>
+        <p class="text-muted">The posts directory is inside the media directory. 250mb limit, if your posts directory exceeds that amount, you will have to wait until we support larger imports.</p>
         <hr>
         <form enctype="multipart/form-data" class="" method="post">
           @csrf
-          <input type="file" name="media[]" multiple="" directory="" webkitdirectory="" mozdirectory="" accept="image/*">
-          <button type="submit" class="mt-4 btn btn-primary btn-block font-weight-bold">Upload Photos</button>
+          <input type="file" name="posts[]" multiple="" directory="" webkitdirectory="" mozdirectory="" accept="image/*">
+          <button type="submit" class="mt-4 btn btn-primary btn-block font-weight-bold">Upload Posts</button>
         </form>
       </div>
     </div>

--- a/resources/views/settings/import/instagram/step-two.blade.php
+++ b/resources/views/settings/import/instagram/step-two.blade.php
@@ -10,13 +10,13 @@
   <section class="mt-5 col-md-8 offset-md-2">
     <div class="card mb-3 step-two">
       <div class="card-body text-center">
-        <p class="h5 font-weight-bold">Import <b>media.json</b> file</p>
-        <p class="text-muted">10mb limit, please only upload the media.json file</p>
+        <p class="h5 font-weight-bold">Import <b>posts_1.json</b> file</p>
+        <p class="text-muted">10mb limit, please only upload the posts_1.json file found in the content directory</p>
         <hr>
         <form enctype="multipart/form-data" class="" method="post">
           @csrf
-          <input type="file" name="media">
-          <button type="submit" class="mt-4 btn btn-primary btn-block font-weight-bold">Upload media.json</button>
+          <input type="file" name="posts_1">
+          <button type="submit" class="mt-4 btn btn-primary btn-block font-weight-bold">Upload posts_1.json</button>
         </form>
       </div>
       </div>


### PR DESCRIPTION
Instagram has changed the format for data dumps. One can now choose between HTML dumps and JSON dumps.
The JSON dumps have a new directory structure. The post images are now in the folder `media/posts` and the JSON file with the post metadata is in `content/posts_1.json`.

This PR adapts the import process to support the new data format.