### PR TITLE
Fix mastodon api compatibility

### DIFF
--- a/app/Http/Controllers/Api/ApiV1Controller.php
+++ b/app/Http/Controllers/Api/ApiV1Controller.php
@@ -1250,8 +1250,8 @@ class ApiV1Controller extends Controller
 			return [
 				'uri' => config('pixelfed.domain.app'),
 				'title' => config('app.name'),
-				'short_description' => 'Pixelfed is an image sharing platform, an ethical alternative to centralized platforms',
-				'description' => 'Pixelfed is an image sharing platform, an ethical alternative to centralized platforms',
+				'short_description' => config_cache('app.short_description'),
+				'description' => config_cache('app.description'),
 				'email' => config('instance.email'),
 				'version' => '2.7.2 (compatible; Pixelfed ' . config('pixelfed.version') .')',
 				'urls' => [
@@ -1259,7 +1259,7 @@ class ApiV1Controller extends Controller
 				],
 				'stats' => $stats,
 				'thumbnail' => url('img/pixelfed-icon-color.png'),
-				'languages' => ['en'],
+				'languages' => [config('app.locale')],
 				'registrations' => (bool) config_cache('pixelfed.open_registration'),
 				'approval_required' => false,
 				'contact_account' => $contact,

--- a/app/Http/Controllers/Api/ApiV1Controller.php
+++ b/app/Http/Controllers/Api/ApiV1Controller.php
@@ -1008,7 +1008,7 @@ class ApiV1Controller extends Controller
 			->map(function($like) {
 				$status =  StatusService::getMastodon($like['status_id'], false);
 				$status['like_id'] = $like->id;
-				$status['liked_at'] = $like->created_at->format('c');
+				$status['liked_at'] = str_replace('+00:00', 'Z', $like->created_at->format(DATE_RFC3339_EXTENDED));
 				return $status;
 			})
 			->filter(function($status) {

--- a/app/Http/Controllers/Api/InstanceApiController.php
+++ b/app/Http/Controllers/Api/InstanceApiController.php
@@ -19,7 +19,7 @@ class InstanceApiController extends Controller {
 				'acct'			  => $admin->username,
 				'display_name' 	  => e($admin->name),
 				'locked' 		  => (bool) $admin->is_private,
-				'created_at' 	  => $admin->created_at->format('c'),
+				'created_at' 	  => str_replace('+00:00', 'Z', $admin->created_at->format(DATE_RFC3339_EXTENDED)),
 				'note' 			  => e($admin->bio),
 				'url' 			  => $admin->url(),
 				'avatar' 		  => $admin->avatarUrl(),

--- a/app/Http/Controllers/InternalApiController.php
+++ b/app/Http/Controllers/InternalApiController.php
@@ -326,7 +326,7 @@ class InternalApiController extends Controller
 				if(!$status) {
 					return false;
 				}
-				$status['bookmarked_at'] = $bookmark->created_at->format('c');
+				$status['bookmarked_at'] = str_replace('+00:00', 'Z', $bookmark->created_at->format(DATE_RFC3339_EXTENDED));
 
 				if($status) {
 					BookmarkService::add($pid, $status['id']);

--- a/app/Services/AdminStatsService.php
+++ b/app/Services/AdminStatsService.php
@@ -37,7 +37,7 @@ class AdminStatsService
         return Cache::remember('admin:dashboard:storage:stats', 120000, function() {
             $res = [];
 
-            $res['last_updated'] = now()->format('c');
+            $res['last_updated'] = str_replace('+00:00', 'Z', now()->format(DATE_RFC3339_EXTENDED));
 
             $avatars = Avatar::count();
             $avatarsLocal = Avatar::whereNull('cdn_url')->count();

--- a/app/Services/MarkerService.php
+++ b/app/Services/MarkerService.php
@@ -20,7 +20,7 @@ class MarkerService
 		$val = [
 			'last_read_id' => (string) $entityId,
 			'version' => $existing ? ($existing['version'] + 1) : 1,
-			'updated_at' => now()->format('c')
+			'updated_at' => str_replace('+00:00', 'Z', now()->format(DATE_RFC3339_EXTENDED))
 		];
 		Cache::put($key, $val, 2592000);
 		return $val;

--- a/app/Services/PollService.php
+++ b/app/Services/PollService.php
@@ -19,7 +19,7 @@ class PollService
 			$poll = Poll::whereStatusId($id)->firstOrFail();
 			return [
 				'id' => (string) $poll->id,
-				'expires_at' => $poll->expires_at->format('c'),
+				'expires_at' => str_replace('+00:00', 'Z', $poll->expires_at->format(DATE_RFC3339_EXTENDED)),
 				'expired' => null,
 				'multiple' => $poll->multiple,
 				'votes_count' => $poll->votes_count,

--- a/app/Status.php
+++ b/app/Status.php
@@ -333,7 +333,7 @@ class Status extends Model
 			'id'    => $this->permalink(),
 			'type'  => 'Create',
 			'actor' => $profile->permalink(),
-			'published' => $this->created_at->format('c'),
+			'published' => str_replace('+00:00', 'Z', $this->created_at->format(DATE_RFC3339_EXTENDED)),
 			'to' => $to,
 			'cc' => $cc,
 			'object' => [
@@ -341,7 +341,7 @@ class Status extends Model
 				'type' => 'Note',
 				'summary' => null,
 				'inReplyTo' => null,
-				'published' => $this->created_at->format('c'),
+				'published' => str_replace('+00:00', 'Z', $this->created_at->format(DATE_RFC3339_EXTENDED)),
 				'url' => $this->url(),
 				'attributedTo' => $this->profile->url(),
 				'to' => $to,

--- a/app/Transformer/Api/NotificationTransformer.php
+++ b/app/Transformer/Api/NotificationTransformer.php
@@ -16,7 +16,7 @@ class NotificationTransformer extends Fractal\TransformerAbstract
 		$res = [
 			'id'       		=> (string) $notification->id,
 			'type'       	=> $this->replaceTypeVerb($notification->action),
-			'created_at' 	=> (string) $notification->created_at->format('c'),
+			'created_at' 	=> (string) str_replace('+00:00', 'Z', $notification->created_at->format(DATE_RFC3339_EXTENDED)),
 		];
 
 		$n = $notification;

--- a/app/Transformer/Api/StatusStatelessTransformer.php
+++ b/app/Transformer/Api/StatusStatelessTransformer.php
@@ -35,7 +35,7 @@ class StatusStatelessTransformer extends Fractal\TransformerAbstract
 			'reblog'                    => null,
 			'content'                   => $status->rendered ?? $status->caption,
 			'content_text'              => $status->caption,
-			'created_at'                => $status->created_at->format('c'),
+			'created_at'                => str_replace('+00:00', 'Z', $status->created_at->format(DATE_RFC3339_EXTENDED)),
 			'emojis'                    => CustomEmoji::scan($status->caption),
 			'reblogs_count'             => $status->reblogs_count ?? 0,
 			'favourites_count'          => $status->likes_count ?? 0,

--- a/app/Transformer/Api/StatusTransformer.php
+++ b/app/Transformer/Api/StatusTransformer.php
@@ -38,7 +38,7 @@ class StatusTransformer extends Fractal\TransformerAbstract
 			'reblog'                    => null,
 			'content'                   => $status->rendered ?? $status->caption,
 			'content_text'              => $status->caption,
-			'created_at'                => $status->created_at->format('c'),
+			'created_at'                => str_replace('+00:00', 'Z', $status->created_at->format(DATE_RFC3339_EXTENDED)),
 			'emojis'                    => CustomEmoji::scan($status->caption),
 			'reblogs_count'             => 0,
 			'favourites_count'          => $status->likes_count ?? 0,


### PR DESCRIPTION
Improve Mastodon API compatibility.

Fix https://github.com/mastodon/mastodon-android/issues/88

This will allow timelines to be displayed on Mastodon for iPhone and iPad, Mastodon for Andoroid, and Toot!

- Force the date format to the format used by Mastodon
- Instance API responses now use the Short and Long Descriptions in the Brand Settings
- Instance API responses now use the language specification from the APP_LOCALE environment variable