### PR TITLE
Fix JSON-LD contexts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Add storage flags to admin dashboard diagnostics ([#3444](https://github.com/pixelfed/pixelfed/pull/3444))
 - Hardcode UTC application timezone to prevent timezone issues ([b0d2c5e1](https://github.com/pixelfed/pixelfed/commit/b0d2c5e1))
 - Remove arbitrary metro url redirect timeout ([84209c24](https://github.com/pixelfed/pixelfed/commit/84209c24))
-- Fix json-ld attributes, fixes #3423 ([95f902b1](https://github.com/pixelfed/pixelfed/commit/95f902b1))
+- Fix JSON-LD contexts ([#3464](https://github.com/pixelfed/pixelfed/pull/3464))
 
 ## [v0.11.3 (2022-05-09)](https://github.com/pixelfed/pixelfed/compare/v0.11.2...v0.11.3)
 

--- a/app/Http/Controllers/DirectMessageController.php
+++ b/app/Http/Controllers/DirectMessageController.php
@@ -797,12 +797,6 @@ class DirectMessageController extends Controller
 		$body = [
 			'@context' => [
 				'https://www.w3.org/ns/activitystreams',
-				'https://w3id.org/security/v1',
-				[
-					'sc'                => 'http://schema.org#',
-					'Hashtag'           => 'as:Hashtag',
-					'sensitive'         => 'as:sensitive',
-				]
 			],
 			'id'                    => $dm->status->permalink(),
 			'type'                  => 'Create',
@@ -845,12 +839,6 @@ class DirectMessageController extends Controller
 		$body = [
 			'@context' => [
 				'https://www.w3.org/ns/activitystreams',
-				'https://w3id.org/security/v1',
-				[
-					'sc'				=> 'http://schema.org#',
-					'Hashtag'			=> 'as:Hashtag',
-					'sensitive'			=> 'as:sensitive',
-				]
 			],
 			'id' => $dm->status->permalink('#delete'),
 			'to' => [

--- a/app/Http/Controllers/DirectMessageController.php
+++ b/app/Http/Controllers/DirectMessageController.php
@@ -796,6 +796,7 @@ class DirectMessageController extends Controller
 
 		$body = [
 			'@context' => [
+				'https://w3id.org/security/v1',
 				'https://www.w3.org/ns/activitystreams',
 			],
 			'id'                    => $dm->status->permalink(),

--- a/app/Transformer/ActivityPub/ProfileTransformer.php
+++ b/app/Transformer/ActivityPub/ProfileTransformer.php
@@ -11,13 +11,10 @@ class ProfileTransformer extends Fractal\TransformerAbstract
     {
         return [
           '@context' => [
-            'https://www.w3.org/ns/activitystreams',
             'https://w3id.org/security/v1',
+            'https://www.w3.org/ns/activitystreams',
             [
               'manuallyApprovesFollowers' => 'as:manuallyApprovesFollowers',
-              'PropertyValue'             => 'schema:PropertyValue',
-              'schema'                    => 'http://schema.org#',
-              'value'                     => 'schema:value'
             ],
           ],
           'id'                        => $profile->permalink(),

--- a/app/Transformer/ActivityPub/Verb/CreateNote.php
+++ b/app/Transformer/ActivityPub/Verb/CreateNote.php
@@ -53,17 +53,32 @@ class CreateNote extends Fractal\TransformerAbstract
 
 		return [
 			'@context' => [
-				'https://www.w3.org/ns/activitystreams',
 				'https://w3id.org/security/v1',
+				'https://www.w3.org/ns/activitystreams',
 				[
-					'sc'				=> 'http://schema.org#',
 					'Hashtag' 			=> 'as:Hashtag',
 					'sensitive' 		=> 'as:sensitive',
-					'commentsEnabled' 	=> 'sc:Boolean',
-					'@capabilities'		=> [
-						'@announce'			=> '@id',
-						'@like'				=> '@id',
-						'@reply'			=> '@id',
+					'schema' 		=> 'http://schema.org/',
+					'pixelfed' 		=> 'http://pixelfed.org/ns#'
+					'commentsEnabled' 	=> [
+						'@id' 		=> 'pixelfed:commentsEnabled',
+						'@type' 		=> 'schema:Boolean'
+					],
+					'capabilities'		=> [
+						'@id' 		=> 'pixelfed:capabilities',
+						'@container' => '@set'
+					],
+					'announce'		=> [
+						'@id' 		=> 'pixelfed:canAnnounce',
+						'@type' => '@id'
+					],
+					'like'		=> [
+						'@id' 		=> 'pixelfed:canLike',
+						'@type' => '@id'
+					],
+					'reply'		=> [
+						'@id' 		=> 'pixelfed:canReply',
+						'@type' => '@id'
 					],
 					'toot' 				=> 'http://joinmastodon.org/ns#',
 					'Emoji'				=> 'toot:Emoji'

--- a/app/Transformer/ActivityPub/Verb/CreateQuestion.php
+++ b/app/Transformer/ActivityPub/Verb/CreateQuestion.php
@@ -16,18 +16,35 @@ class CreateQuestion extends Fractal\TransformerAbstract
 	{
 		return [
 			'@context' => [
-				'https://www.w3.org/ns/activitystreams',
 				'https://w3id.org/security/v1',
+				'https://www.w3.org/ns/activitystreams',
 				[
-					'sc'				=> 'http://schema.org#',
 					'Hashtag' 			=> 'as:Hashtag',
 					'sensitive' 		=> 'as:sensitive',
-					'commentsEnabled' 	=> 'sc:Boolean',
-					'@capabilities'		=> [
-						'@announce'			=> '@id',
-						'@like'				=> '@id',
-						'@reply'			=> '@id',
+					'schema' 		=> 'http://schema.org/',
+					'pixelfed' 		=> 'http://pixelfed.org/ns#'
+					'commentsEnabled' 	=> [
+						'@id' 		=> 'pixelfed:commentsEnabled',
+						'@type' 		=> 'schema:Boolean'
 					],
+					'capabilities'		=> [
+						'@id' 		=> 'pixelfed:capabilities',
+						'@container' => '@set'
+					],
+					'announce'		=> [
+						'@id' 		=> 'pixelfed:canAnnounce',
+						'@type' => '@id'
+					],
+					'like'		=> [
+						'@id' 		=> 'pixelfed:canLike',
+						'@type' => '@id'
+					],
+					'reply'		=> [
+						'@id' 		=> 'pixelfed:canReply',
+						'@type' => '@id'
+					],
+					'toot' 				=> 'http://joinmastodon.org/ns#',
+					'Emoji'				=> 'toot:Emoji'
 				]
 			],
 			'id' 					=> $status->permalink(),

--- a/app/Transformer/ActivityPub/Verb/Note.php
+++ b/app/Transformer/ActivityPub/Verb/Note.php
@@ -54,17 +54,32 @@ class Note extends Fractal\TransformerAbstract
 
 		return [
 			'@context' => [
-				'https://www.w3.org/ns/activitystreams',
 				'https://w3id.org/security/v1',
+				'https://www.w3.org/ns/activitystreams',
 				[
-					'sc'				=> 'http://schema.org#',
 					'Hashtag' 			=> 'as:Hashtag',
 					'sensitive' 		=> 'as:sensitive',
-					'commentsEnabled' 	=> 'sc:Boolean',
-					'@capabilities'		=> [
-						'@announce'			=> '@id',
-						'@like'				=> '@id',
-						'@reply'			=> '@id',
+					'schema' 		=> 'http://schema.org/',
+					'pixelfed' 		=> 'http://pixelfed.org/ns#'
+					'commentsEnabled' 	=> [
+						'@id' 		=> 'pixelfed:commentsEnabled',
+						'@type' 		=> 'schema:Boolean'
+					],
+					'capabilities'		=> [
+						'@id' 		=> 'pixelfed:capabilities',
+						'@container' => '@set'
+					],
+					'announce'		=> [
+						'@id' 		=> 'pixelfed:canAnnounce',
+						'@type' => '@id'
+					],
+					'like'		=> [
+						'@id' 		=> 'pixelfed:canLike',
+						'@type' => '@id'
+					],
+					'reply'		=> [
+						'@id' 		=> 'pixelfed:canReply',
+						'@type' => '@id'
 					],
 					'toot' 				=> 'http://joinmastodon.org/ns#',
 					'Emoji'				=> 'toot:Emoji'

--- a/app/Transformer/ActivityPub/Verb/Question.php
+++ b/app/Transformer/ActivityPub/Verb/Question.php
@@ -32,58 +32,75 @@ class Question extends Fractal\TransformerAbstract
 		$tags = array_merge($mentions, $hashtags);
 
 		return [
-				'@context' => [
-					'https://www.w3.org/ns/activitystreams',
-					'https://w3id.org/security/v1',
-					[
-						'sc'				=> 'http://schema.org#',
-						'Hashtag' 			=> 'as:Hashtag',
-						'sensitive' 		=> 'as:sensitive',
-						'commentsEnabled' 	=> 'sc:Boolean',
-						'@capabilities'		=> [
-							'@announce'			=> '@id',
-							'@like'				=> '@id',
-							'@reply'			=> '@id',
-						],
+			'@context' => [
+				'https://w3id.org/security/v1',
+				'https://www.w3.org/ns/activitystreams',
+				[
+					'Hashtag' 			=> 'as:Hashtag',
+					'sensitive' 		=> 'as:sensitive',
+					'schema' 		=> 'http://schema.org/',
+					'pixelfed' 		=> 'http://pixelfed.org/ns#'
+					'commentsEnabled' 	=> [
+						'@id' 		=> 'pixelfed:commentsEnabled',
+						'@type' 		=> 'schema:Boolean'
+					],
+					'capabilities'		=> [
+						'@id' 		=> 'pixelfed:capabilities',
+						'@container' => '@set'
+					],
+					'announce'		=> [
+						'@id' 		=> 'pixelfed:canAnnounce',
+						'@type' => '@id'
+					],
+					'like'		=> [
+						'@id' 		=> 'pixelfed:canLike',
+						'@type' => '@id'
+					],
+					'reply'		=> [
+						'@id' 		=> 'pixelfed:canReply',
+						'@type' => '@id'
+					],
+					'toot' 				=> 'http://joinmastodon.org/ns#',
+					'Emoji'				=> 'toot:Emoji'
+				]
+			],
+			'id' 				=> $status->url(),
+			'type' 				=> 'Question',
+			'summary'   		=> null,
+			'content'   		=> $status->rendered ?? $status->caption,
+			'inReplyTo' 		=> $status->in_reply_to_id ? $status->parent()->url() : null,
+			'published'    		=> $status->created_at->toAtomString(),
+			'url'          		=> $status->url(),
+			'attributedTo' 		=> $status->profile->permalink(),
+			'to'           		=> $status->scopeToAudience('to'),
+			'cc' 				=> $status->scopeToAudience('cc'),
+			'sensitive'       	=> (bool) $status->is_nsfw,
+			'attachment'      	=> [],
+			'tag' 				=> $tags,
+			'commentsEnabled'  => (bool) !$status->comments_disabled,
+			'capabilities' => [
+				'announce' => 'https://www.w3.org/ns/activitystreams#Public',
+				'like' => 'https://www.w3.org/ns/activitystreams#Public',
+				'reply' => $status->comments_disabled == true ? null : 'https://www.w3.org/ns/activitystreams#Public'
+			],
+			'location' => $status->place_id ? [
+					'type' => 'Place',
+					'name' => $status->place->name,
+					'longitude' => $status->place->long,
+					'latitude' => $status->place->lat,
+					'country' => $status->place->country
+				] : null,
+			'endTime' => $status->poll->expires_at->toAtomString(),
+			'oneOf' => collect($status->poll->poll_options)->map(function($option, $index) use($status) {
+				return [
+					'type' => 'Note',
+					'name' => $option,
+					'replies' => [
+						'type' => 'Collection',
+						'totalItems' => $status->poll->cached_tallies[$index]
 					]
-				],
-				'id' 				=> $status->url(),
-				'type' 				=> 'Question',
-				'summary'   		=> null,
-				'content'   		=> $status->rendered ?? $status->caption,
-				'inReplyTo' 		=> $status->in_reply_to_id ? $status->parent()->url() : null,
-				'published'    		=> $status->created_at->toAtomString(),
-				'url'          		=> $status->url(),
-				'attributedTo' 		=> $status->profile->permalink(),
-				'to'           		=> $status->scopeToAudience('to'),
-				'cc' 				=> $status->scopeToAudience('cc'),
-				'sensitive'       	=> (bool) $status->is_nsfw,
-				'attachment'      	=> [],
-				'tag' 				=> $tags,
-				'commentsEnabled'  => (bool) !$status->comments_disabled,
-				'capabilities' => [
-					'announce' => 'https://www.w3.org/ns/activitystreams#Public',
-					'like' => 'https://www.w3.org/ns/activitystreams#Public',
-					'reply' => $status->comments_disabled == true ? null : 'https://www.w3.org/ns/activitystreams#Public'
-				],
-				'location' => $status->place_id ? [
-						'type' => 'Place',
-						'name' => $status->place->name,
-						'longitude' => $status->place->long,
-						'latitude' => $status->place->lat,
-						'country' => $status->place->country
-					] : null,
-				'endTime' => $status->poll->expires_at->toAtomString(),
-				'oneOf' => collect($status->poll->poll_options)->map(function($option, $index) use($status) {
-					return [
-						'type' => 'Note',
-						'name' => $option,
-						'replies' => [
-							'type' => 'Collection',
-							'totalItems' => $status->poll->cached_tallies[$index]
-						]
-					];
-				})
-			];
+				];
+			})
+		];
 	}
 }


### PR DESCRIPTION
- Changed: Move ActivityPub context to end (before custom properties), so it overrides any other namespaces
- Removed: Remove schema:PropertyValue and schema:value where unused (can be added back later)
- Added: Add a pixelfed namespace (doesn't resolve yet, but neither does toot / joinmastodon)
- Changed: Properly define extensions like commentsEnabled and capabilities so they get normalized correctly within the pixelfed namespace