### PR TITLE
Fix global memory limit set in constructor

### DIFF
--- a/app/Console/Commands/ImportCities.php
+++ b/app/Console/Commands/ImportCities.php
@@ -65,7 +65,6 @@ class ImportCities extends Command
     public function __construct()
     {
         parent::__construct();
-        ini_set('memory_limit', '256M');
     }
 
     /**
@@ -75,6 +74,8 @@ class ImportCities extends Command
      */
     public function handle()
     {
+        $old_memory_limit = ini_get('memory_limit');
+        ini_set('memory_limit', '256M');
         $path = storage_path('app/cities.json');
 
         if(hash_file('sha512', $path) !== self::CHECKSUM) {
@@ -136,6 +137,7 @@ class ImportCities extends Command
         $this->line('');
         $this->info('Successfully imported ' . $cityCount . ' entries!');
         $this->line('');
+        ini_set('memory_limit', $old_memory_limit);
         return;
     }
 


### PR DESCRIPTION
Instead, set it when running the import.

Having the set in the constructor was causing memory_limit to be changed for "artisan queue:work" processes.

Perhaps this class should be a seeder instead (`artisan make:seeder CitySeeder`).