### PR TITLE
Add Content-Type and User-Agent for activity delivery

### DIFF
--- a/app/Jobs/DeletePipeline/FanoutDeletePipeline.php
+++ b/app/Jobs/DeletePipeline/FanoutDeletePipeline.php
@@ -63,7 +63,12 @@ class FanoutDeletePipeline implements ShouldQueue
 
         $requests = function($audience) use ($client, $activity, $profile, $payload) {
             foreach($audience as $url) {
-                $headers = HttpSignature::sign($profile, $url, $activity);
+				$version = config('pixelfed.version');
+				$appUrl = config('app.url');
+				$headers = HttpSignature::sign($profile, $url, $activity, [
+					'Content-Type'	=> 'application/ld+json; profile="https://www.w3.org/ns/activitystreams"',
+					'User-Agent'	=> "(Pixelfed/{$version}; +{$appUrl})",
+				]);
                 yield function() use ($client, $url, $headers, $payload) {
                     return $client->postAsync($url, [
                         'curl' => [

--- a/app/Jobs/SharePipeline/SharePipeline.php
+++ b/app/Jobs/SharePipeline/SharePipeline.php
@@ -129,7 +129,12 @@ class SharePipeline implements ShouldQueue
 
 		$requests = function($audience) use ($client, $activity, $profile, $payload) {
 			foreach($audience as $url) {
-				$headers = HttpSignature::sign($profile, $url, $activity);
+				$version = config('pixelfed.version');
+				$appUrl = config('app.url');
+				$headers = HttpSignature::sign($profile, $url, $activity, [
+					'Content-Type'	=> 'application/ld+json; profile="https://www.w3.org/ns/activitystreams"',
+					'User-Agent'	=> "(Pixelfed/{$version}; +{$appUrl})",
+				]);
 				yield function() use ($client, $url, $headers, $payload) {
 					return $client->postAsync($url, [
 						'curl' => [

--- a/app/Jobs/SharePipeline/UndoSharePipeline.php
+++ b/app/Jobs/SharePipeline/UndoSharePipeline.php
@@ -92,7 +92,12 @@ class UndoSharePipeline implements ShouldQueue
 
 		$requests = function($audience) use ($client, $activity, $profile, $payload) {
 			foreach($audience as $url) {
-				$headers = HttpSignature::sign($profile, $url, $activity);
+				$version = config('pixelfed.version');
+				$appUrl = config('app.url');
+				$headers = HttpSignature::sign($profile, $url, $activity, [
+					'Content-Type'	=> 'application/ld+json; profile="https://www.w3.org/ns/activitystreams"',
+					'User-Agent'	=> "(Pixelfed/{$version}; +{$appUrl})",
+				]);
 				yield function() use ($client, $url, $headers, $payload) {
 					return $client->postAsync($url, [
 						'curl' => [

--- a/app/Jobs/StatusPipeline/StatusActivityPubDeliver.php
+++ b/app/Jobs/StatusPipeline/StatusActivityPubDeliver.php
@@ -87,7 +87,12 @@ class StatusActivityPubDeliver implements ShouldQueue
 
 		$requests = function($audience) use ($client, $activity, $profile, $payload) {
 			foreach($audience as $url) {
-				$headers = HttpSignature::sign($profile, $url, $activity);
+				$version = config('pixelfed.version');
+				$appUrl = config('app.url');
+				$headers = HttpSignature::sign($profile, $url, $activity, [
+					'Content-Type'	=> 'application/ld+json; profile="https://www.w3.org/ns/activitystreams"',
+					'User-Agent'	=> "(Pixelfed/{$version}; +{$appUrl})",
+				]);
 				yield function() use ($client, $url, $headers, $payload) {
 					return $client->postAsync($url, [
 						'curl' => [

--- a/app/Jobs/StatusPipeline/StatusDelete.php
+++ b/app/Jobs/StatusPipeline/StatusDelete.php
@@ -144,7 +144,12 @@ class StatusDelete implements ShouldQueue
 
 		$requests = function($audience) use ($client, $activity, $profile, $payload) {
 			foreach($audience as $url) {
-				$headers = HttpSignature::sign($profile, $url, $activity);
+				$version = config('pixelfed.version');
+				$appUrl = config('app.url');
+				$headers = HttpSignature::sign($profile, $url, $activity, [
+					'Content-Type'	=> 'application/ld+json; profile="https://www.w3.org/ns/activitystreams"',
+					'User-Agent'	=> "(Pixelfed/{$version}; +{$appUrl})",
+				]);
 				yield function() use ($client, $url, $headers, $payload) {
 					return $client->postAsync($url, [
 						'curl' => [

--- a/app/Jobs/StoryPipeline/StoryDelete.php
+++ b/app/Jobs/StoryPipeline/StoryDelete.php
@@ -108,7 +108,12 @@ class StoryDelete implements ShouldQueue
 
 		$requests = function($audience) use ($client, $activity, $profile, $payload) {
 			foreach($audience as $url) {
-				$headers = HttpSignature::sign($profile, $url, $activity);
+				$version = config('pixelfed.version');
+				$appUrl = config('app.url');
+				$headers = HttpSignature::sign($profile, $url, $activity, [
+					'Content-Type'	=> 'application/ld+json; profile="https://www.w3.org/ns/activitystreams"',
+					'User-Agent'	=> "(Pixelfed/{$version}; +{$appUrl})",
+				]);
 				yield function() use ($client, $url, $headers, $payload) {
 					return $client->postAsync($url, [
 						'curl' => [

--- a/app/Jobs/StoryPipeline/StoryExpire.php
+++ b/app/Jobs/StoryPipeline/StoryExpire.php
@@ -125,7 +125,12 @@ class StoryExpire implements ShouldQueue
 
 		$requests = function($audience) use ($client, $activity, $profile, $payload) {
 			foreach($audience as $url) {
-				$headers = HttpSignature::sign($profile, $url, $activity);
+				$version = config('pixelfed.version');
+				$appUrl = config('app.url');
+				$headers = HttpSignature::sign($profile, $url, $activity, [
+					'Content-Type'	=> 'application/ld+json; profile="https://www.w3.org/ns/activitystreams"',
+					'User-Agent'	=> "(Pixelfed/{$version}; +{$appUrl})",
+				]);
 				yield function() use ($client, $url, $headers, $payload) {
 					return $client->postAsync($url, [
 						'curl' => [

--- a/app/Jobs/StoryPipeline/StoryFanout.php
+++ b/app/Jobs/StoryPipeline/StoryFanout.php
@@ -79,7 +79,13 @@ class StoryFanout implements ShouldQueue
 
 		$requests = function($audience) use ($client, $activity, $profile, $payload) {
 			foreach($audience as $url) {
-				$headers = HttpSignature::sign($profile, $url, $activity);
+				$version = config('pixelfed.version');
+				$appUrl = config('app.url');
+				$proxy = config('');
+				$headers = HttpSignature::sign($profile, $url, $activity, [
+					'Content-Type'	=> 'application/ld+json; profile="https://www.w3.org/ns/activitystreams"',
+					'User-Agent'	=> "(Pixelfed/{$version}; +{$appUrl})",
+				]);
 				yield function() use ($client, $url, $headers, $payload) {
 					return $client->postAsync($url, [
 						'curl' => [

--- a/app/Services/ActivityPubDeliveryService.php
+++ b/app/Services/ActivityPubDeliveryService.php
@@ -49,7 +49,12 @@ class ActivityPubDeliveryService
 
 		$body = $this->payload;
 		$payload = json_encode($body);
-		$headers = HttpSignature::sign($this->sender, $this->to, $body);
+		$version = config('pixelfed.version');
+		$appUrl = config('app.url');
+		$headers = HttpSignature::sign($this->sender, $this->to, $body, [
+			'Content-Type'	=> 'application/ld+json; profile="https://www.w3.org/ns/activitystreams"',
+			'User-Agent'	=> "(Pixelfed/{$version}; +{$appUrl})",
+		]);
 
 		$ch = curl_init($this->to);
 		curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);


### PR DESCRIPTION
Fix https://github.com/pixelfed/pixelfed/issues/3049

Add the appropriate Content-Type and User-Agent to the header when delivering the Activity. 

In addition to Pleroma, it solves the problem of delivery not reaching servers that are blocking inappropriate requests by web application firewalls. (An example of WAF is mstdn.jp)