### PR TITLE
Fix wrong url scheme in sudo mode when using reverse proxy

### DIFF
--- a/app/Http/Controllers/AccountController.php
+++ b/app/Http/Controllers/AccountController.php
@@ -466,6 +466,12 @@ class AccountController extends Controller
 			if($trustDevice == true) {
 				$request->session()->put('sudoTrustDevice', 1);
 			}
+
+            //Fix wrong scheme when using reverse proxy
+            if(!str_contains($next, 'https') && config('instance.force_https_urls', true)) {
+                $next = Str::of($next)->replace('http', 'https')->toString();
+            }
+
 			return redirect($next);
 		} else {
 			return redirect()


### PR DESCRIPTION
Refers to issue #3889 

As a fix I simply replaced the string of the wrong redirect. I pay attention to the variable `FORCE_HTTPS_URLS`.

Edit: not needed when setting `X-Forwarded-Proto https` as request header.