### PR TITLE
Add register link to login page

### DIFF
--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -69,6 +69,10 @@
                     <hr>
 
                     <p class="text-center font-weight-bold">
+                        @if(config_cache('pixelfed.open_registration'))
+                        <a href="/register">Register</a>
+                        <span class="px-1">·</span>
+                        @endif
                         <a href="{{ route('password.request') }}">
                             {{ __('Forgot Password') }}
                         </a>


### PR DESCRIPTION
At the moment, the login page does not have a link to allow users to go to the register page from the login page:

![image](https://user-images.githubusercontent.com/30006386/197395311-fd2b4bbd-588d-413d-abe9-ca0383a1fa27.png)
(screenshot taken from [pixelfed.de/login](https://pixelfed.de/login))

This PR effectively copies the register link from the index page and adds it to the login page too:

![image](https://user-images.githubusercontent.com/30006386/197395374-6c1c675b-b692-424f-977f-e4d7c1089f2b.png)

This can make navigation a little easier, and (not that this is a real reason to have this but I thought I'd mention anyway) [Instagram has the same thing on their login page](https://www.instagram.com/accounts/login/).