### PR TITLE
SSO OIDC client support

### DIFF
--- a/.env.docker
+++ b/.env.docker
@@ -148,3 +148,9 @@ TRUST_PROXIES="*"
 ## Passport
 #PASSPORT_PRIVATE_KEY=
 #PASSPORT_PUBLIC_KEY=
+
+# Login with OpenID Connect for Single-Sign-On registration and authentication
+#OIDC_ENABLED=true
+#OIDC_CLIENT_ID=pixelfed
+#OIDC_CLIENT_SECRET=RANDOM-SECRET-HERE
+#OIDC_PROVIDER_URL=https://login.real.domain/realms/realm-name

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ yarn-error.log
 .git-credentials
 /.composer/
 /nginx.conf
+/data

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
 		"buzz/laravel-h-captcha": "1.0.3",
 		"doctrine/dbal": "^2.7",
 		"fruitcake/laravel-cors": "^2.0",
+		"gcs/oidc-client": "*",
 		"intervention/image": "^2.4",
 		"jenssegers/agent": "^2.6",
 		"laravel/framework": "^9.0",
@@ -94,6 +95,11 @@
 		"sort-packages": true,
 		"optimize-autoloader": true
 	},
+	"repositories": [{
+		"type": "path",
+		"url": "./oidc-client",
+		"only": [ "gcs/oidc-client" ]
+	}],
 	"minimum-stability": "dev",
 	"prefer-stable": true
 }

--- a/composer.lock
+++ b/composer.lock
@@ -1787,6 +1787,36 @@
             "time": "2022-02-20T15:07:15+00:00"
         },
         {
+            "name": "gcs/oidc-client",
+            "version": "1.0.0",
+            "dist": {
+                "type": "path",
+                "url": "./oidc-client",
+                "reference": "bfed1ebb0ce47c482676ef60a181a0dcd1c47a7d"
+            },
+            "require": {
+                "jumbojett/openid-connect-php": "^0.8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "GCS\\OIDCClient\\": "src/"
+                }
+            },
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Cabinet Office Digital Development",
+                    "email": "webmaster@cabinetoffice.gov.uk"
+                }
+            ],
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
             "name": "graham-campbell/result-type",
             "version": "v1.1.0",
             "source": {
@@ -2397,6 +2427,43 @@
                 }
             ],
             "time": "2020-06-13T08:05:20+00:00"
