### PR TITLE
Fix for firstOrCreate failing hashtags with case differences on name column

### DIFF
--- a/app/Jobs/StatusPipeline/StatusEntityLexer.php
+++ b/app/Jobs/StatusPipeline/StatusEntityLexer.php
@@ -107,9 +107,13 @@ class StatusEntityLexer implements ShouldQueue
 			}
 			DB::transaction(function () use ($status, $tag) {
 				$slug = str_slug($tag, '-', false);
-				$hashtag = Hashtag::firstOrCreate(
-					['name' => $tag, 'slug' => $slug]
-				);
+				$hashtag = Hashtag::where('slug', $slug)->first();
+				if (!$hashtag) {
+					$hashtag = Hashtag::create(
+						['name' => $tag, 'slug' => $slug]
+					);
+				}
+
 				StatusHashtag::firstOrCreate(
 					[
 						'status_id' => $status->id,


### PR DESCRIPTION
Fix for: https://github.com/pixelfed/pixelfed/issues/1569

Since slug is also a unique index which generates a consistent slug from a hashtag, this should allow us to consistently link hashtags without the case sensitivity issues on the 'name' column. 

I'm open to alternatives fixes, however firstOrCreate() also makes 2 database calls so this is in theory no less performant.