### PR TITLE
Make authentication views accessible

### DIFF
--- a/resources/views/auth/checkpoint.blade.php
+++ b/resources/views/auth/checkpoint.blade.php
@@ -19,7 +19,7 @@
                         <div class="form-group row">
 
                             <div class="col-md-12">
-                                <input id="code" type="text" class="form-control{{ $errors->has('code') ? ' is-invalid' : '' }}" name="code" placeholder="{{__('Two-Factor Authentication Code')}}" required autocomplete="off" autofocus="" inputmode="numeric" minlength="6">
+                                <input id="code" type="text" class="form-control{{ $errors->has('code') ? ' is-invalid' : '' }}" name="code" placeholder="{{__('Two-Factor Authentication Code')}}" required autocomplete="off" autofocus="" inputmode="numeric" minlength="6" aria-label="{{ __('Two-Factor Authentication Code') }}">
 
                                 @if ($errors->has('code'))
                                     <span class="invalid-feedback">

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -14,7 +14,17 @@
                         <div class="form-group row">
 
                             <div class="col-md-12">
-                                <input id="email" type="email" class="form-control{{ $errors->has('email') ? ' is-invalid' : '' }}" name="email" value="{{ old('email') }}" placeholder="{{__('Email')}}" required autofocus>
+                                <input
+                                    id="email"
+                                    type="email"
+                                    class="form-control{{ $errors->has('email') ? ' is-invalid' : '' }}"
+                                    name="email"
+                                    value="{{ old('email') }}"
+                                    placeholder="{{ __('Email') }}"
+                                    aria-label="{{ __('Email') }}"
+                                    required
+                                    autofocus
+                                >
 
                                 @if ($errors->has('email'))
                                     <span class="invalid-feedback">
@@ -27,7 +37,15 @@
                         <div class="form-group row">
 
                             <div class="col-md-12">
-                                <input id="password" type="password" class="form-control{{ $errors->has('password') ? ' is-invalid' : '' }}" name="password" placeholder="{{__('Password')}}" required>
+                                <input
+                                    id="password"
+                                    type="password"
+                                    class="form-control{{ $errors->has('password') ? ' is-invalid' : '' }}"
+                                    name="password"
+                                    placeholder="{{ __('Password') }}"
+                                    aria-label="{{ __('Password') }}"
+                                    required
+                                >
 
                                 @if ($errors->has('password'))
                                     <span class="invalid-feedback">
@@ -41,7 +59,7 @@
                             <div class="col-md-12">
                                 <div class="checkbox">
                                     <label>
-                                        <input type="checkbox" name="remember" {{ old('remember') ? 'checked' : '' }}> 
+                                        <input type="checkbox" name="remember" {{ old('remember') ? 'checked' : '' }}>
                                         <span class="font-weight-bold ml-1 text-muted">
                                             {{ __('Remember Me') }}
                                         </span>

--- a/resources/views/auth/passwords/email.blade.php
+++ b/resources/views/auth/passwords/email.blade.php
@@ -19,7 +19,16 @@
 
                         <div class="form-group row">
                             <div class="col-md-12">
-                                <input id="email" type="email" class="form-control" name="email" placeholder="{{ __('E-Mail Address') }}" value="{{ old('email') }}" required>
+                                <input
+                                    id="email"
+                                    type="email"
+                                    class="form-control"
+                                    name="email"
+                                    placeholder="{{ __('E-Mail Address') }}"
+                                    aria-label="{{ __('E-Mail Address') }}"
+                                    value="{{ old('email') }}"
+                                    required
+                                >
                             </div>
                         </div>
 

--- a/resources/views/auth/passwords/reset.blade.php
+++ b/resources/views/auth/passwords/reset.blade.php
@@ -15,7 +15,17 @@
 
                         <div class="form-group row">
                             <div class="col-md-12">
-                                <input id="email" type="email" class="form-control{{ $errors->has('email') ? ' is-invalid' : '' }}" name="email" value="{{ $email ?? old('email') }}" placeholder="{{ __('E-Mail Address') }}" required autofocus>
+                                <input
+                                    id="email"
+                                    type="email"
+                                    class="form-control{{ $errors->has('email') ? ' is-invalid' : '' }}"
+                                    name="email"
+                                    value="{{ $email ?? old('email') }}"
+                                    placeholder="{{ __('E-Mail Address') }}"
+                                    aria-label="{{ __('E-Mail Address') }}"
+                                    required
+                                    autofocus
+                                >
                                 @if ($errors->has('email'))
                                     <span class="invalid-feedback">
                                         <strong>{{ $errors->first('email') }}</strong>
@@ -26,7 +36,15 @@
                         <hr>
                         <div class="form-group row">
                             <div class="col-md-12">
