### PR TITLE
Fix PWA implementation to support Gecko-based browsers, using html link tag

### DIFF
--- a/resources/views/site/index.blade.php
+++ b/resources/views/site/index.blade.php
@@ -20,6 +20,7 @@
 	<meta name="medium" content="image">
 	<meta name="theme-color" content="#10c5f8">
 	<meta name="apple-mobile-web-app-capable" content="yes">
+	<link rel="manifest" href="/manifest.json">
 	<link rel="shortcut icon" type="image/png" href="/img/favicon.png?v=2">
 	<link rel="apple-touch-icon" type="image/png" href="/img/favicon.png?v=2">
 	<link href="{{ mix('css/landing.css') }}" rel="stylesheet">


### PR DESCRIPTION
In order to implement PWA successfully (so Browsers have the option to use Pixelfed full screen as an App), you need to add this line into the main / (root) view.

Firefox (for example) does not achieve to use PWA currently. I guess this need is only for Firefox (Gecko-based browsers).

Source: https://developer.mozilla.org/en-US/docs/Web/Manifest