### PR TITLE
Added “Run on YunoHost”

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ A free and ethical photo sharing platform, powered by ActivityPub federation.
 
 Documentation for Pixelfed can be found on the [Pixelfed documentation website](https://docs.pixelfed.org/).
 
+## Run on YunoHost
+
+[![Install on YunoHost](https://user-images.githubusercontent.com/42862428/139559471-9495f1e9-e7a4-49f1-9a4b-675ddcc510a2.png 'Install on YunoHost')](https://install-app.yunohost.org/?app=pixelfed)
+
+Pixelfed app for [YunoHost](https://yunohost.org 'YunoHost'). See [the package source code](https://github.com/YunoHost-Apps/pixelfed_ynh 'pixelfed_ynh repository on GitHub')
+
 ## License
 
 Pixelfed is open-sourced software licensed under the AGPL license.


### PR DESCRIPTION
Pixelfed is super simple to self-host even for people with limited technical skills, thanks to [YunoHost](https://yunohost.org 'YunoHost'). Such a great advantage (which very few Fediverse social media have) should be made more visible, as in the [Wallabag repository](https://github.com/wallabag/wallabag#run-on-yunohost '“Run on YunoHost“ on Wallabag README on GitHub')