### PR TITLE
Update Dockerfile* to php-8.1

### DIFF
--- a/contrib/docker/Dockerfile.apache
+++ b/contrib/docker/Dockerfile.apache
@@ -1,4 +1,4 @@
-FROM php:7.4-apache-bullseye
+FROM php:8.1-apache-bullseye
 
 # Use the default production configuration
 COPY contrib/docker/php.production.ini "$PHP_INI_DIR/php.ini"

--- a/contrib/docker/Dockerfile.fpm
+++ b/contrib/docker/Dockerfile.fpm
@@ -1,4 +1,4 @@
-FROM php:7.4-fpm-buster
+FROM php:8.1-fpm-buster
 
 # Use the default production configuration
 COPY contrib/docker/php.production.ini "$PHP_INI_DIR/php.ini"


### PR DESCRIPTION
Repo requires php-8.1. Dockerfiles under contrib/docker were at 7.4, causing build failures related to php version.

With his patch, current dev release builds Dockerfile.apache but Dockerfile.fpm still fails later.