### PR TITLE
Add Cloud Backups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 - Manual email verification requests. ([bc659387](https://github.com/pixelfed/pixelfed/commit/bc659387))
 - Added StatusMentionService, fixes #3026. ([e5387d67](https://github.com/pixelfed/pixelfed/commit/e5387d67))
+- Cloud Backups, a command to store backups on S3 or compatible filesystems. [#3037](https://github.com/pixelfed/pixelfed/pull/3037) ([3515a98e](https://github.com/pixelfed/pixelfed/commit/3515a98e))
 
 ### Updated
 - Updated NotificationService, fix 500 bug. ([4a609dc3](https://github.com/pixelfed/pixelfed/commit/4a609dc3))

--- a/app/Console/Commands/BackupToCloud.php
+++ b/app/Console/Commands/BackupToCloud.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Http\File;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Storage;
+use Spatie\Backup\BackupDestination\BackupDestination;
+
+class BackupToCloud extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'backup:cloud';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Send backups to cloud storage';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+		$localDisk = Storage::disk('local');
+		$cloudDisk = Storage::disk('backup');
+		$backupDestination = new BackupDestination($localDisk, '', 'local');
+
+		if(
+			empty(config('filesystems.disks.backup.key')) ||
+			empty(config('filesystems.disks.backup.secret')) ||
+			empty(config('filesystems.disks.backup.endpoint')) ||
+			empty(config('filesystems.disks.backup.region')) ||
+			empty(config('filesystems.disks.backup.bucket'))
+		) {
+			$this->error('Backup disk not configured.');
+			$this->error('See https://docs.pixelfed.org/technical-documentation/env.html#filesystem for more information.');
+			return Command::FAILURE;
+		}
+
+		$newest = $backupDestination->newestBackup();
+		$name = $newest->path();
+		$parts = explode('/', $name);
+		$fileName = array_pop($parts);
+		$storagePath = 'backups';
+		$path = storage_path('app/'. $name);
+		$file = $cloudDisk->putFileAs($storagePath, new File($path), $fileName, 'private');
+		$this->info("Backup file successfully saved!");
+		$url = $cloudDisk->url($file);
+		$this->table(
+			['Name', 'URL'],
+			[
+				[$fileName, $url]
+			],
+		);
+		return Command::SUCCESS;
+    }
+}

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -82,7 +82,7 @@ return [
         ],
 
         'backup' => [
-            'driver' => env('PF_BACKUP_DRIVER', 'local'),
+            'driver' => env('PF_BACKUP_DRIVER', 's3'),
             'visibility' => 'private',
             'root' => env('PF_BACKUP_DRIVER', 'local') == 'local' ?
                 storage_path('app/backups/') :


### PR DESCRIPTION
A command to send the most recent backup to a **S3 compatible** filesystem.

### Configuration

You must set the following `.env` variables and replace the appropriate values.

In order to allow more flexibility in configurations, we use a separate filesystem driver for **backups** and another for **user content and media**. If you are using S3 cloud storage for media, you can reuse your `AWS_` .env variable values or a separate bucket.

```
PF_BACKUP_KEY="XXXXXXXXXXXXXXXXXXXX"
PF_BACKUP_SECRET="XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
PF_BACKUP_ENDPOINT="https://s3.us-east-1.amazonaws.com"
PF_BACKUP_REGION="us-east-1"
PF_BACKUP_BUCKET="XXX"
PF_BACKUP_ROOT="/"
```
We store backup files on S3 with `private` visibility.

### Usage

Run the following command to send your most recent backup to your **backup** filesystem driver
```
php artisan backup:cloud
```

### Notes
This command does not prune old backups at this time.