### PR TITLE
Update email and password views with the settings template

### DIFF
--- a/resources/views/settings/email.blade.php
+++ b/resources/views/settings/email.blade.php
@@ -1,63 +1,33 @@
-@extends('layouts.app')
+@extends('settings.template')
 
-@section('content')
-@if (session('status'))
-    <div class="alert alert-primary px-3 h6 text-center">
-        {{ session('status') }}
-    </div>
-@endif
-@if ($errors->any())
-    <div class="alert alert-danger px-3 h6 text-center">
-            @foreach($errors->all() as $error)
-                <p class="font-weight-bold mb-1">{{ $error }}</p>
-            @endforeach
-    </div>
-@endif
-@if (session('error'))
-    <div class="alert alert-danger px-3 h6 text-center">
-        {{ session('error') }}
-    </div>
-@endif
+@section('section')
 
-<div class="container">
-  <div class="col-12">
-    <div class="card shadow-none border mt-5">
-      <div class="card-body">
-        <div class="row">
-          <div class="col-12 p-3 p-md-5">
-			  <div class="title">
-			    <h3 class="font-weight-bold">Email Settings</h3>
-			  </div>
-			  <hr>
-			  <form method="post" action="{{route('settings.email')}}">
-			    @csrf
-			    <input type="hidden" class="form-control" name="name" value="{{Auth::user()->profile->name}}">
-			    <input type="hidden" class="form-control" name="username" value="{{Auth::user()->profile->username}}">
-			    <input type="hidden" class="form-control" name="website" value="{{Auth::user()->profile->website}}">
+	<div class="title">
+		<h3 class="font-weight-bold">Email Settings</h3>
+	</div>
+	<hr>
+	<form method="post" action="{{route('settings.email')}}">
+		@csrf
+		<input type="hidden" class="form-control" name="name" value="{{Auth::user()->profile->name}}">
+		<input type="hidden" class="form-control" name="username" value="{{Auth::user()->profile->username}}">
+		<input type="hidden" class="form-control" name="website" value="{{Auth::user()->profile->website}}">
 
-			    <div class="form-group">
-			      <label for="email" class="font-weight-bold">Email Address</label>
-			        <input type="email" class="form-control" id="email" name="email" placeholder="Email Address" value="{{Auth::user()->email}}">
-			        <p class="help-text small text-muted font-weight-bold">
-			          @if(Auth::user()->email_verified_at)
-			          <span class="text-success">Verified</span> {{Auth::user()->email_verified_at->diffForHumans()}}
-			          @else
-			          <span class="text-danger">Unverified</span> You need to <a href="/i/verify-email">verify your email</a>.
-			          @endif
-			        </p>
-			    </div>
-			    <div class="form-group row">
-			      <div class="col-12 text-right">
-			        <button type="submit" class="btn btn-primary font-weight-bold py-0 px-5">Submit</button>
-			      </div>
-			    </div>
-			  </form>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-
+		<div class="form-group">
+			<label for="email" class="font-weight-bold">Email Address</label>
+			<input type="email" class="form-control" id="email" name="email" placeholder="Email Address" value="{{Auth::user()->email}}">
+			<p class="help-text small text-muted font-weight-bold">
+				@if(Auth::user()->email_verified_at)
+					<span class="text-success">Verified</span> {{Auth::user()->email_verified_at->diffForHumans()}}
+				@else
+					<span class="text-danger">Unverified</span> You need to <a href="/i/verify-email">verify your email</a>.
+				@endif
+			</p>
+		</div>
+		<div class="form-group row">
+			<div class="col-12 text-right">
+				<button type="submit" class="btn btn-primary font-weight-bold py-0 px-5">Submit</button>
+			</div>
+		</div>
+	</form>
 
 @endsection

--- a/resources/views/settings/password.blade.php
+++ b/resources/views/settings/password.blade.php
@@ -1,66 +1,37 @@
-@extends('layouts.app')
+@extends('settings.template')
 
