### PR TITLE
Add error logging for migrating to cloud storage failures

### DIFF
--- a/app/Console/Commands/CloudMediaMigrate.php
+++ b/app/Console/Commands/CloudMediaMigrate.php
@@ -66,10 +66,13 @@ class CloudMediaMigrate extends Command
                     try {
                         MediaStorageService::store($media);
                     } catch (FileNotFoundException $e) {
+                        $this->error('Error migrating media ' . $media->id . ' to cloud storage: ' . $e->getMessage());
                         return;
                     } catch (NotFoundHttpException $e) {
+                        $this->error('Error migrating media ' . $media->id . ' to cloud storage: ' . $e->getMessage());
                         return;
                     } catch (\Exception $e) {
+                        $this->error('Error migrating media ' . $media->id . ' to cloud storage: ' . $e->getMessage());
                         return;
                     }
                 }


### PR DESCRIPTION
Adding this logging enabled me to find out that I needed to enable ACL support on the S3 bucket to fix migrations.