+        },
+        {
+            "name": "jumbojett/openid-connect-php",
+            "version": "v0.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/jumbojett/OpenID-Connect-PHP.git",
+                "reference": "08c29b063803538f345183b66ac05cff7ed6eb9b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/jumbojett/OpenID-Connect-PHP/zipball/08c29b063803538f345183b66ac05cff7ed6eb9b",
+                "reference": "08c29b063803538f345183b66ac05cff7ed6eb9b",
+                "shasum": ""
+            },
+            "require": {
+                "ext-curl": "*",
+                "ext-json": "*",
+                "php": ">=5.4",
+                "phpseclib/phpseclib": "~2.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "description": "Bare-bones OpenID Connect client",
+            "support": {
+                "issues": "https://github.com/jumbojett/OpenID-Connect-PHP/issues",
+                "source": "https://github.com/jumbojett/OpenID-Connect-PHP/tree/v0.8.0"
+            },
+            "time": "2019-01-02T19:05:13+00:00"
         },
         {
             "name": "laravel/framework",

--- a/config/app.php
+++ b/config/app.php
@@ -161,6 +161,7 @@ return [
         // App\Providers\TelescopeServiceProvider::class,
         App\Providers\PassportServiceProvider::class,
 
+	GCS\OIDCClient\OIDCServiceProvider::class,
     ],
 
     /*

--- a/config/auth.php
+++ b/config/auth.php
@@ -37,7 +37,7 @@ return [
 
     'guards' => [
         'web' => [
-            'driver'   => 'session',
+            'driver'   => 'oidc',
             'provider' => 'users',
         ],
 

--- a/config/oidc.php
+++ b/config/oidc.php
@@ -1,0 +1,10 @@
+<?php
+
+return [
+    'enabled'       => env('OIDC_ENABLED', false),
+    'client_id'     => env('OIDC_CLIENT_ID'),
+    'client_secret' => env('OIDC_CLIENT_SECRET'),
+    'provider_url'  => env('OIDC_PROVIDER_URL'),
+    'provider_name' => env('OIDC_PROVIDER_NAME', 'OIDC'),
+    'scopes'        => ['openid', 'roles']
+];

--- a/contrib/docker/Dockerfile.apache
+++ b/contrib/docker/Dockerfile.apache
@@ -1,10 +1,10 @@
-FROM php:7.4-apache-bullseye
+FROM php:8.1-apache
 
 # Use the default production configuration
 COPY contrib/docker/php.production.ini "$PHP_INI_DIR/php.ini"
 
 # Install Composer
-ENV COMPOSER_VERSION=2.1.14 \
+ENV COMPOSER_VERSION=2.4.4 \
     COMPOSER_HOME=/var/www/.composer \
     COMPOSER_MEMORY_LIMIT=-1 \
     PATH="~/.composer/vendor/bin:./vendor/bin:${PATH}"

--- a/contrib/docker/Dockerfile.apache
+++ b/contrib/docker/Dockerfile.apache
@@ -95,6 +95,5 @@ RUN cp -r storage storage.skel \
   && composer install --prefer-dist --no-interaction --no-ansi --optimize-autoloader \
   && rm -rf html && ln -s public html \
   && chown -R www-data:www-data /var/www
-VOLUME /var/www/storage /var/www/bootstrap
 
 CMD ["/var/www/contrib/docker/start.apache.sh"]

--- a/contrib/docker/start.apache.sh
+++ b/contrib/docker/start.apache.sh
@@ -1,8 +1,51 @@
 #!/bin/bash
 
+info() { echo >&2 "$*" ; }
+
 # Create the storage tree if needed and fix permissions
 cp -r storage.skel/* storage/
 chown -R www-data:www-data storage/ bootstrap/
+
+# Do initial setup if it hasn't been done
+# These are the one-time setup tasks from:
+# https://docs.pixelfed.org/running-pixelfed/installation/#one-time-setup-tasks
+if [ -z "$APP_KEY" ]; then
+	info "creating app key"
+	php artisan key:generate || exit 1
+fi
+
+if [ ! -r storage/.migrated ]; then
+	for i in `seq 1 10`; do
+		info "******* WAITING FOR DB TO COME UP ********"
+		if echo 'exit' | mysql \
+			-u $DB_USERNAME \
+			-p$DB_PASSWORD \
+			-h $DB_HOST \
+			-P $DB_PORT \
+			$DB_DATABASE \
+		; then
+			break
+		fi
+		sleep 10
+	done
+
+	info "Creating database scheme; this might take a while"
+	php artisan migrate --force || exit 1
+	touch storage/.migrated
+fi
+
+if [ ! -r storage/.instance ]; then
+	info "Creating ActivityPub federation id"
+	php artisan instance:actor || exit 1
+	touch storage/.instance
+fi
+
+if [ ! -r storage/.passport ]; then
+	info "Creating OAuth keys"
+	php artisan passport:keys || exit 1
+	touch storage/.passport
+fi
+
 
 # Refresh the environment
 php artisan storage:link
@@ -12,4 +55,4 @@ php artisan view:cache
 php artisan config:cache
 
 # Finally run Apache
-apache2-foreground
+exec apache2-foreground

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,8 +22,7 @@ services:
     env_file:
       - .env.docker
     volumes:
-      - app-storage:/var/www/storage
-      - app-bootstrap:/var/www/bootstrap
+      - ./data/app-storage:/var/www/storage
       - "./.env.docker:/var/www/.env"
     networks:
       - external
@@ -43,8 +42,7 @@ services:
     env_file:
       - .env.docker
     volumes:
-      - app-storage:/var/www/storage
-      - app-bootstrap:/var/www/bootstrap
+      - ./data/app-storage:/var/www/storage
     networks:
       - external
       - internal
@@ -63,7 +61,7 @@ services:
     env_file:
       - .env.docker
     volumes:
-      - "db-data:/var/lib/mysql"
+      - ./data/db-data:/var/lib/mysql
 
   redis:
     image: redis:5-alpine
@@ -71,15 +69,9 @@ services:
     env_file:
       - .env.docker
     volumes:
-      - "redis-data:/data"
+      - ./data/redis-data:/data
     networks:
       - internal
-
-volumes:
-  db-data:
-  redis-data:
-  app-storage:
-  app-bootstrap:
 
 networks:
   internal:

--- a/oidc-client/LICENSE
+++ b/oidc-client/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019 GCS
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/oidc-client/README.md
+++ b/oidc-client/README.md
@@ -1,0 +1,61 @@
+# OIDC Client
+
+A Laravel package for delegating authentication to an OpenID Provider.
+
+## How to install
+
+Begin by adding this package to your depedencies with the command:
+
+```
+composer require gcs/oidc-client
+```
+
+Then add the following line to the list of registered service providers in `config/app.php`:
+
+```
+GCS\OIDCClient\OIDCServiceProvider::class
+```
+
+Edit your  `config/auth.php` file to use OpenID as the authentication method for your users:
+
+```
+'guards' => [
+    'web' => [
+        'driver' => 'oidc',
+        ...
+    ],
+    ...
+],
+```
+
+## How to configure
+
+Run the following command to publish the `config/oidc.php` configuration file:
+
+```
+php artisan vendor:publish --provider="GCS\OIDCClient\OIDCServiceProvider"
+```
+
+The settings to configure are the following
+
+- `client_id` This is the ID of your client application used by the OpenID provider. You should set this through an environment variable called `OIDC_CLIENT_ID`.
+- `client_secret` This is the secret code of your client application only known by the OpenID provider. You should set this through an environment variable called `OIDC_CLIENT_SECRET`.
+- `provider_url` This is base URL of the OpenID provider. You should set this through an environment variable called `OIDC_PROVIDER_URL`.
+- `provider_name` This is a short name for your OpenID provider, which will only appears in your OpenID routes. Do not use spaces. You should set this through an environment variable called `OIDC_PROVIDER_NAME`.
+- `scopes` This is a list of scopes your application will request from the OpenID provider. The `openid` scope is required. **Add any additional scopes.**
+
+
+## How to use
+
+Once everything is set up, you can replace your login system with a call to the route `route('oidc.signin')`. For logouts, use the route `route('oidc.signout')`.
+
+You may want to overwrite the `$redirectTo` variable inside `OIDCController` in order to specify the route you want your users to be taken to upon successful authentication. 
+
+Another important method you may need to overwrite is `retrieveByInfo` inside `OIDCUserProvider`. This function takes the array of user attributes retrieved from the OpenID provider, and returns a User model for the authenticated user. This is where you may want to merge the info you receive from the provider with the info you hold about that user in your application database.
+
+---
+*Developed by Cabinet Office Digital Development in October 2019.
+*
+
+
+

--- a/oidc-client/composer.json
+++ b/oidc-client/composer.json
@@ -1,0 +1,19 @@
+{
+    "name": "gcs/oidc-client",
+    "version": "1.0.0",
+    "license": "MIT",
+    "require": {
+        "jumbojett/openid-connect-php": "^0.8.0"
+    },
+    "authors": [
+        {
+            "name": "Cabinet Office Digital Development",
+            "email": "webmaster@cabinetoffice.gov.uk"
+        }
+    ],
+    "autoload": {
+        "psr-4": {
+            "GCS\\OIDCClient\\": "src/"
+        }
+    }
+}

--- a/oidc-client/src/Auth/OIDCGuard.php
+++ b/oidc-client/src/Auth/OIDCGuard.php
@@ -1,0 +1,114 @@
+<?php
+
+
+namespace GCS\OIDCClient\Auth;
+
+
+use Illuminate\Auth\SessionGuard;
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Contracts\Auth\Authenticatable as AuthenticatableContract;
+use Illuminate\Contracts\Session\Session;
+use Jumbojett\OpenIDConnectClient as Client;
+use Jumbojett\OpenIDConnectClientException;
+use Symfony\Component\HttpFoundation\Request;
+
+class OIDCGuard extends SessionGuard
+{
+    /**
+     * Instance of the OpenIDConnectClient
+     *
+     * @var Client
+     */
+    private $oidc;
+    
+    public function __construct($name, Client $oidc, OIDCUserProvider $provider, 
+                                Session $session, Request $request = null)
+    {
+        parent::__construct($name, $provider, $session, $request);
+        $this->oidc = $oidc;
+    }
+    
+    public function redirect()
+    {
+        try {
+            $this->oidc->authenticate();
+        } catch (OpenIDConnectClientException $e) {
+            throw $e;
+        }
+    }
+    
+    public function retrieveUserInfo()
+    {
+        try {
+            $this->oidc->authenticate();
+        } catch (OpenIDConnectClientException $e) {
+            throw $e;
+        }
+        $userInfo = $this->oidc->requestUserInfo();
+        return $userInfo;
+    }
+    
+    public function generateUser($user_info)
+    {
+        $user = $this->provider->retrieveByInfo($user_info);
+        return $user;
+    }
+
+    public function login(AuthenticatableContract $user, $remember = false)
+    {
+        $this->updateSession($user);
+
+        if ($remember) {
+            $this->ensureRememberTokenIsSet($user);
+            $this->queueRecallerCookie($user);
+        }
+        $this->fireLoginEvent($user, $remember);
+
+        $this->setUser($user);
+        return true;
+    }
+
+    public function user()
+    {
+        if ($this->loggedOut) {
+            return null;
+        }
+
+	// enable trusted device mode since there is no password
+	$this->session->put('sudoTrustDevice', 1);
+
+        if (! is_null($this->user)) {
+            return $this->user;
+        }
+
+        $user = $this->session->get($this->getName());
+        
+        if (! is_null($user) && $this->user = $user) {
+            $this->fireAuthenticatedEvent($this->user);
+        }
+
+        if (is_null($this->user) && ! is_null($recaller = $this->recaller())) {
+            $this->user = $this->userFromRecaller($recaller);
+
+            if ($this->user) {
+                $this->updateSession($this->user);
+
+                $this->fireLoginEvent($this->user, true);
+            }
+        }
+
+        return $this->user;
+    }
+    
+    protected function updateSession($user)
+    {
+        $this->session->put($this->getName(), $user);
+
+        $this->session->migrate(true);
+    }
+
+    public function logout()
+    {
+        parent::logout();
+    }
+}

