### PR TITLE
Remove unnecessary empty constructors

### DIFF
--- a/app/Console/Commands/AvatarDefaultMigration.php
+++ b/app/Console/Commands/AvatarDefaultMigration.php
@@ -24,16 +24,6 @@ class AvatarDefaultMigration extends Command
     protected $description = 'Replace old svg identicon avatars with default png avatar';
 
     /**
-     * Create a new command instance.
-     *
-     * @return void
-     */
-    public function __construct()
-    {
-        parent::__construct();
-    }
-
-    /**
      * Execute the console command.
      *
      * @return mixed
@@ -53,9 +43,9 @@ class AvatarDefaultMigration extends Command
 
         Avatar::whereChangeCount(0)->chunk(50, function($avatars) use ($bar) {
             foreach($avatars as $avatar) {
-                if( $avatar->media_path == 'public/avatars/default.png' || 
+                if( $avatar->media_path == 'public/avatars/default.png' ||
                     $avatar->thumb_path == 'public/avatars/default.png' ||
-                    $avatar->media_path == 'public/avatars/default.jpg' || 
+                    $avatar->media_path == 'public/avatars/default.jpg' ||
                     $avatar->thumb_path == 'public/avatars/default.jpg'
                 ) {
                     continue;
@@ -65,7 +55,7 @@ class AvatarDefaultMigration extends Command
                     // do not modify non-default avatars
                     continue;
                 }
-                
+
                 DB::transaction(function() use ($avatar, $bar) {
 
                     if(is_file(storage_path('app/' . $avatar->media_path))) {

--- a/app/Console/Commands/AvatarSync.php
+++ b/app/Console/Commands/AvatarSync.php
@@ -31,16 +31,6 @@ class AvatarSync extends Command
 	public $fixed = 0;
 
 	/**
-	 * Create a new command instance.
-	 *
-	 * @return void
-	 */
-	public function __construct()
-	{
-	    parent::__construct();
-	}
-
-	/**
 	 * Execute the console command.
 	 *
 	 * @return int

--- a/app/Console/Commands/BackupToCloud.php
+++ b/app/Console/Commands/BackupToCloud.php
@@ -24,16 +24,6 @@ class BackupToCloud extends Command
     protected $description = 'Send backups to cloud storage';
 
     /**
-     * Create a new command instance.
-     *
-     * @return void
-     */
-    public function __construct()
-    {
-        parent::__construct();
-    }
-
-    /**
      * Execute the console command.
      *
      * @return int

--- a/app/Console/Commands/BannedEmailCheck.php
+++ b/app/Console/Commands/BannedEmailCheck.php
@@ -23,16 +23,6 @@ class BannedEmailCheck extends Command
     protected $description = 'Checks user emails for banned domains';
 
     /**
-     * Create a new command instance.
-     *
-     * @return void
-     */
-    public function __construct()
-    {
-        parent::__construct();
-    }
-
-    /**
      * Execute the console command.
      *
      * @return mixed

--- a/app/Console/Commands/CatchUnoptimizedMedia.php
+++ b/app/Console/Commands/CatchUnoptimizedMedia.php
@@ -24,16 +24,6 @@ class CatchUnoptimizedMedia extends Command
     protected $description = 'Find and optimize media that has not yet been optimized.';
 
     /**
-     * Create a new command instance.
-     *
-     * @return void
-     */
-    public function __construct(Media $media)
-    {
-        parent::__construct();
-    }
-
-    /**
      * Execute the console command.
      *
      * @return mixed

--- a/app/Console/Commands/DatabaseSessionGarbageCollector.php
+++ b/app/Console/Commands/DatabaseSessionGarbageCollector.php
@@ -22,16 +22,6 @@ class DatabaseSessionGarbageCollector extends Command
     protected $description = 'Database sessions garbage collector';
 
     /**
-     * Create a new command instance.
-     *
-     * @return void
-     */
-    public function __construct()
-    {
-        parent::__construct();
-    }
-
-    /**
      * Execute the console command.
      *
      * @return int

--- a/app/Console/Commands/ExportLanguages.php
+++ b/app/Console/Commands/ExportLanguages.php
@@ -21,16 +21,6 @@ class ExportLanguages extends Command
     protected $description = 'Build and export js localization files.';
 
     /**
-     * Create a new command instance.
-     *
-     * @return void
-     */
-    public function __construct()
-    {
-    	parent::__construct();
-    }
-
-    /**
      * Execute the console command.
      *
      * @return int

--- a/app/Console/Commands/FailedJobGC.php
+++ b/app/Console/Commands/FailedJobGC.php
@@ -22,16 +22,6 @@ class FailedJobGC extends Command
     protected $description = 'Delete failed jobs over 1 month old';
 
     /**
-     * Create a new command instance.
-     *
-     * @return void
-     */
-    public function __construct()
-    {
-        parent::__construct();
-    }
-
-    /**
      * Execute the console command.
      *
      * @return mixed

--- a/app/Console/Commands/FixDuplicateProfiles.php
+++ b/app/Console/Commands/FixDuplicateProfiles.php
@@ -29,16 +29,6 @@ class FixDuplicateProfiles extends Command
     protected $description = 'Fix duplicate profiles';
 
     /**
-     * Create a new command instance.
-     *
-     * @return void
-     */
-    public function __construct()
-    {
-        parent::__construct();
-    }
-
-    /**
      * Execute the console command.
      *
      * @return mixed
@@ -59,9 +49,9 @@ class FixDuplicateProfiles extends Command
             $dup = Profile::whereUserId($profile->user_id)->get();
 
             if(
-                $dup->first()->username === $dup->last()->username && 
-                $dup->last()->statuses()->count() == 0 && 
-                $dup->last()->followers()->count() == 0 && 
+                $dup->first()->username === $dup->last()->username &&
+                $dup->last()->statuses()->count() == 0 &&
+                $dup->last()->followers()->count() == 0 &&
                 $dup->last()->likes()->count() == 0 &&
                 $dup->last()->media()->count() == 0
             ) {

--- a/app/Console/Commands/FixHashtags.php
+++ b/app/Console/Commands/FixHashtags.php
@@ -27,16 +27,6 @@ class FixHashtags extends Command
     protected $description = 'Fix Hashtags';
 
     /**
-     * Create a new command instance.
-     *
-     * @return void
-     */
-    public function __construct()
-    {
-        parent::__construct();
-    }
-
-    /**
      * Execute the console command.
      *
      * @return mixed
@@ -72,7 +62,7 @@ class FixHashtags extends Command
             $this->info(' ');
             $this->info('Found no orphaned hashtags to delete!');
         }
-        
+
 
         $this->info(' ');
 

--- a/app/Console/Commands/FixLikes.php
+++ b/app/Console/Commands/FixLikes.php
@@ -23,16 +23,6 @@ class FixLikes extends Command
     protected $description = 'Fix Like counts';
 
     /**
-     * Create a new command instance.
-     *
-     * @return void
-     */
-    public function __construct()
-    {
-        parent::__construct();
-    }
-
-    /**
      * Execute the console command.
      *
      * @return mixed
@@ -41,7 +31,7 @@ class FixLikes extends Command
     {
         $chunk = 100;
         $limit = Like::select('status_id')->groupBy('status_id')->get()->count();
-        
+
         if($limit > 1000) {
             if($this->confirm('We have found more than 1000 records to update, this may take a few moments. Are you sure you want to continue?') == false) {
                 $this->error('Cancelling command...');

--- a/app/Console/Commands/FixRemotePostCount.php
+++ b/app/Console/Commands/FixRemotePostCount.php
@@ -23,16 +23,6 @@ class FixRemotePostCount extends Command
     protected $description = 'Fix remote accounts post count';
 
     /**
-     * Create a new command instance.
-     *
-     * @return void
-     */
-    public function __construct()
-    {
-        parent::__construct();
-    }
-
-    /**
      * Execute the console command.
      *
      * @return int

--- a/app/Console/Commands/FixStatusCount.php
+++ b/app/Console/Commands/FixStatusCount.php
@@ -22,16 +22,6 @@ class FixStatusCount extends Command
     protected $description = 'fix profile status count';
 
     /**
-     * Create a new command instance.
-     *
-     * @return void
-     */
-    public function __construct()
-    {
-        parent::__construct();
-    }
-
-    /**
      * Execute the console command.
      *
      * @return int

--- a/app/Console/Commands/FixUsernames.php
+++ b/app/Console/Commands/FixUsernames.php
@@ -24,16 +24,6 @@ class FixUsernames extends Command
     protected $description = 'Fix invalid usernames';
 
     /**
-     * Create a new command instance.
-     *
-     * @return void
-     */
-    public function __construct()
-    {
-        parent::__construct();
-    }
-
-    /**
      * Execute the console command.
      *
      * @return mixed
@@ -67,7 +57,7 @@ class FixUsernames extends Command
                 }
             }
         });
-        
+
         if($affected->count() > 0) {
             $this->info('Found: ' . $affected->count() . ' affected usernames');
 
@@ -105,7 +95,7 @@ class FixUsernames extends Command
                     case $opts[3]:
                         $new = false;
                         break;
-                    
+
                     default:
                         $new = "user_" . str_random(6);
                         break;

--- a/app/Console/Commands/GenerateInstanceActor.php
+++ b/app/Console/Commands/GenerateInstanceActor.php
@@ -13,11 +13,6 @@ class GenerateInstanceActor extends Command
 	protected $signature = 'instance:actor';
 	protected $description = 'Generate instance actor';
 
-	public function __construct()
-	{
-		parent::__construct();
-	}
-
 	public function handle()
 	{
 		if(Schema::hasTable('instance_actors') == false) {

--- a/app/Console/Commands/ImportCities.php
+++ b/app/Console/Commands/ImportCities.php
@@ -58,16 +58,6 @@ class ImportCities extends Command
     ];
 
     /**
-     * Create a new command instance.
-     *
-     * @return void
-     */
-    public function __construct()
-    {
-        parent::__construct();
-    }
-
-    /**
      * Execute the console command.
      *
      * @return mixed
@@ -103,19 +93,19 @@ class ImportCities extends Command
         $this->line('');
         $this->info("Found {$cityCount} cities to insert ...");
         $this->line('');
-        
+
         $bar = $this->output->createProgressBar($cityCount);
         $bar->start();
-        
+
         $buffer = [];
         $count = 0;
-        
+
         foreach ($cities as $city) {
             $buffer[] = [
-                "name" => $city->name, 
-                "slug" => Str::slug($city->name), 
-                "country" => $this->codeToCountry($city->country), 
-                "lat" => $city->lat, 
+                "name" => $city->name,
+                "slug" => Str::slug($city->name),
+                "country" => $this->codeToCountry($city->country),
+                "lat" => $city->lat,
                 "long" => $city->lng
             ];
 

--- a/app/Console/Commands/Installer.php
+++ b/app/Console/Commands/Installer.php
@@ -25,16 +25,6 @@ class Installer extends Command
     public $installType = 'Simple';
 
     /**
-     * Create a new command instance.
-     *
-     * @return void
-     */
-    public function __construct()
-    {
-        parent::__construct();
-    }
-
-    /**
      * Execute the console command.
      *
      * @return mixed

--- a/app/Console/Commands/MediaFix.php
+++ b/app/Console/Commands/MediaFix.php
@@ -23,16 +23,6 @@ class MediaFix extends Command
     protected $description = 'Fix media on v0.10.8+';
 
     /**
-     * Create a new command instance.
-     *
-     * @return void
-     */
-    public function __construct()
-    {
-        parent::__construct();
-    }
-
-    /**
      * Execute the console command.
      *
      * @return mixed

--- a/app/Console/Commands/MediaGarbageCollector.php
+++ b/app/Console/Commands/MediaGarbageCollector.php
@@ -23,16 +23,6 @@ class MediaGarbageCollector extends Command
 	protected $description = 'Delete media uploads not attached to any active statuses';
 
 	/**
-	 * Create a new command instance.
-	 *
-	 * @return void
-	 */
-	public function __construct()
-	{
-		parent::__construct();
-	}
-
-	/**
 	 * Execute the console command.
 	 *
 	 * @return mixed

--- a/app/Console/Commands/MediaS3GarbageCollector.php
+++ b/app/Console/Commands/MediaS3GarbageCollector.php
@@ -29,16 +29,6 @@ class MediaS3GarbageCollector extends Command
     protected $description = 'Delete (local) media uploads that exist on S3';
 
     /**
-    * Create a new command instance.
-    *
-    * @return void
-    */
-    public function __construct()
-    {
-        parent::__construct();
-    }
-
-    /**
     * Execute the console command.
     *
     * @return int

--- a/app/Console/Commands/PasswordResetGC.php
+++ b/app/Console/Commands/PasswordResetGC.php
@@ -22,16 +22,6 @@ class PasswordResetGC extends Command
     protected $description = 'Delete password reset tokens over 24 hours old';
 
     /**
-     * Create a new command instance.
-     *
-     * @return void
-     */
-    public function __construct()
-    {
-        parent::__construct();
-    }
-
-    /**
      * Execute the console command.
      *
      * @return mixed

--- a/app/Console/Commands/RegenerateThumbnails.php
+++ b/app/Console/Commands/RegenerateThumbnails.php
@@ -23,16 +23,6 @@ class RegenerateThumbnails extends Command
     protected $description = 'Regenerate thumbnails';
 
     /**
-     * Create a new command instance.
-     *
-     * @return void
-     */
-    public function __construct()
-    {
-        parent::__construct();
-    }
-
-    /**
      * Execute the console command.
      *
      * @return mixed

--- a/app/Console/Commands/SeedFollows.php
+++ b/app/Console/Commands/SeedFollows.php
@@ -24,16 +24,6 @@ class SeedFollows extends Command
     protected $description = 'Seed follows for testing';
 
     /**
-     * Create a new command instance.
-     *
-     * @return void
-     */
-    public function __construct()
-    {
-        parent::__construct();
-    }
-
-    /**
      * Execute the console command.
      *
      * @return mixed

--- a/app/Console/Commands/StatusDedupe.php
+++ b/app/Console/Commands/StatusDedupe.php
@@ -24,16 +24,6 @@ class StatusDedupe extends Command
     protected $description = 'Removes duplicate statuses from before unique uri migration';
 
     /**
-     * Create a new command instance.
-     *
-     * @return void
-     */
-    public function __construct()
-    {
-        parent::__construct();
-    }
-
-    /**
      * Execute the console command.
      *
      * @return mixed

--- a/app/Console/Commands/StoryGC.php
+++ b/app/Console/Commands/StoryGC.php
@@ -27,16 +27,6 @@ class StoryGC extends Command
 	protected $description = 'Clear expired Stories';
 
 	/**
-	* Create a new command instance.
-	*
-	* @return void
-	*/
-	public function __construct()
-	{
-		parent::__construct();
-	}
-
-	/**
 	* Execute the console command.
 	*
 	* @return mixed

--- a/app/Console/Commands/UpdateCommand.php
+++ b/app/Console/Commands/UpdateCommand.php
@@ -23,16 +23,6 @@ class UpdateCommand extends Command
     protected $description = 'Run pixelfed schema updates between versions.';
 
     /**
-     * Create a new command instance.
-     *
-     * @return void
-     */
-    public function __construct()
-    {
-        parent::__construct();
-    }
-
-    /**
      * Execute the console command.
      *
      * @return mixed
@@ -68,7 +58,7 @@ class UpdateCommand extends Command
     protected function getVersionFile()
     {
         $path = storage_path('app/version.json');
-        return is_file($path) ? 
+        return is_file($path) ?
             json_decode(file_get_contents($path), true) :
             false;
     }

--- a/app/Console/Commands/UserAdmin.php
+++ b/app/Console/Commands/UserAdmin.php
@@ -22,16 +22,6 @@ class UserAdmin extends Command
     protected $description = 'Make a user an admin, or remove admin privileges.';
 
     /**
-     * Create a new command instance.
-     *
-     * @return void
-     */
-    public function __construct()
-    {
-        parent::__construct();
-    }
-
-    /**
      * Execute the console command.
      *
      * @return mixed

--- a/app/Console/Commands/UserCreate.php
+++ b/app/Console/Commands/UserCreate.php
@@ -22,16 +22,6 @@ class UserCreate extends Command
     protected $description = 'Create a new user';
 
     /**
-     * Create a new command instance.
-     *
-     * @return void
-     */
-    public function __construct()
-    {
-        parent::__construct();
-    }
-
-    /**
      * Execute the console command.
      *
      * @return mixed
@@ -83,19 +73,19 @@ class UserCreate extends Command
             $this->error('Password mismatch, please try again...');
             exit;
         }
-        
+
         if (strlen($password) < 6) {
             $this->error('Must be 6 or more characters, please try again...');
             exit;
         }
-        
+
         $is_admin = $this->confirm('Make this user an admin?');
         $confirm_email = $this->confirm('Manually verify email address?');
 
-        if($this->confirm('Are you sure you want to create this user?') && 
+        if($this->confirm('Are you sure you want to create this user?') &&
             $username &&
-            $name && 
-            $email && 
+            $name &&
+            $email &&
             $password
         ) {
             $user = new User;

--- a/app/Console/Commands/UserDelete.php
+++ b/app/Console/Commands/UserDelete.php
@@ -23,16 +23,6 @@ class UserDelete extends Command
     protected $description = 'Delete account';
 
     /**
-     * Create a new command instance.
-     *
-     * @return void
-     */
-    public function __construct()
-    {
-        parent::__construct();
-    }
-
-    /**
      * Execute the console command.
      *
      * @return mixed

--- a/app/Console/Commands/UserShow.php
+++ b/app/Console/Commands/UserShow.php
@@ -22,16 +22,6 @@ class UserShow extends Command
     protected $description = 'Show user info';
 
     /**
-     * Create a new command instance.
-     *
-     * @return void
-     */
-    public function __construct()
-    {
-        parent::__construct();
-    }
-
-    /**
      * Execute the console command.
      *
      * @return mixed

--- a/app/Console/Commands/UserSuspend.php
+++ b/app/Console/Commands/UserSuspend.php
@@ -22,16 +22,6 @@ class UserSuspend extends Command
     protected $description = 'Suspend a local user.';
 
     /**
-     * Create a new command instance.
-     *
-     * @return void
-     */
-    public function __construct()
-    {
-        parent::__construct();
-    }
-
-    /**
      * Execute the console command.
      *
      * @return mixed

--- a/app/Console/Commands/UserTable.php
+++ b/app/Console/Commands/UserTable.php
@@ -22,16 +22,6 @@ class UserTable extends Command
     protected $description = 'Display latest users';
 
     /**
-     * Create a new command instance.
-     *
-     * @return void
-     */
-    public function __construct()
-    {
-        parent::__construct();
-    }
-
-    /**
      * Execute the console command.
      *
      * @return mixed

--- a/app/Console/Commands/UserUnsuspend.php
+++ b/app/Console/Commands/UserUnsuspend.php
@@ -22,16 +22,6 @@ class UserUnsuspend extends Command
     protected $description = 'Unsuspend a local user.';
 
     /**
-     * Create a new command instance.
-     *
-     * @return void
-     */
-    public function __construct()
-    {
-        parent::__construct();
-    }
-
-    /**
      * Execute the console command.
      *
      * @return mixed

--- a/app/Console/Commands/UserVerifyEmail.php
+++ b/app/Console/Commands/UserVerifyEmail.php
@@ -23,16 +23,6 @@ class UserVerifyEmail extends Command
     protected $description = 'Verify user email address';
 
     /**
-     * Create a new command instance.
-     *
-     * @return void
-     */
-    public function __construct()
-    {
-        parent::__construct();
-    }
-
-    /**
      * Execute the console command.
      *
      * @return mixed

--- a/app/Console/Commands/VideoThumbnail.php
+++ b/app/Console/Commands/VideoThumbnail.php
@@ -5,7 +5,7 @@ namespace App\Console\Commands;
 use Illuminate\Console\Command;
 
 use App\Media;
-use App\Jobs\VideoPipeline\VideoThumbnail as Pipeline; 
+use App\Jobs\VideoPipeline\VideoThumbnail as Pipeline;
 
 class VideoThumbnail extends Command
 {
@@ -22,16 +22,6 @@ class VideoThumbnail extends Command
      * @var string
      */
     protected $description = 'Generate missing video thumbnails';
-
-    /**
-     * Create a new command instance.
-     *
-     * @return void
-     */
-    public function __construct()
-    {
-        parent::__construct();
-    }
 
     /**
      * Execute the console command.


### PR DESCRIPTION
We can remove constructors that _only_ contain `parent::__construct();` since these will fall back to their parent class automatically. This cleans up the code and makes it easier to read when first opening the file(s).