-@section('content')
-@if (session('status'))
-    <div class="alert alert-primary px-3 h6 text-center">
-        {{ session('status') }}
-    </div>
-@endif
-@if ($errors->any())
-    <div class="alert alert-danger px-3 h6 text-center">
-            @foreach($errors->all() as $error)
-                <p class="font-weight-bold mb-1">{{ $error }}</p>
-            @endforeach
-    </div>
-@endif
-@if (session('error'))
-    <div class="alert alert-danger px-3 h6 text-center">
-        {{ session('error') }}
-    </div>
-@endif
+@section('section')
 
-<div class="container">
-  <div class="col-12">
-    <div class="card shadow-none border mt-5">
-      <div class="card-body">
-        <div class="row">
-          <div class="col-12 p-3 p-md-5">
-			  <div class="title">
-			    <h3 class="font-weight-bold">Update Password</h3>
-			  </div>
-			  <hr>
-			  <form method="post">
-			    @csrf
-			    <div class="form-group row">
-			      <label for="existing" class="col-sm-3 col-form-label font-weight-bold">Current</label>
-			      <div class="col-sm-9">
-			        <input type="password" class="form-control" name="current" placeholder="Your current password">
-			      </div>
-			    </div>
-			    <hr>
-			    <div class="form-group row">
-			      <label for="new" class="col-sm-3 col-form-label font-weight-bold">New</label>
-			      <div class="col-sm-9">
-			        <input type="password" class="form-control" name="password" placeholder="Enter new password here">
-			      </div>
-			    </div>
-			    <div class="form-group row">
-			      <label for="confirm" class="col-sm-3 col-form-label font-weight-bold">Confirm</label>
-			      <div class="col-sm-9">
-			        <input type="password" class="form-control" name="password_confirmation" placeholder="Confirm new password">
-			      </div>
-			    </div>
-			    <div class="form-group row">
-			      <div class="col-12 text-right">
-			        <button type="submit" class="btn btn-primary font-weight-bold py-0 px-5">Submit</button>
-			      </div>
-			    </div>
-			  </form>
+	<div class="title">
+		<h3 class="font-weight-bold">Update Password</h3>
+	</div>
+	<hr>
+	<form method="post">
+		@csrf
+		<div class="form-group row">
+			<label for="existing" class="col-sm-3 col-form-label font-weight-bold">Current</label>
+			<div class="col-sm-9">
+				<input type="password" class="form-control" name="current" placeholder="Your current password">
 			</div>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
+		</div>
+		<hr>
+		<div class="form-group row">
+			<label for="new" class="col-sm-3 col-form-label font-weight-bold">New</label>
+			<div class="col-sm-9">
+				<input type="password" class="form-control" name="password" placeholder="Enter new password here">
+			</div>
+		</div>
+		<div class="form-group row">
+			<label for="confirm" class="col-sm-3 col-form-label font-weight-bold">Confirm</label>
+			<div class="col-sm-9">
+				<input type="password" class="form-control" name="password_confirmation" placeholder="Confirm new password">
+			</div>
+		</div>
+		<div class="form-group row">
+			<div class="col-12 text-right">
+				<button type="submit" class="btn btn-primary font-weight-bold py-0 px-5">Submit</button>
+			</div>
+		</div>
+	</form>
 
 @endsection


### PR DESCRIPTION
This pull request updates the email and password views, in account settings, to also use settings template. Just like all other views in the account settings. 
It makes alle the account settings pages consistent and you won't need to manually navigate back.

![Old email settings page](https://user-images.githubusercontent.com/16917300/205444568-3079e838-9918-49a9-add3-5941dc84ee7b.jpg)
![New email settings page](https://user-images.githubusercontent.com/16917300/205444563-dafdca50-620e-476b-be71-782cb4930dcd.jpg)
![Old password settings page](https://user-images.githubusercontent.com/16917300/205444571-35cdb5db-c3d7-4e52-8367-3afca4daa3c5.jpg)
![New password settings page](https://user-images.githubusercontent.com/16917300/205444566-1f527bbe-b525-439f-9486-a7bd0c53580b.jpg)
