### PR TITLE
Add media:content to atom feed

### DIFF
--- a/resources/views/atom/user.blade.php
+++ b/resources/views/atom/user.blade.php
@@ -3,30 +3,34 @@
 	'<?xml version="1.0" encoding="UTF-8"?>'.PHP_EOL
 ?>
 <feed xmlns="http://www.w3.org/2005/Atom" xmlns:media="http://search.yahoo.com/mrss/">
-  <id>{{$permalink}}</id>
-  <title>{{$profile['username']}} on Pixelfed</title>
-  <subtitle type="html">{{$profile['note']}}</subtitle>
-  <updated>{{$profile['created_at']}}</updated>
-  <author>
-	<uri>{{$profile['url']}}</uri>
-	<name>{{$profile['url']}}</name>
-  </author>
-  <link rel="alternate" type="text/html" href="{{$profile['url']}}"/>
-  <link rel="self" type="application/atom+xml" href="{{$permalink}}"/>
-@foreach($items as $item)       <entry>
-                <title>{{ $item['content'] ? strip_tags($item['content']) : "No caption" }}</title>
-		<link rel="alternate" href="{{ $item['url'] }}" />
+	<id>{{$permalink}}</id>
+	<title>{{$profile['username']}} on Pixelfed</title>
+	<subtitle type="html">{{$profile['note']}}</subtitle>
+	<updated>{{$items[0]['created_at']}</updated>
+	<author>
+		<name>{{$profile['username']}}</name>
+		<uri>{{$profile['url']}}</uri>
+	</author>
+	<link rel="alternate" type="text/html" href="{{$profile['url']}}"/>
+	<link rel="self" type="application/atom+xml" href="{{$permalink}}"/>
+@foreach($items as $item)
+	<entry>
 		<id>{{ $item['url'] }}</id>
+		<title>{{ $item['content_text'] ? $item['content_text'] : "No caption" }}</title>
+		<updated>{{ $item['created_at'] }}</updated>
 		<author>
-			<name> <![CDATA[{{ $profile['username'] }}]]></name>
+			<name>{{$profile['username']}}</name>
+			<uri>{{$profile['url']}}</uri>
 		</author>
-		<summary type="html">
+		<content type="html">
 		<![CDATA[
 			<img id="rss_item_{{$loop->iteration}}" src="{{ $item['media_attachments'][0]['url'] }}" alt="{{ $item['media_attachments'][0]['description'] }}">
 			<p style="padding:10px;">{{ $item['content'] }}</p>
-		  ]]>
-		</summary>
-		<updated>{{ $item['created_at'] }}</updated>
+		]]>
+		</content>
+		<link rel="alternate" href="{{ $item['url'] }}" />
+		<summary>{{ $item['content'] }}</summary>
+		<media:content url="{{ $item['media_attachments'][0]['url'] }}" type="image/png" medium="image">
 	</entry>
 @endforeach
 </feed>

--- a/resources/views/atom/user.blade.php
+++ b/resources/views/atom/user.blade.php
@@ -1,19 +1,19 @@
 <?=
-	/* Using an echo tag here so the `<? ... ?>` won't get parsed as short tags */
-	'<?xml version="1.0" encoding="UTF-8"?>'.PHP_EOL
+/* Using an echo tag here so the `<? ... ?>` won't get parsed as short tags */
+'<?xml version="1.0" encoding="UTF-8"?>' . PHP_EOL
 ?>
 <feed xmlns="http://www.w3.org/2005/Atom" xmlns:media="http://search.yahoo.com/mrss/">
 	<id>{{$permalink}}</id>
 	<title>{{$profile['username']}} on Pixelfed</title>
 	<subtitle type="html">{{$profile['note']}}</subtitle>
-	<updated>{{$items[0]['created_at']}</updated>
+	<updated>{{$items[0]['created_at']}}</updated>
 	<author>
 		<name>{{$profile['username']}}</name>
 		<uri>{{$profile['url']}}</uri>
 	</author>
-	<link rel="alternate" type="text/html" href="{{$profile['url']}}"/>
-	<link rel="self" type="application/atom+xml" href="{{$permalink}}"/>
-@foreach($items as $item)
+	<link rel="alternate" type="text/html" href="{{$profile['url']}}" />
+	<link rel="self" type="application/atom+xml" href="{{$permalink}}" />
+	@foreach($items as $item)
 	<entry>
 		<id>{{ $item['url'] }}</id>
 		<title>{{ $item['content_text'] ? $item['content_text'] : "No caption" }}</title>
@@ -23,14 +23,14 @@
 			<uri>{{$profile['url']}}</uri>
 		</author>
 		<content type="html">
-		<![CDATA[
+			<![CDATA[
 			<img id="rss_item_{{$loop->iteration}}" src="{{ $item['media_attachments'][0]['url'] }}" alt="{{ $item['media_attachments'][0]['description'] }}">
 			<p style="padding:10px;">{{ $item['content'] }}</p>
-		]]>
+			]]>
 		</content>
 		<link rel="alternate" href="{{ $item['url'] }}" />
-		<summary>{{ $item['content'] }}</summary>
+		<summary type="html">{{ $item['content'] }}</summary>
 		<media:content url="{{ $item['media_attachments'][0]['url'] }}" type="image/png" medium="image">
 	</entry>
-@endforeach
+	@endforeach
 </feed>

--- a/resources/views/atom/user.blade.php
+++ b/resources/views/atom/user.blade.php
@@ -30,7 +30,7 @@
 		</content>
 		<link rel="alternate" href="{{ $item['url'] }}" />
 		<summary type="html">{{ $item['content'] }}</summary>
-		<media:content url="{{ $item['media_attachments'][0]['url'] }}" type="image/png" medium="image">
+		<media:content url="{{ $item['media_attachments'][0]['url'] }}" type="image/png" medium="image" />
 	</entry>
 	@endforeach
 </feed>


### PR DESCRIPTION
I tried using my atom feed, but was missing the option to extract the image URL. So I've added `media:content` as described [here](https://www.rssboard.org/media-rss#media-content), and cleaned the code up a bit (tabs instead of spaces, alignment, that sort of thing).

I don't have a dev environment running at the moment, so cannot verify the feed myself. If you can, great, otherwise I'll get that set up this weekend.