### PR TITLE
Fix Emoji Mime Type Validation

### DIFF
--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -40,12 +40,12 @@ use App\Models\CustomEmoji;
 
 class AdminController extends Controller
 {
-	use AdminReportController, 
+	use AdminReportController,
 	AdminDirectoryController,
 	AdminDiscoverController,
 	// AdminGroupsController,
-	AdminMediaController, 
-	AdminSettingsController, 
+	AdminMediaController,
+	AdminSettingsController,
 	AdminInstanceController,
 	// AdminStorageController,
 	AdminUserController;
@@ -518,7 +518,7 @@ class AdminController extends Controller
 					->whereShortcode($request->input('shortcode'));
 				})
 			],
-			'emoji' => 'required|file|mimetypes:jpg,png|max:' . (config('federation.custom_emoji.max_size') / 1000)
+			'emoji' => 'required|file|mimes:jpg,png|max:' . (config('federation.custom_emoji.max_size') / 1000)
 		]);
 
 		$emoji = new CustomEmoji;


### PR DESCRIPTION
This will fix #3690 , and allows to upload emoji as jpg/png.

May be a good thing to allow webp too.