-                                <input id="password" type="password" class="form-control{{ $errors->has('password') ? ' is-invalid' : '' }}" name="password" placeholder="{{ __('Password') }}" required>
+                                <input
+                                    id="password"
+                                    type="password"
+                                    class="form-control{{ $errors->has('password') ? ' is-invalid' : '' }}"
+                                    name="password"
+                                    placeholder="{{ __('Password') }}"
+                                    aria-label="{{ __('Password') }}"
+                                    required
+                                >
 
                                 @if ($errors->has('password'))
                                     <span class="invalid-feedback">
@@ -38,7 +56,15 @@
 
                         <div class="form-group row">
                             <div class="col-md-12">
-                                <input id="password-confirm" type="password" class="form-control{{ $errors->has('password_confirmation') ? ' is-invalid' : '' }}" name="password_confirmation" placeholder="{{ __('Confirm Password') }}" required>
+                                <input
+                                    id="password-confirm"
+                                    type="password"
+                                    class="form-control{{ $errors->has('password_confirmation') ? ' is-invalid' : '' }}"
+                                    name="password_confirmation"
+                                    placeholder="{{ __('Confirm Password') }}"
+                                    aria-label="{{ __('Confirm Password') }}"
+                                    required
+                                >
 
                                 @if ($errors->has('password_confirmation'))
                                     <span class="invalid-feedback">

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -14,7 +14,17 @@
                         <div class="form-group row">
                             <div class="col-md-12">
                                 <label class="small font-weight-bold text-lighter">Name</label>
-                                <input id="name" type="text" class="form-control{{ $errors->has('name') ? ' is-invalid' : '' }}" name="name" value="{{ old('name') }}" placeholder="{{ __('Name') }}" required autofocus>
+                                <input
+                                    id="name"
+                                    type="text"
+                                    class="form-control{{ $errors->has('name') ? ' is-invalid' : '' }}"
+                                    name="name"
+                                    value="{{ old('name') }}"
+                                    placeholder="{{ __('Name') }}"
+                                    aria-label="{{ __('Name') }}"
+                                    required
+                                    autofocus
+                                >
 
                                 @if ($errors->has('name'))
                                     <span class="invalid-feedback">
@@ -27,7 +37,16 @@
                         <div class="form-group row">
                             <div class="col-md-12">
                                 <label class="small font-weight-bold text-lighter">Username</label>
-                                <input id="username" type="text" class="form-control{{ $errors->has('username') ? ' is-invalid' : '' }}" name="username" value="{{ old('username') }}" placeholder="{{ __('Username') }}" required>
+                                <input
+                                    id="username"
+                                    type="text"
+                                    class="form-control{{ $errors->has('username') ? ' is-invalid' : '' }}"
+                                    name="username"
+                                    value="{{ old('username') }}"
+                                    placeholder="{{ __('Username') }}"
+                                    aria-label="{{ __('Username') }}"
+                                    required
+                                >
 
                                 @if ($errors->has('username'))
                                     <span class="invalid-feedback">
@@ -88,7 +107,7 @@
                         @endif
 
                         <p class="small">By signing up, you agree to our <a href="{{route('site.terms')}}" class="font-weight-bold text-dark">Terms of Use</a> and <a href="{{route('site.privacy')}}" class="font-weight-bold text-dark">Privacy Policy</a>.</p>
-                        
+
                         <div class="form-group row">
                             <div class="col-md-12">
                                 <button type="submit" class="btn btn-primary btn-block py-0 font-weight-bold">

--- a/resources/views/auth/sudo.blade.php
+++ b/resources/views/auth/sudo.blade.php
@@ -14,7 +14,15 @@
                         @csrf
 
                         <div class="form-group">
-                            <input id="password" type="password" class="form-control{{ $errors->has('password') ? ' is-invalid' : '' }}" name="password" placeholder="{{__('Password')}}" required>
+                            <input
+                                id="password"
+                                type="password"
+                                class="form-control{{ $errors->has('password') ? ' is-invalid' : '' }}"
+                                name="password"
+                                placeholder="{{ __('Password') }}"
+                                aria-label="{{ __('Password') }}"
+                                required
+                            >
 
                             @if ($errors->has('password'))
                                 <span class="invalid-feedback">
@@ -28,7 +36,7 @@
                               <input type="checkbox" class="custom-control-input" id="trusted-device" name="trustDevice">
                               <label class="custom-control-label text-muted" for="trusted-device">Trust this device and don't ask again</label>
                             </div>
-                        </div>  
+                        </div>
 
                         <div class="form-group row mb-0">
                             <div class="col-md-12">


### PR DESCRIPTION
The inputs on the authentication views didn't have proper labelling, making them almost unreadable for screen readers. This PR fixes that by adding [the `aria-label` attribute](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label) to all relevant input fields in the `auth` folder. 

I've also taken the liberty to increase the legibility of the code by putting every attribute on its own line for the input fields. It was getting kind of long 🙂 