### PR TITLE
Improve Docker entrypoints

### DIFF
--- a/contrib/docker/Dockerfile.apache
+++ b/contrib/docker/Dockerfile.apache
@@ -97,4 +97,4 @@ RUN php artisan horizon:publish
 
 VOLUME /var/www/storage /var/www/bootstrap
 
-CMD ["/var/www/contrib/docker/start.apache.sh"]
+ENTRYPOINT ["/var/www/contrib/docker/start.apache.sh"]

--- a/contrib/docker/start.apache.sh
+++ b/contrib/docker/start.apache.sh
@@ -1,15 +1,39 @@
 #!/bin/bash
 
+# We should already be in /var/www, but just to be explicit
+cd /var/www || exit
+
 # Create the storage tree if needed and fix permissions
 cp -r storage.skel/* storage/
 chown -R www-data:www-data storage/ bootstrap/
 
-# Refresh the environment
-php artisan storage:link
-php artisan horizon:publish
-php artisan route:cache
-php artisan view:cache
-php artisan config:cache
+if [[ ! -e storage/.docker.init ]]; then
+    echo "Fresh installation, initializing database..."
+    chown www-data:www-data .env &&
+        gosu www-data php artisan key:generate &&
+        gosu www-data php artisan migrate:fresh --force &&
+        gosu www-data php artisan passport:keys &&
+        echo "done" >storage/.docker.init
+fi
 
-# Finally run Apache
-apache2-foreground
+# Refresh the environment
+gosu www-data php artisan storage:link
+gosu www-data php artisan horizon:publish
+gosu www-data php artisan config:cache
+# gosu www-data php artisan cache:clear
+gosu www-data php artisan route:cache
+gosu www-data php artisan view:cache
+
+# Check for migrations
+gosu www-data php artisan migrate:status | grep No && migrations=yes || migrations=no
+
+if [ "$migrations" = "yes" ]; then
+    echo "Found outstanding migrations, running those..."
+    gosu www-data php artisan migrate --force
+fi
+
+# Create instance actor
+gosu www-data php artisan instance:actor
+
+# Finally run Apache, passing along any parameters from `CMD`
+dumb-init apache2-foreground "$@"

--- a/contrib/docker/worker.apache.sh
+++ b/contrib/docker/worker.apache.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# We should already be in /var/www, but just to be explicit
+cd /var/www || exit
+
+if [[ ! -e storage/.docker.init ]]; then
+    echo "Database is not initialized yet, exiting..."
+    sleep 5
+    exit 1
+fi
+
+# Check for migrations
+gosu www-data php artisan migrate:status | grep No && migrations=yes || migrations=no
+
+if [ "$migrations" = "yes" ]; then
+    echo "Found outstanding migrations, exiting..."
+    sleep 5
+    exit 1
+fi
+
+# Finally run Apache
+gosu www-data php artisan horizon

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,7 @@ services:
     networks:
       - external
       - internal
-    command: gosu www-data php artisan horizon
+    entrypoint: [ /var/www/contrib/docker/worker.apache.sh ]
     depends_on:
       - db
       - redis


### PR DESCRIPTION
Splitting up #4074. This PR only includes the improvements to the Docker entrypoints:

- `start.apache.sh` now initializes a new install and runs database migrations when needed
- Added a `worker.apache.sh` that will check if the new install is initialized and if there are any pending migrations before starting