### PR TITLE
display all photos in the atom feed

### DIFF
--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -210,7 +210,6 @@ class ProfileController extends Controller
 			->whereVisibility('public')
 			->whereType('photo')
 			->orderByDesc('id')
-			->take(10)
 			->get()
 			->map(function($status) {
 				return StatusService::get($status->id);


### PR DESCRIPTION
until now, the atom feed only displays 10 images
this makes the atom feed display all photo feeds

related: https://github.com/pixelfed/pixelfed/issues/3193

Disclaimer: I am messing around a bit and I know it is usually worthless to just create a commit without a setup and running tests. BUT: at least we have a conversation!