### PR TITLE
Publish docker image to GitHub registry

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -1,13 +1,11 @@
----
 name: Build Docker image
 
 on:
-  workflow_dispatch:
   push:
     branches:
       - dev
     tags:
-      - '*'
+      - "*"
   pull_request:
     paths:
       - .github/workflows/build-docker.yml
@@ -15,6 +13,7 @@ on:
       - contrib/docker/Dockerfile.fpm
 permissions:
   contents: read
+  packages: write
 
 jobs:
   build-docker-apache:
@@ -38,18 +37,17 @@ jobs:
 
       - name: Login to DockerHub
         uses: docker/login-action@v2
-        secrets: inherit
         with:
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
         if: github.event_name != 'pull_request'
 
       - name: Fetch tags
         uses: docker/metadata-action@v4
-        secrets: inherit
         id: meta
         with:
-          images: ${{ secrets.DOCKER_HUB_ORGANISATION }}/pixelfed
+          images: ghcr.io/${{ github.repository_owner }}/pixelfed
           flavor: |
             latest=auto
             suffix=-apache
@@ -92,18 +90,17 @@ jobs:
 
       - name: Login to DockerHub
         uses: docker/login-action@v2
-        secrets: inherit
         with:
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
         if: github.event_name != 'pull_request'
 
       - name: Fetch tags
         uses: docker/metadata-action@v4
-        secrets: inherit
         id: meta
         with:
-          images: ${{ secrets.DOCKER_HUB_ORGANISATION }}/pixelfed
+          images: ghcr.io/${{ github.repository_owner }}/pixelfed
           flavor: |
             suffix=-fpm
           tags: |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
 ## App and Worker
   app:
     # Comment to use dockerhub image
-    image: pixelfed/pixelfed:latest
+    image: ghcr.io/pixelfed/pixelfed:latest
     restart: unless-stopped
     env_file:
       - .env.docker
@@ -32,7 +32,7 @@ services:
       - redis
 
   worker:
-    image: pixelfed/pixelfed:latest
+    image: ghcr.io/pixelfed/pixelfed:latest
     restart: unless-stopped
     env_file:
       - .env.docker


### PR DESCRIPTION
It appears that the image is currently not being published to Docker Hub, perhaps there is some setup missing.

This changes the workflow to publish to GitHub registry, which requires no setup and is better integrated with GitHub.

Sample builds are available on my fork: https://github.com/jgillich/pixelfed/pkgs/container/pixelfed