### PR TITLE
Enhance translation: Use phrase instead of single words

### DIFF
--- a/resources/lang/de/web.php
+++ b/resources/lang/de/web.php
@@ -84,6 +84,7 @@ return [
 		'updatedA' => 'aktualisierte ein',
 		'sentA' => 'sendete ein',
 
+		'followedYou' => 'folgt dir',
 		'followed' => 'gefolgt',
 		'mentioned' => 'erwähnt',
 		'you' => 'du',

--- a/resources/lang/de/web.php
+++ b/resources/lang/de/web.php
@@ -78,6 +78,7 @@ return [
 		'liked' => 'gefällt dein',
 		'commented' => 'kommentierte dein',
 		'reacted' => 'reagierte auf dein',
+		'sharedYourPost' => 'teilte deinen Beitrag',
 		'shared' => 'teilte deine',
 		'tagged' => 'markierte dich in einem',
 


### PR DESCRIPTION
I recommend to use the complete phrase "followed you" here instead of the single words "followed" and "you".