### PR TITLE
Fix starting check of username to allow numbers.

### DIFF
--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -76,7 +76,7 @@ class RegisterController extends Controller
 					return $fail('Username is invalid. Can only contain one dash (-), period (.) or underscore (_).');
 				}
 
-				if (!ctype_alpha($value[0])) {
+				if (!ctype_alnum($value[0])) {
 					return $fail('Username is invalid. Must start with a letter or number.');
 				}
 


### PR DESCRIPTION
The check for the first letter of username used to be !ctype_alpha, but the error message says "Must start with a letter or number." Updated check to be !ctype_alnum, to be coherent with the error message.