### PR TITLE
Fix Contactform UX and validation (fixes #2239 and #2240)

### DIFF
--- a/app/Http/Controllers/ContactController.php
+++ b/app/Http/Controllers/ContactController.php
@@ -6,6 +6,7 @@ use Illuminate\Http\Request;
 use Auth;
 use App\Contact;
 use App\Jobs\ContactPipeline\ContactPipeline;
+use App\Rules\MaxMultiLine;
 
 class ContactController extends Controller
 {
@@ -21,7 +22,7 @@ class ContactController extends Controller
 		abort_if(!Auth::check(), 403);
 
 		$this->validate($request, [
-			'message' => 'required|string|min:5|max:500',
+			'message' => ['required', 'string', 'min:5', new MaxMultiLine('500')],
 			'request_response' => 'string|max:3'
 		]);
 

--- a/app/Rules/MaxMultiLine.php
+++ b/app/Rules/MaxMultiLine.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Rules;
+
+use Illuminate\Support\Str;
+use Illuminate\Contracts\Validation\InvokableRule;
+
+class MaxMultiLine implements InvokableRule
+{
+    private $maxCharacters;
+
+    public function __construct($maxCharacters)
+    {
+        $this->maxCharacters = $maxCharacters;
+    }
+
+    /**
+     * Run the validation rule.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  \Closure(string): \Illuminate\Translation\PotentiallyTranslatedString  $fail
+     * @return void
+     */
+    public function __invoke($attribute, $value, $fail)
+    {
+        $realCount = Str::length($value) - Str::substrCount($value, "\r\n");
+
+        if($realCount > $this->maxCharacters)
+        {
+            $fail('validation.max.string')->translate(['max' => $this->maxCharacters]);
+        }
+    }
+}

--- a/resources/views/site/contact.blade.php
+++ b/resources/views/site/contact.blade.php
@@ -24,7 +24,7 @@
       @csrf
   		<div class="form-group">
   			<label for="input1" class="font-weight-bold">Message</label>
-  			<textarea class="form-control" id="input1" name="message" rows="6" placeholder=""></textarea>
+  			<textarea class="form-control" id="input1" name="message" rows="6" placeholder="" maxlength="500" required>{{old('message')}}</textarea>
   			<span class="form-text text-muted text-right msg-counter">0/500</span>
   		</div>
 		<div class="form-group form-check">


### PR DESCRIPTION
This PR improves the UX on the contact page:
- if an error occurs the old user input is now showing in de form (fix #2239)
- added the maxlength and required attributes to the textarea

And fixes #2240 by creating a custom validation rule which counts the double new line characters ``\r\n`` as one.