### PR TITLE
docker: Remove bootstrap volume and streamline startup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ yarn-error.log
 .git-credentials
 /.composer/
 /nginx.conf
+/data

--- a/contrib/docker/Dockerfile.apache
+++ b/contrib/docker/Dockerfile.apache
@@ -1,10 +1,10 @@
-FROM php:7.4-apache-bullseye
+FROM php:8.1-apache
 
 # Use the default production configuration
 COPY contrib/docker/php.production.ini "$PHP_INI_DIR/php.ini"
 
 # Install Composer
-ENV COMPOSER_VERSION=2.1.14 \
+ENV COMPOSER_VERSION=2.4.4 \
     COMPOSER_HOME=/var/www/.composer \
     COMPOSER_MEMORY_LIMIT=-1 \
     PATH="~/.composer/vendor/bin:./vendor/bin:${PATH}"

--- a/contrib/docker/Dockerfile.apache
+++ b/contrib/docker/Dockerfile.apache
@@ -95,6 +95,5 @@ RUN cp -r storage storage.skel \
   && composer install --prefer-dist --no-interaction --no-ansi --optimize-autoloader \
   && rm -rf html && ln -s public html \
   && chown -R www-data:www-data /var/www
-VOLUME /var/www/storage /var/www/bootstrap
 
 CMD ["/var/www/contrib/docker/start.apache.sh"]

--- a/contrib/docker/start.apache.sh
+++ b/contrib/docker/start.apache.sh
@@ -1,8 +1,51 @@
 #!/bin/bash
 
+info() { echo >&2 "$*" ; }
+
 # Create the storage tree if needed and fix permissions
 cp -r storage.skel/* storage/
 chown -R www-data:www-data storage/ bootstrap/
+
+# Do initial setup if it hasn't been done
+# These are the one-time setup tasks from:
+# https://docs.pixelfed.org/running-pixelfed/installation/#one-time-setup-tasks
+if [ -z "$APP_KEY" ]; then
+	info "creating app key"
+	php artisan key:generate || exit 1
+fi
+
+if [ ! -r storage/.migrated ]; then
+	for i in `seq 1 10`; do
+		info "******* WAITING FOR DB TO COME UP ********"
+		if echo 'exit' | mysql \
+			-u $DB_USERNAME \
+			-p$DB_PASSWORD \
+			-h $DB_HOST \
+			-P $DB_PORT \
+			$DB_DATABASE \
+		; then
+			break
+		fi
+		sleep 10
+	done
+
+	info "Creating database scheme; this might take a while"
+	php artisan migrate --force || exit 1
+	touch storage/.migrated
+fi
+
+if [ ! -r storage/.instance ]; then
+	info "Creating ActivityPub federation id"
+	php artisan instance:actor || exit 1
+	touch storage/.instance
+fi
+
+if [ ! -r storage/.passport ]; then
+	info "Creating OAuth keys"
+	php artisan passport:keys || exit 1
+	touch storage/.passport
+fi
+
 
 # Refresh the environment
 php artisan storage:link
@@ -12,4 +55,4 @@ php artisan view:cache
 php artisan config:cache
 
 # Finally run Apache
-apache2-foreground
+exec apache2-foreground

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,8 +22,7 @@ services:
     env_file:
       - .env.docker
     volumes:
-      - app-storage:/var/www/storage
-      - app-bootstrap:/var/www/bootstrap
+      - ./data/app-storage:/var/www/storage
       - "./.env.docker:/var/www/.env"
     networks:
       - external
@@ -43,8 +42,7 @@ services:
     env_file:
       - .env.docker
     volumes:
-      - app-storage:/var/www/storage
-      - app-bootstrap:/var/www/bootstrap
+      - ./data/app-storage:/var/www/storage
     networks:
       - external
       - internal
@@ -63,7 +61,7 @@ services:
     env_file:
       - .env.docker
     volumes:
-      - "db-data:/var/lib/mysql"
+      - ./data/db-data:/var/lib/mysql
 
   redis:
     image: redis:5-alpine
@@ -71,15 +69,9 @@ services:
     env_file:
       - .env.docker
     volumes:
-      - "redis-data:/data"
+      - ./data/redis-data:/data
     networks:
       - internal
-
-volumes:
-  db-data:
-  redis-data:
-  app-storage:
-  app-bootstrap:
 
 networks:
   internal:


### PR DESCRIPTION
This patch modifies the `start.apache.sh` script to perform the initial setup on first boot of the container so that the database and all of the various keys are applied.  I'm not positive these are the right steps in the right order, although it allows me to bring my pixelfed server online.

The patch also moves the storage, db, and redis volumes into a local `data` directory for easier management and removes the bootstrap volume since it did not seem necessary for normal operation.  Was there a reason for the separate `bootstrap` volume that I missed in [the `cp -r storage.skel` discussion](https://github.com/pixelfed/pixelfed/pull/2137#discussion_r434468862)?