### PR TITLE
Suggested weight optimization for the SVG logo

### DIFF
--- a/public/img/pixelfed-icon-color.svg
+++ b/public/img/pixelfed-icon-color.svg
@@ -1,101 +1,88 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg width="50px" height="50px" viewBox="0 0 50 50" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <!-- Generator: Sketch 51.3 (57544) - http://www.bohemiancoding.com/sketch -->
-    <title>icon/color/svg/pixelfed-icon-color</title>
-    <desc>Created with Sketch.</desc>
-    <defs>
-        <rect id="path-1" x="0" y="0.112107623" width="50" height="49.7757848"></rect>
-        <linearGradient x1="100%" y1="55.8067876%" x2="0%" y2="60.1177402%" id="linearGradient-3">
-            <stop stop-color="#FF5C34" offset="0%"></stop>
-            <stop stop-color="#EB0256" offset="100%"></stop>
-        </linearGradient>
-        <linearGradient x1="33.0892153%" y1="100%" x2="68.9900955%" y2="15.3101693%" id="linearGradient-4">
-            <stop stop-color="#A63FDB" offset="0%"></stop>
-            <stop stop-color="#FF257E" offset="100%"></stop>
-        </linearGradient>
-        <linearGradient x1="14.7223019%" y1="50%" x2="94.315299%" y2="67.5256558%" id="linearGradient-5">
-            <stop stop-color="#00FFF0" offset="0%"></stop>
-            <stop stop-color="#0087FF" offset="100%"></stop>
-        </linearGradient>
-        <linearGradient x1="81.2260936%" y1="10.0128769%" x2="20.8151903%" y2="74.4920673%" id="linearGradient-6">
-            <stop stop-color="#17C934" offset="0%"></stop>
-            <stop stop-color="#03FF6E" offset="100%"></stop>
-        </linearGradient>
-        <linearGradient x1="50%" y1="111.913008%" x2="30.5601577%" y2="0%" id="linearGradient-7">
-            <stop stop-color="#FFB000" offset="0%"></stop>
-            <stop stop-color="#FF7725" offset="100%"></stop>
-        </linearGradient>
-        <path d="M25.8796198,24.6636771 C25.5187511,17.8623246 19.644178,12.6376937 12.7583935,12.9941375 C5.87260905,13.3505813 0.583119676,19.1531217 0.94398835,25.9544743 L0.954359402,26.1499392 C0.924772259,25.6582574 0.909768036,25.162698 0.909768036,24.6636771 C0.909768036,14.5077362 7.12441451,5.78550566 16.0023658,2.00478143 L16.5257487,1.7959139 C22.9188985,-0.755414121 30.1955057,2.29544903 32.7785059,8.61020748 C35.3615061,14.9249659 32.2727696,22.1123491 25.8796198,24.6636771 Z" id="path-8"></path>
-        <path d="M16.3387661,1.87053346 L16.5257487,1.7959139 C22.9188985,-0.755414121 30.1955057,2.29544903 32.7785059,8.61020748 C35.3615061,14.9249659 32.2727696,22.1123491 25.8796198,24.6636771 C25.8261894,23.6566658 25.6518881,22.6842191 25.3713301,21.7593344 C28.8012958,19.9026454 31.1268503,16.3032843 31.1268503,12.167421 C31.1268503,6.13067623 26.1723508,1.23692769 20.060666,1.23692769 C18.7548626,1.23692769 17.5018839,1.46032366 16.3387661,1.87053346 Z" id="path-9"></path>
-        <linearGradient x1="-81.3646199%" y1="59.6233723%" x2="121.418067%" y2="72.057922%" id="linearGradient-10">
-            <stop stop-color="#9EE85D" offset="0%"></stop>
-            <stop stop-color="#0ED061" offset="100%"></stop>
-        </linearGradient>
-        <path d="M28.3794511,9.27014825 L28.5664337,9.1955287 C34.9595835,6.64420067 42.2361907,9.69506383 44.8191909,16.0098223 C47.4021911,22.3245807 44.3134546,29.5119639 37.9203048,32.0632919 C37.8668744,31.0562806 37.6925731,30.0838339 37.4120151,29.1589492 C40.8419808,27.3022602 43.1675353,23.7028991 43.1675353,19.5670358 C43.1675353,13.530291 38.2130358,8.63654249 32.101351,8.63654249 C30.7955476,8.63654249 29.5425689,8.85993845 28.3794511,9.27014825 Z" id="path-11"></path>
-        <linearGradient x1="45.510285%" y1="116.818646%" x2="0%" y2="-4.0376427%" id="linearGradient-12">
-            <stop stop-color="#21EFE3" offset="0%"></stop>
-            <stop stop-color="#2598FF" offset="100%"></stop>
-        </linearGradient>
-        <path d="M25.1352415,22.7323503 L25.3222242,22.6577307 C31.7153739,20.1064027 38.9919812,23.1572658 41.5749814,29.4720243 C44.1579816,35.7867827 41.069245,42.9741659 34.6760953,45.5254939 C34.6226649,44.5184826 34.4483636,43.5460359 34.1678055,42.6211512 C37.5977712,40.7644622 39.9233257,37.1651011 39.9233257,33.0292378 C39.9233257,26.992493 34.9688263,22.0987445 28.8571415,22.0987445 C27.5513381,22.0987445 26.2983594,22.3221405 25.1352415,22.7323503 Z" id="path-13"></path>
-        <linearGradient x1="100%" y1="58.2065614%" x2="-89.649052%" y2="74.3165445%" id="linearGradient-14">
-            <stop stop-color="#A63FDB" offset="0%"></stop>
-            <stop stop-color="#FF257E" offset="100%"></stop>
-        </linearGradient>
-        <path d="M10.6540931,23.7648224 L10.8410757,23.6902028 C17.2342255,21.1388748 24.5108328,24.1897379 27.093833,30.5044964 C29.6768331,36.8192548 26.5880966,44.006638 20.1949468,46.557966 C20.1415164,45.5509547 19.9672152,44.578508 19.6866571,43.6536233 C23.1166228,41.7969343 25.4421773,38.1975732 25.4421773,34.0617099 C25.4421773,28.0249651 20.4876778,23.1312166 14.375993,23.1312166 C13.0701896,23.1312166 11.8172109,23.3546126 10.6540931,23.7648224 Z" id="path-15"></path>
-        <path d="M5.54585436,10.6972047 L5.73283698,10.6225852 C12.1259868,8.07125717 19.402594,11.1221203 21.9855942,17.4368788 C24.5685944,23.7516372 21.4798579,30.9390204 15.0867081,33.4903484 C15.0332777,32.483337 14.8589764,31.5108904 14.5784184,30.5860057 C18.0083841,28.7293167 20.3339386,25.1299556 20.3339386,20.9940923 C20.3339386,14.9573475 15.3794391,10.063599 9.26775427,10.063599 C7.9619509,10.063599 6.70897218,10.2869949 5.54585436,10.6972047 Z" id="path-16"></path>
-        <path d="M35.631732,42.3730981 L40.1765635,42.3730981 C44.4579764,42.3730981 47.9287473,39.0094481 47.9287473,34.8601757 C47.9287473,30.7109033 44.4579764,27.3472534 40.1765635,27.3472534 L33.6170234,27.3472534 C31.1469775,27.3472534 29.1446097,29.2878206 29.1446097,31.6816316 L29.1446097,48.5516086 L35.631732,42.3730981 Z" id="path-17"></path>
-        <filter x="-26.6%" y="-18.9%" width="153.2%" height="147.2%" filterUnits="objectBoundingBox" id="filter-18">
-            <feOffset dx="0" dy="1" in="SourceAlpha" result="shadowOffsetOuter1"></feOffset>
-            <feGaussianBlur stdDeviation="1.5" in="shadowOffsetOuter1" result="shadowBlurOuter1"></feGaussianBlur>
-            <feColorMatrix values="0 0 0 0 0   0 0 0 0 0   0 0 0 0 0  0 0 0 0.298686594 0" type="matrix" in="shadowBlurOuter1"></feColorMatrix>
-        </filter>
-    </defs>
-    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <g id="icon-copy-9">
-            <g id="Group">
-                <mask id="mask-2" fill="white">
-                    <use xlink:href="#path-1"></use>
-                </mask>
-                <g id="Rectangle"></g>
-                <g id="Group-12" mask="url(#mask-2)">
-                    <g transform="translate(-12.598536, -12.100617)">
-                        <g id="Group-5" stroke-width="1" fill-rule="evenodd" transform="translate(37.298810, 37.253293) rotate(40.000000) translate(-37.298810, -37.253293) translate(11.517560, 12.253293)">
-                            <path d="M25.8796198,24.6636771 C19.1892035,23.016023 12.4132807,27.0374857 10.7451726,33.6458656 C9.07706451,40.2542455 13.1484497,46.9470835 19.8388659,48.5947376 L20.3450373,48.7193929 C9.69088103,46.3380067 1.6209996,37.2282295 0.954359365,26.1499385 L0.94398835,25.9544743 C0.583119676,19.1531217 5.87260905,13.3505813 12.7583935,12.9941375 C19.644178,12.6376937 25.5187511,17.8623246 25.8796198,24.6636771 Z" id="Combined-Shape" fill="url(#linearGradient-3)"></path>
-                            <path d="M25.8796198,24.6636771 C22.3283116,30.5015748 24.2407085,38.0777295 30.1510778,41.5854923 C36.0614471,45.0932551 43.7316521,43.2043076 47.2829602,37.3664099 L47.5182297,36.9796568 C43.2031146,44.3603916 35.1286161,49.3273543 25.8796198,49.3273543 C23.9775953,49.3273543 22.125241,49.1172988 20.3450373,48.7193929 L19.8388659,48.5947376 C13.1484497,46.9470835 9.07706451,40.2542455 10.7451726,33.6458656 C12.4132807,27.0374857 19.1892035,23.016023 25.8796198,24.6636771 Z" id="Combined-Shape-Copy-6" fill="url(#linearGradient-4)"></path>
-                            <path d="M25.8796198,24.6636771 C30.3117909,29.8809656 38.1867277,30.5614853 43.4687835,26.1836605 C48.7508393,21.8058357 49.439807,14.0274595 45.0076359,8.81017106 L44.9061506,8.69070851 C48.612765,12.9940954 50.8494715,18.5708837 50.8494715,24.6636771 C50.8494715,29.1494627 49.6370515,33.3555446 47.5182297,36.9796568 L47.2829602,37.3664099 C43.7316521,43.2043076 36.0614471,45.0932551 30.1510778,41.5854923 C24.2407085,38.0777295 22.3283116,30.5015748 25.8796198,24.6636771 Z" id="Combined-Shape-Copy-5" fill="url(#linearGradient-5)"></path>
-                            <path d="M25.8796198,24.6636771 C32.2727696,22.1123491 35.3615061,14.9249659 32.7785059,8.61020748 C30.1955057,2.29544903 22.9188985,-0.755414121 16.5257487,1.7959139 L16.0023658,2.00478143 C19.0317193,0.714714639 22.3711681,0 25.8796198,0 C33.5016588,0 40.3260608,3.37321498 44.9061506,8.69070851 L45.0076359,8.81017106 C49.439807,14.0274595 48.7508393,21.8058357 43.4687835,26.1836605 C38.1867277,30.5614853 30.3117909,29.8809656 25.8796198,24.6636771 Z" id="Combined-Shape-Copy-4" fill="url(#linearGradient-6)"></path>
-                            <g id="Combined-Shape-Copy-3" fill="url(#linearGradient-7)">
-                                <use xlink:href="#path-8"></use>
-                                <use fill-opacity="0.1" style="mix-blend-mode: multiply;" xlink:href="#path-8"></use>
-                            </g>
-                            <g id="Combined-Shape" opacity="0.504910714">
-                                <use fill="url(#linearGradient-7)" xlink:href="#path-9"></use>
-                                <use fill-opacity="0.496178668" fill="#000000" style="mix-blend-mode: overlay;" xlink:href="#path-9"></use>
-                            </g>
-                            <g id="Combined-Shape-Copy-7" opacity="0.544252232" transform="translate(37.055527, 20.178799) rotate(72.000000) translate(-37.055527, -20.178799) ">
-                                <use fill="url(#linearGradient-10)" xlink:href="#path-11"></use>
-                                <use fill-opacity="0.499886775" fill="#000000" style="mix-blend-mode: overlay;" xlink:href="#path-11"></use>
-                            </g>
-                            <g id="Combined-Shape-Copy-8" opacity="0.562220982" transform="translate(33.811317, 33.641001) rotate(143.000000) translate(-33.811317, -33.641001) ">
-                                <use fill="url(#linearGradient-12)" xlink:href="#path-13"></use>
-                                <use fill="#000000" style="mix-blend-mode: overlay;" xlink:href="#path-13"></use>
-                            </g>
-                            <g id="Combined-Shape-Copy-9" opacity="0.584151786" transform="translate(19.330169, 34.673473) rotate(217.000000) translate(-19.330169, -34.673473) ">
-                                <use fill="url(#linearGradient-14)" xlink:href="#path-15"></use>
-                                <use fill-opacity="0.503085371" fill="#000000" style="mix-blend-mode: overlay;" xlink:href="#path-15"></use>
-                            </g>
-                            <g id="Combined-Shape-Copy-10" opacity="0.180133929" transform="translate(14.221930, 21.605855) rotate(-71.000000) translate(-14.221930, -21.605855) ">
-                                <use fill="url(#linearGradient-3)" xlink:href="#path-16"></use>
-                                <use fill-opacity="0.772843071" fill="#000000" style="mix-blend-mode: multiply;" xlink:href="#path-16"></use>
-                            </g>
-                        </g>
-                        <g id="Path-6-Copy-2" fill-rule="nonzero">
-                            <use fill="black" fill-opacity="1" filter="url(#filter-18)" xlink:href="#path-17"></use>
-                            <use fill="#FFFFFF" xlink:href="#path-17"></use>
-                        </g>
-                    </g>
-                </g>
-            </g>
-        </g>
+<svg width="50" height="50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <defs>
+    <path id="a" d="M0 .11h50v49.78H0z"/>
+    <linearGradient x1="100%" y1="55.81%" x2="0%" y2="60.12%" id="c">
+      <stop stop-color="#FF5C34" offset="0%"/>
+      <stop stop-color="#EB0256" offset="100%"/>
+    </linearGradient>
+    <linearGradient x1="33.09%" y1="100%" x2="68.99%" y2="15.31%" id="d">
+      <stop stop-color="#A63FDB" offset="0%"/>
+      <stop stop-color="#FF257E" offset="100%"/>
+    </linearGradient>
+    <linearGradient x1="14.72%" y1="50%" x2="94.32%" y2="67.53%" id="e">
+      <stop stop-color="#00FFF0" offset="0%"/>
+      <stop stop-color="#0087FF" offset="100%"/>
+    </linearGradient>
+    <linearGradient x1="81.23%" y1="10.01%" x2="20.82%" y2="74.49%" id="f">
+      <stop stop-color="#17C934" offset="0%"/>
+      <stop stop-color="#03FF6E" offset="100%"/>
+    </linearGradient>
+    <linearGradient x1="50%" y1="111.91%" x2="30.56%" y2="0%" id="g">
+      <stop stop-color="#FFB000" offset="0%"/>
+      <stop stop-color="#FF7725" offset="100%"/>
+    </linearGradient>
+    <path d="M25.88 24.66A12.43 12.43 0 0 0 12.76 13 12.39 12.39 0 0 0 .94 25.95l.01.2A24.67 24.67 0 0 1 16 2l.53-.2c6.39-2.56 13.67.5 16.25 6.81s-.5 13.5-6.9 16.05Z" id="h"/>
+    <path d="m16.34 1.87.19-.07c6.39-2.56 13.67.5 16.25 6.81s-.5 13.5-6.9 16.05c-.05-1-.23-1.98-.5-2.9a10.9 10.9 0 0 0 5.75-9.6A11 11 0 0 0 20.06 1.25c-1.3 0-2.56.22-3.72.63Z" id="i"/>
+    <linearGradient x1="-81.36%" y1="59.62%" x2="121.42%" y2="72.06%" id="j">
+      <stop stop-color="#9EE85D" offset="0%"/>
+      <stop stop-color="#0ED061" offset="100%"/>
+    </linearGradient>
+    <path d="m28.38 9.27.19-.07c6.39-2.56 13.67.5 16.25 6.81s-.5 13.5-6.9 16.05c-.05-1-.23-1.98-.5-2.9a10.9 10.9 0 0 0 5.75-9.6A11 11 0 0 0 32.1 8.65c-1.3 0-2.56.22-3.72.63Z" id="k"/>
+    <linearGradient x1="45.51%" y1="116.82%" x2="0%" y2="-4.04%" id="l">
+      <stop stop-color="#21EFE3" offset="0%"/>
+      <stop stop-color="#2598FF" offset="100%"/>
+    </linearGradient>
+    <path d="m25.14 22.73.18-.07c6.4-2.55 13.67.5 16.25 6.81 2.59 6.32-.5 13.5-6.9 16.06a11.97 11.97 0 0 0-.5-2.9 10.9 10.9 0 0 0 5.75-9.6A11 11 0 0 0 28.86 22.1c-1.3 0-2.56.22-3.72.63Z" id="m"/>
+    <linearGradient x1="100%" y1="58.21%" x2="-89.65%" y2="74.32%" id="n">
+      <stop stop-color="#A63FDB" offset="0%"/>
+      <stop stop-color="#FF257E" offset="100%"/>
+    </linearGradient>
+    <path d="m10.65 23.76.2-.07c6.38-2.55 13.66.5 16.24 6.81 2.59 6.32-.5 13.5-6.9 16.06-.05-1-.22-1.98-.5-2.9a10.9 10.9 0 0 0 5.75-9.6 11 11 0 0 0-11.06-10.93c-1.31 0-2.56.22-3.73.63Z" id="o"/>
+    <path d="m5.55 10.7.18-.08c6.4-2.55 13.67.5 16.26 6.82a12.28 12.28 0 0 1-6.9 16.05c-.06-1-.23-1.98-.51-2.9a10.9 10.9 0 0 0 5.75-9.6A11 11 0 0 0 9.27 10.06c-1.3 0-2.56.23-3.72.64Z" id="p"/>
+    <path d="M35.63 42.37h4.55a7.64 7.64 0 0 0 7.75-7.51 7.64 7.64 0 0 0-7.75-7.51h-6.56a4.4 4.4 0 0 0-4.48 4.33v16.87l6.5-6.18Z" id="r"/>
+    <filter x="-26.6%" y="-18.9%" width="153.2%" height="147.2%" filterUnits="objectBoundingBox" id="q">
+      <feOffset dy="1" in="SourceAlpha" result="shadowOffsetOuter1"/>
+      <feGaussianBlur stdDeviation="1.5" in="shadowOffsetOuter1" result="shadowBlurOuter1"/>
+      <feColorMatrix values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.298686594 0" in="shadowBlurOuter1"/>
+    </filter>
+  </defs>
+  <g fill="none" fill-rule="evenodd">
+    <mask id="b" fill="#fff">
+      <use xlink:href="#a"/>
+    </mask>
+    <g mask="url(#b)">
+      <path d="M25.88 24.66a12.5 12.5 0 0 0-15.13 8.99 12.32 12.32 0 0 0 9.09 14.94l.5.13A24.77 24.77 0 0 1 .96 26.15v-.2A12.39 12.39 0 0 1 12.74 13a12.43 12.43 0 0 1 13.13 11.67Z" fill="url(#c)" transform="rotate(40 25.03 23.6)"/>
+      <path d="M25.88 24.66a12.25 12.25 0 0 0 4.27 16.93 12.57 12.57 0 0 0 17.13-4.22l.24-.39a25.02 25.02 0 0 1-21.64 12.35c-1.9 0-3.75-.21-5.53-.61l-.51-.13a12.32 12.32 0 0 1-9.1-14.94 12.5 12.5 0 0 1 15.14-8.99Z" fill="url(#d)" transform="rotate(40 25.03 23.6)"/>
+      <path d="M25.88 24.66a12.6 12.6 0 0 0 17.59 1.52A12.23 12.23 0 0 0 45 8.81l-.1-.12a24.39 24.39 0 0 1 2.6 28.29l-.23.39a12.57 12.57 0 0 1-17.13 4.22 12.25 12.25 0 0 1-4.27-16.93Z" fill="url(#e)" transform="rotate(40 25.03 23.6)"/>
+      <path d="M25.88 24.66a12.28 12.28 0 0 0 6.9-16.05A12.54 12.54 0 0 0 16.53 1.8L16 2c3.03-1.29 6.37-2 9.88-2 7.62 0 14.45 3.37 19.03 8.7l.1.11c4.43 5.22 3.74 13-1.54 17.37a12.6 12.6 0 0 1-17.59-1.52Z" fill="url(#f)" transform="rotate(40 25.03 23.6)"/>
+      <g fill="url(#g)" transform="rotate(40 25.03 23.6)">
+        <use xlink:href="#h"/>
+        <use fill-opacity=".1" style="mix-blend-mode:multiply" xlink:href="#h"/>
+      </g>
+      <g opacity=".5" transform="rotate(40 25.03 23.6)">
+        <use fill="url(#g)" xlink:href="#i"/>
+        <use fill-opacity=".5" fill="#000" style="mix-blend-mode:overlay" xlink:href="#i"/>
+      </g>
+      <g opacity=".54" transform="rotate(112 33.87 24.23)">
+        <use fill="url(#j)" xlink:href="#k"/>
+        <use fill-opacity=".5" fill="#000" style="mix-blend-mode:overlay" xlink:href="#k"/>
+      </g>
+      <g opacity=".56" transform="rotate(-177 29.6 35.4)">
+        <use fill="url(#l)" xlink:href="#m"/>
+        <use fill="#000" style="mix-blend-mode:overlay" xlink:href="#m"/>
+      </g>
+      <g opacity=".58" transform="rotate(-103 13.95 33.85)">
+        <use fill="url(#n)" xlink:href="#o"/>
+        <use fill-opacity=".5" fill="#000" style="mix-blend-mode:overlay" xlink:href="#o"/>
+      </g>
+      <g opacity=".18" transform="rotate(-31 4.44 11.5)">
+        <use fill="url(#c)" xlink:href="#p"/>
+        <use fill-opacity=".77" fill="#000" style="mix-blend-mode:multiply" xlink:href="#p"/>
+      </g>
+      <g fill-rule="nonzero" transform="translate(-12.6 -12.1)">
+        <use fill="#000" filter="url(#q)" xlink:href="#r"/>
+        <use fill="#FFF" xlink:href="#r"/>
+      </g>
     </g>
+  </g>
 </svg>


### PR DESCRIPTION
I ran the logo in [SVGOMG](https://jakearchibald.github.io/svgomg/), a tool for optimizing SVG images, and it saves 54 % of the weight without losing anything visually.

I kept the pretty markup, even if minification would have saved a few more bytes.