--- a/oidc-client/src/Auth/OIDCUserProvider.php
+++ b/oidc-client/src/Auth/OIDCUserProvider.php
@@ -1,0 +1,130 @@
+<?php
+
+
+namespace GCS\OIDCClient\Auth;
+
+
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Contracts\Auth\UserProvider;
+
+
+class OIDCUserProvider implements UserProvider
+{
+    private function is_admin($user_info)
+    {
+	    if (!property_exists($user_info, "resource_access"))
+		    return false;
+	    if (!property_exists($user_info->resource_access, "pixelfed"))
+		    return false;
+	    if (!property_exists($user_info->resource_access->pixelfed, "roles"))
+		    return false;
+	    return in_array("admin", $user_info->resource_access->pixelfed->roles);
+    }
+
+    public function retrieveByInfo($user_info)
+    {
+        \Log::info(print_r($user_info, true));
+        $model = config('auth.providers.users.model');
+	$user = $model::where('email', $user_info->email)->first();
+	if ($user) {
+		// user exists, make sure the other fields match
+		$need_save = false;
+		if ($user->name != $user_info->name)
+		{
+			$user->name = $user_info->name;
+			$need_save = true;
+		}
+		if ($user->username != $user_info->preferred_username)
+		{
+			$user->username = $user_info->preferred_username;
+			$need_save = true;
+		}
+
+		$is_admin = $this->is_admin($user_info);
+		if ($user->is_admin != $is_admin)
+		{
+			$user->is_admin = $is_admin;
+			$need_save = true;
+		}
+
+
+		if ($need_save)
+			$user->save();
+	} else {
+		/* Not a user, create them */
+		$user = new $model;
+		$user->username = $user_info->preferred_username;
+		$user->name = $user_info->name;
+		$user->email = $user_info->email;
+		$user->password = 'INVALID-PASSWORD'; // bcrypt($password);
+		$user->is_admin = $this->is_admin($user_info);
+		$user->email_verified_at = now();
+		$user->save();
+
+		// reload them to fill in all the fields
+		$user = $model::where('email', $user_info->email)->first();
+		\Log::info('Created new user! ' . $user->name);
+	}
+
+	\Log::info(print_r($user, true));
+        return $user;
+    }
+
+    /**
+     * Retrieve a user by their unique identifier.
+     *
+     * @param mixed $identifier
+     * @return \Illuminate\Contracts\Auth\Authenticatable|null
+     */
+    public function retrieveById($identifier)
+    {
+        return null;
+    }
+
+    /**
+     * Retrieve a user by their unique identifier and "remember me" token.
+     *
+     * @param mixed $identifier
+     * @param string $token
+     * @return \Illuminate\Contracts\Auth\Authenticatable|null
+     */
+    public function retrieveByToken($identifier, $token)
+    {
+        return null;
+    }
+
+    /**
+     * Update the "remember me" token for the given user in storage.
+     *
+     * @param \Illuminate\Contracts\Auth\Authenticatable $user
+     * @param string $token
+     * @return void
+     */
+    public function updateRememberToken(Authenticatable $user, $token)
+    {
+        return;
+    }
+
+    /**
+     * Retrieve a user by the given credentials.
+     *
+     * @param array $credentials
+     * @return \Illuminate\Contracts\Auth\Authenticatable|null
+     */
+    public function retrieveByCredentials(array $credentials)
+    {
+        return null;
+    }
+
+    /**
+     * Validate a user against the given credentials.
+     *
+     * @param \Illuminate\Contracts\Auth\Authenticatable $user
+     * @param array $credentials
+     * @return bool
+     */
+    public function validateCredentials(Authenticatable $user, array $credentials)
+    {
+        return true;
+    }
+}

