### PR TITLE
Update Dockerfile.apache

### DIFF
--- a/contrib/docker/Dockerfile.apache
+++ b/contrib/docker/Dockerfile.apache
@@ -1,4 +1,4 @@
-FROM php:7.4-apache-bullseye
+FROM php:8.1-apache-bullseye
 
 # Use the default production configuration
 COPY contrib/docker/php.production.ini "$PHP_INI_DIR/php.ini"


### PR DESCRIPTION
The old PHP version prevents building the container image. It builds fine when "upgrading" towards 8.1, hence this change.