### PR TITLE
Add a command to import emoji archives to pixelfed

### DIFF
--- a/app/Console/Commands/ImportEmojis.php
+++ b/app/Console/Commands/ImportEmojis.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\CustomEmoji;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Storage;
+
+class ImportEmojis extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'import:emojis
+                            {path : Path to a tar.gz archive with the emojis}
+                            {--prefix : Define a prefix for the emjoi shortcode}
+                            {--suffix : Define a suffix for the emjoi shortcode}
+                            {--overwrite : Overwrite existing emojis}
+                            {--disabled : Import all emojis as disabled}';
+
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Import emojis to the database';
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        $path = $this->argument('path');
+
+        if (!file_exists($path) || !mime_content_type($path) == 'application/x-tar') {
+            $this->error('Path does not exist or is not a tarfile');
+            return Command::FAILURE;
+        }
+
+        $imported = 0;
+        $skipped = 0;
+        $failed = 0;
+
+        $tar = new \PharData($path);
+        $tar->decompress();
+
+        foreach (new \RecursiveIteratorIterator($tar) as $entry) {
+            $this->line("Processing {$entry->getFilename()}");
+            if (!$entry->isFile() || !$this->isImage($entry)) {
+                $failed++;
+                continue;
+            }
+
+            $filename = pathinfo($entry->getFilename(), PATHINFO_FILENAME);
+            $extension = pathinfo($entry->getFilename(), PATHINFO_EXTENSION);
+
+            // Skip macOS shadow files
+            if (str_starts_with($filename, '._')) {
+                continue;
+            }
+
+            $shortcode = implode('', [
+                $this->option('prefix'),
+                $filename,
+                $this->option('suffix'),
+            ]);
+
+            $customEmoji = CustomEmoji::whereShortcode($shortcode)->first();
+
+            if ($customEmoji && !$this->option('overwrite')) {
+                $skipped++;
+                continue;
+            }
+
+            $emoji = $customEmoji ?? new CustomEmoji();
+            $emoji->shortcode = $shortcode;
+            $emoji->domain = config('pixelfed.domain.app');
+            $emoji->disabled = $this->option('disabled');
+            $emoji->save();
+
+            $fileName = $emoji->id . '.' . $extension;
+            Storage::putFileAs('public/emoji', $entry->getPathname(), $fileName);
+            $emoji->media_path = 'emoji/' . $fileName;
+            $emoji->save();
+            $imported++;
+            Cache::forget('pf:custom_emoji');
+        }
+
+        $this->line("Imported: {$imported}");
+        $this->line("Skipped: {$skipped}");
+        $this->line("Failed: {$failed}");
+
+        //delete file
+        unlink(str_replace('.tar.gz', '.tar', $path));
+
+        return Command::SUCCESS;
+    }
+
+    private function isImage($file)
+    {
+        $image = getimagesize($file->getPathname());
+        return $image !== false;
+    }
+}

--- a/app/Console/Commands/ImportEmojis.php
+++ b/app/Console/Commands/ImportEmojis.php
@@ -52,7 +52,7 @@ class ImportEmojis extends Command
 
         foreach (new \RecursiveIteratorIterator($tar) as $entry) {
             $this->line("Processing {$entry->getFilename()}");
-            if (!$entry->isFile() || !$this->isImage($entry)) {
+            if (!$entry->isFile() || !$this->isImage($entry) || !$this->isEmoji($entry->getPathname())) {
                 $failed++;
                 continue;
             }
@@ -106,5 +106,13 @@ class ImportEmojis extends Command
     {
         $image = getimagesize($file->getPathname());
         return $image !== false;
+    }
+
+    private function isEmoji($filename)
+    {
+        $allowedMimeTypes = ['image/png', 'image/jpeg', 'image/webp'];
+        $mimeType = mime_content_type($filename);
+
+        return in_array($mimeType, $allowedMimeTypes);
     }
 }


### PR DESCRIPTION
### Summary:
This pull request adds a new command to the pixelfed CLI that allows users to import emojis from a `.tar.gz`  archive. The command takes a file path as an argument and adds the emoji to the databaset.

### Description:
The new command is called `php artisan import:emoji` and it is added to the `pixelfed` CLI. To use the command, the user must provide a file path to a file containing the emojis they want to import.

The command first extracts the archive and then iterates over all files. All emojis are then added to the database.

### Signature
The signature of the command:
````
import:emojis
{path : Path to a tar.gz archive with the emojis}
{--prefix : Define a prefix for the emjoi shortcode}
{--suffix : Define a suffix for the emjoi shortcode}
{--overwrite : Overwrite existing emojis}
{--disabled : Import all emojis as disabled}
````

### Motivation
I find the Mastodon feature to import whole emoji archives very handy. Currently in Pixelfed you have to create each emoji individually with a lot of effort.