--- a/oidc-client/src/Controllers/OIDCController.php
+++ b/oidc-client/src/Controllers/OIDCController.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace GCS\OIDCClient\Controllers;
+
+
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Validation\ValidationException;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Foundation\Bus\DispatchesJobs;
+use Illuminate\Foundation\Validation\ValidatesRequests;
+use Illuminate\Foundation\Auth\RedirectsUsers;
+
+
+class OIDCController extends Controller
+{
+
+    use RedirectsUsers,ValidatesRequests;
+    use AuthorizesRequests, DispatchesJobs;
+
+
+    protected $redirectTo = '/';
+
+    /**
+     * Create a new controller instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+    }
+
+    public function signin()
+    {
+        $this->guard()->redirect();
+    }
+
+    public function callback(Request $request)
+    {
+        $userInfo = $this->guard()->retrieveUserInfo();
+        $user = $this->guard()->generateUser($userInfo);
+        
+        if ($this->guard()->login($user)) {
+            return $this->sendLoginResponse($request);
+        }
+        return $this->sendFailedLoginResponse($request);
+    }
+
+    protected function sendLoginResponse(Request $request)
+    {
+        $request->session()->regenerate();
+        
+        return redirect()->intended($this->redirectPath());
+    }
+
+    protected function sendFailedLoginResponse(Request $request)
+    {
+        throw ValidationException::withMessages([
+            'user' => [trans('auth.failed')],
+        ]);
+    }
+
+    public function signout(Request $request)
+    {
+        $this->guard()->logout();
+
+        $request->session()->invalidate();
+
+        return redirect()->intended($this->redirectPath());
+    }
+    
+    private function guard()
+    {
+        return Auth::guard();
+    }
+    
+}

--- a/oidc-client/src/OIDCServiceProvider.php
+++ b/oidc-client/src/OIDCServiceProvider.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace GCS\OIDCClient;
+
+use GCS\OIDCClient\Auth\OIDCGuard;
+use GCS\OIDCClient\Auth\OIDCUserProvider;
+
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\ServiceProvider;
+use Jumbojett\OpenIDConnectClient;
+
+class OIDCServiceProvider extends ServiceProvider
+{
+    /**
+     * Register services.
+     *
+     * @return void
+     */
+    public function register()
+    {
+        //
+    }
+
+    /**
+     * Bootstrap services.
+     *
+     * @return void
+     */
+    public function boot()
+    {
+        $this->publishes([
+            __DIR__.'/config.php' => config_path('oidc.php'),
+        ]);
+
+        $this->loadRoutesFrom(__DIR__ .'/routes.php');
+
+        Auth::extend('oidc', function($app) {
+            $client = $this->createOpenIDConnectClient();
+            $provider = new OIDCUserProvider();
+            return new OIDCGuard(
+                'oidc', $client, $provider, 
+                $app['session.store']);
+        });
+    }
+
+    private function createOpenIDConnectClient()
+    {
+        $client = new OpenIDConnectClient(
+            config('oidc.provider_url'),
+            config('oidc.client_id'),
+            config('oidc.client_secret')
+        );
+        foreach (config('oidc.scopes') as $scope) {
+            $client->addScope($scope);
+        }
+        $client->setRedirectURL(
+            route('oidc.callback')
+        );
+        return $client;
+    }
+    
+}

