### PR TITLE
Resolve issue with backticks in raw SQL for postgresql migrations

### DIFF
--- a/app/Console/Commands/FixDuplicateProfiles.php
+++ b/app/Console/Commands/FixDuplicateProfiles.php
@@ -71,7 +71,7 @@ class FixDuplicateProfiles extends Command
     {
         $duplicates = DB::table('profiles')
             ->whereNull('domain')
-            ->select('username', DB::raw('COUNT(*) as `count`'))
+            ->select('username', DB::raw('COUNT(*) as "count"'))
             ->groupBy('username')
             ->havingRaw('COUNT(*) > 1')
             ->pluck('username');


### PR DESCRIPTION
Error during migrations due to backticks around count alias.

![image](https://user-images.githubusercontent.com/9691551/214802386-8b8c383a-8e58-4704-b797-e8422ba332d5.png)

Fix changes to double quotes - snippets from testing syntax in MySQL + PostgreSQL
MySQL syntax

```sql
mysql> select 1 as "count";
+-------+
| count |
+-------+
|     1 |
+-------+
```

PostgreSQL
```sql
pixelfed=# select 1 as "count";
 count
-------
     1
(1 row)
```