### PR TITLE
Allow email delivery using Google Workspace SMTP Relay by fixing EHLO authentication.

### DIFF
--- a/config/mail.php
+++ b/config/mail.php
@@ -85,8 +85,21 @@ return [
     */
 
     'username' => env('MAIL_USERNAME'),
-
     'password' => env('MAIL_PASSWORD'),
+    
+    
+    /*
+    |--------------------------------------------------------------------------
+    | SMTP EHLO Domain
+    |--------------------------------------------------------------------------
+    |
+    | Some SMTP servers require to present a known domain in order to 
+    | allow sending through its relay. (ie: Google Workspace)
+    | This will use the MAIL_SMTP_EHLO env variable to avoid the 421 error
+    | if not present by authenticating the sender domain instead the host.
+    |
+    */
+    'local_domain' => ENV('MAIL_SMTP_EHLO'),
 
     /*
     |--------------------------------------------------------------------------

--- a/config/mail.php
+++ b/config/mail.php
@@ -99,7 +99,7 @@ return [
     | if not present by authenticating the sender domain instead the host.
     |
     */
-    'local_domain' => ENV('MAIL_SMTP_EHLO'),
+    'local_domain' => env('MAIL_SMTP_EHLO'),
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
Adding compatibility with Google Workspaces SMTP Relay. 
More info can be found here: https://support.google.com/a/answer/2956491

![imagen](https://user-images.githubusercontent.com/86560527/209797758-1093fb39-2712-49dd-84fe-a97c8163740f.png)

These changes add a new optional environment variable:
`MAIL_SMTP_EHLO="yourdomain.com"`
Which will replace the EHLO domain by "yourdomain.com" if the remote SMTP server needs some special authentication through EHLO (such as Google Workspace SMTP Relay), in the Laravel/Symfony mailer.

More info regarding this can be found here:
https://blog.trippyboy.com/2021/laravel/laravel-expected-response-code-250-but-got-an-empty-response/