--- a/oidc-client/src/routes.php
+++ b/oidc-client/src/routes.php
@@ -1,0 +1,10 @@
+<?php
+
+Route::prefix(config('oidc.provider_name'))->middleware('web')->group(function () {
+    Route::get('/sign-in', 'GCS\OIDCClient\Controllers\OIDCController@signin')
+        ->name('oidc.signin');
+    Route::get('/sign-out', 'GCS\OIDCClient\Controllers\OIDCController@signout')
+        ->name('oidc.signout');
+    Route::get('/callback', 'GCS\OIDCClient\Controllers\OIDCController@callback')
+        ->name('oidc.callback');
+});

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -7,6 +7,9 @@
             <div class="">
                 <div class="card-header bg-transparent p-3 text-center font-weight-bold h3">{{ __('Login') }}</div>
 
+@if (config('oidc.enabled'))
+                <a href="{{ route('oidc.signin') }}">Login with {{config('oidc.provider_name')}}</a>
+@else
                 <div class="card-body">
                     <form method="POST" action="{{ route('login') }}">
                         @csrf
@@ -74,6 +77,7 @@
                         </a>
                     </p>
                 </div>
+@endif
             </div>
         </div>
     </div>

--- a/resources/views/site/index.blade.php
+++ b/resources/views/site/index.blade.php
@@ -66,6 +66,11 @@
 						<div class="d-block d-md-none">
 							<p class="font-weight-light mt-3 mb-5 text-center px-5">{{ config_cache('app.short_description') ?? 'Pixelfed is an image sharing platform, an ethical alternative to centralized platforms.' }}</p>
 						</div>
+@if (config('oidc.enabled'))
+						<div class="card my-4 shadow-none border">
+							<a href="{{ route('oidc.signin') }}">Login with {{config('oidc.provider_name')}}</a>
+						</div>
+@else
 						<div class="card my-4 shadow-none border">
 							<div class="card-body px-lg-5">
 								<div class="text-center">
@@ -138,6 +143,7 @@
 								<a href="/password/reset">Password Reset</a>
 							</p>
 						</div>
+@endif
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
This is a *very early* draft set of changes to integrate Single Sign On using OpenID Connect into PixelFed.  This hacks together the [GCS OIDC Client](https://bitbucket.org/cabinetoffice/oidc-client/src/master/) library with some glue to create user accounts based on the values received from the SSO server (Keycloak in my tests).

Todo:
* [x] `isAdmin` should be set based on the roles in the SSO account
* [x] Full name, email and username (and admin) need to be updated on each login
* [x] UI needs to hide normal login if OIDC is enabled
* [ ] UI needs to be themed so that it isn't just a bare `<a href>` link
* [x] Changes squashed
* [ ] Documentation updated

Caveats: I don't know anything about PHP, SSO, Artisan, Composer etc so please feel free to make things more idiomatic.