### PR TITLE
Fix PWA not working on firefox because of wrong icon sizes

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -9,12 +9,12 @@
     {
       "src": "img/favicon.png",
       "type": "image/png",
-      "sizes": "153x152"
+      "sizes": "256x256"
     },
     {
       "src": "img/pixelfed-icon-color.svg",
       "type": "image/svg",
-      "sizes": "50x50"
+      "sizes": "128x128"
     }
   ]
 }


### PR DESCRIPTION
Related to: https://github.com/pixelfed/pixelfed/pull/2868

I tried to install Pixelfed from Firefox and it's not working. After a lot of debugging i figured out that the reason was no other than the icon sizes on key "icons" on the manifest.json was not a 2 multiple, which is not good standard values and most devices can't add Pixelfed as an App because of this:

Sources: https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps/Installable_PWAs