### PR TITLE
Allow webp images in stories

### DIFF
--- a/app/Http/Controllers/StoryComposeController.php
+++ b/app/Http/Controllers/StoryComposeController.php
@@ -40,7 +40,7 @@ class StoryComposeController extends Controller
 			'file' => function() {
 				return [
 					'required',
-					'mimetypes:image/jpeg,image/png,video/mp4',
+					'mimetypes:image/jpeg,image/png,image/webp,video/mp4',
 					'max:' . config_cache('pixelfed.max_photo_size'),
 				];
 			},
@@ -104,6 +104,7 @@ class StoryComposeController extends Controller
 		if(in_array($photo->getMimeType(), [
 			'image/jpeg',
 			'image/png',
+            'image/webp',
 			'video/mp4'
 		]) == false) {
 			abort(400, 'Invalid media type');
@@ -112,7 +113,7 @@ class StoryComposeController extends Controller
 
 		$storagePath = MediaPathService::story($user->profile);
 		$path = $photo->storeAs($storagePath, Str::random(random_int(2, 12)) . '_' . Str::random(random_int(32, 35)) . '_' . Str::random(random_int(1, 14)) . '.' . $photo->extension());
-		if(in_array($photo->getMimeType(), ['image/jpeg','image/png'])) {
+		if(in_array($photo->getMimeType(), ['image/jpeg','image/png', 'image/webp'])) {
 			$fpath = storage_path('app/' . $path);
 			$img = Intervention::make($fpath);
 			$img->orientate();


### PR DESCRIPTION
Refers to #3857 

I have added webp as a mime type to the stories. I have tested in my local development instance the upload of WEBP images afterwards - It works so far without problems.

Test Story with webp image from #3857:
![brave_DeRHaJZe9j](https://user-images.githubusercontent.com/53119369/205457431-bc1d1bd5-9e7a-4419-9f7a-d097ee336d38.png)

