### PR TITLE
fix: add opt of forceScheme(https)

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -39,7 +39,9 @@ class AppServiceProvider extends ServiceProvider
 	 */
 	public function boot()
 	{
-		URL::forceScheme('https');
+		if (preg_match("/^https/", env('APP_URL')) || env('APP_ENV') === 'production') {
+			URL::forceScheme('https');
+		}
 		Schema::defaultStringLength(191);
 		Paginator::useBootstrap();
 		Avatar::observe(AvatarObserver::class);


### PR DESCRIPTION
When running the application locally with
APP_URL=http://localhost it is unexpected for
all route URLs returned by `route('route-name')`
to use the https prefix.

Configuring SSL for your local environment should
not be a required step to development locally.

The new logic checks the configured URL for presence
of https:// OR that this the application is running
in a production environment.

I have not worked with Laravel before, so very open to pointers
for alternative places this could be handled. 🧠 