### PR TITLE
Improve Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,8 +1,15 @@
-data
-Dockerfile
-contrib/docker/Dockerfile.*
-docker-compose*.yml
+# Ignore all markdown files
+*.md
+
+# And these files and folders
+.circleci
+.ddev
 .dockerignore
-.git
-.gitignore
-.env
+.editorconfig
+.env*
+.git*
+.node-version
+contrib/docker/Dockerfile.*
+data
+docker-compose*.yml
+LICENSE

--- a/contrib/docker/Dockerfile.apache
+++ b/contrib/docker/Dockerfile.apache
@@ -4,96 +4,98 @@ ENV COMPOSER_MEMORY_LIMIT=-1
 ARG DEBIAN_FRONTEND=noninteractive
 WORKDIR /var/www/
 
-# Get Composer binary
+# Get Composer binary from https://hub.docker.com/_/composer/
 COPY --from=composer:2.4.4 /usr/bin/composer /usr/bin/composer
 
 # Install package dependencies
 RUN apt-get update \
-  && apt-get upgrade -y \
-#  && apt-get install -y --no-install-recommends apt-utils \
-  && apt-get install -y --no-install-recommends \
+    && apt-get upgrade -y \
+    && apt-get install -y --no-install-recommends \
 ## Standard
-      locales \
-      locales-all \
-      git \
-      gosu \
-      zip \
-      unzip \
-      libzip-dev \
-      libcurl4-openssl-dev \
+        dumb-init \
+        git \
+        gosu \
+        libcurl4-openssl-dev \
+        libzip-dev \
+        locales \
+        locales-all \
+        unzip \
+        zip \
 ## Image Optimization
-      optipng \
-      pngquant \
-      jpegoptim \
-      gifsicle \
+        gifsicle \
+        jpegoptim \
+        optipng \
+        pngquant \
 ## Image Processing
-      libjpeg62-turbo-dev \
-      libpng-dev \
-      libmagickwand-dev \
+        libjpeg62-turbo-dev \
+        libmagickwand-dev \
+        libpng-dev \
 # Required for GD
-      libxpm4 \
-      libxpm-dev \
-      libwebp6 \
-      libwebp-dev \
+        libwebp-dev \
+        libwebp6 \
+        libxpm-dev \
+        libxpm4 \
 ## Video Processing
-      ffmpeg \
+        ffmpeg \
 ## Database
-#      libpq-dev \
-#      libsqlite3-dev \
-      mariadb-client \
+        mariadb-client \
+## Clean up, to reduce cache size
+    && apt-get autoremove --purge -y \
+    && apt-get clean \
+    && rm -rf /var/cache/apt \
+    && rm -rf /var/lib/apt/lists/
+
 # Locales Update
-  && sed -i '/en_US/s/^#//g' /etc/locale.gen \
-  && locale-gen \
-  && update-locale \
+RUN sed -i '/en_US/s/^#//g' /etc/locale.gen \
+    && locale-gen \
+    && update-locale
+
 # Install PHP extensions
-  && docker-php-source extract \
-#PHP Imagemagick extensions
-  && pecl install imagick \
-  && docker-php-ext-enable imagick \
-# PHP GD extensions
-  && docker-php-ext-configure gd \
-      --with-freetype \
-      --with-jpeg \
-      --with-webp \
-      --with-xpm \
-  && docker-php-ext-install -j$(nproc) gd \
-#PHP Redis extensions
-  && pecl install redis \
-  && docker-php-ext-enable redis \
-#PHP Database extensions
-  && docker-php-ext-install pdo_mysql \
-#pdo_pgsql pdo_sqlite \
-#PHP extensions (dependencies)
-  && docker-php-ext-configure intl \
-  && docker-php-ext-install -j$(nproc) intl bcmath zip pcntl exif curl \
-#APACHE Bootstrap
-  && a2enmod rewrite remoteip \
- && {\
-     echo RemoteIPHeader X-Real-IP ;\
-     echo RemoteIPTrustedProxy 10.0.0.0/8 ;\
-     echo RemoteIPTrustedProxy 172.16.0.0/12 ;\
-     echo RemoteIPTrustedProxy 192.168.0.0/16 ;\
-     echo SetEnvIf X-Forwarded-Proto "https" HTTPS=on ;\
-    } > /etc/apache2/conf-available/remoteip.conf \
- && a2enconf remoteip \
-#Cleanup
-  && docker-php-source delete \
-  && apt-get autoremove --purge -y \
-  && apt-get clean \
-  && rm -rf /var/cache/apt \
-  && rm -rf /var/lib/apt/lists/
+RUN docker-php-source extract \
+## PHP Imagemagick extensions
+    && pecl install imagick \
+    && docker-php-ext-enable imagick \
+## PHP GD extensions
+    && docker-php-ext-configure gd \
+        --with-freetype \
+        --with-jpeg \
+        --with-webp \
+        --with-xpm \
+    && docker-php-ext-install -j$(nproc) gd \
+## PHP Redis extensions
+    && pecl install redis \
+    && docker-php-ext-enable redis \
+## PHP Database extensions
+    && docker-php-ext-install pdo_mysql \
+## PHP extensions (dependencies)
+    && docker-php-ext-configure intl \
+    && docker-php-ext-install -j$(nproc) intl bcmath zip pcntl exif curl \
+## Clean up, to reduce cache size
+    && docker-php-source delete
 
 # Use the default production configuration
 COPY contrib/docker/php.production.ini "$PHP_INI_DIR/php.ini"
 
+# APACHE Bootstrap
+RUN a2enmod rewrite remoteip \
+    && {\
+        echo RemoteIPHeader X-Real-IP ;\
+        echo RemoteIPTrustedProxy 10.0.0.0/8 ;\
+        echo RemoteIPTrustedProxy 172.16.0.0/12 ;\
+        echo RemoteIPTrustedProxy 192.168.0.0/16 ;\
+        echo SetEnvIf X-Forwarded-Proto "https" HTTPS=on ;\
+    } > /etc/apache2/conf-available/remoteip.conf \
+    && a2enconf remoteip
+
+# Copy everything from the repository to the image
+# See `.dockerignore` for what is excluded
 COPY . /var/www/
+
 # for detail why storage is copied this way, pls refer to https://github.com/pixelfed/pixelfed/pull/2137#discussion_r434468862
 RUN cp -r storage storage.skel \
-  && composer install --prefer-dist --no-interaction --no-ansi --optimize-autoloader \
-  && rm -rf html && ln -s public html \
-  && chown -R www-data:www-data /var/www
-
-RUN php artisan horizon:publish
+    && composer install --prefer-dist --no-interaction --no-ansi --optimize-autoloader \
+    && rm -rf html && ln -s public html \
+    && chown -R www-data:www-data /var/www
 
 VOLUME /var/www/storage /var/www/bootstrap
 


### PR DESCRIPTION
Splitting up #4074. This PR only includes the improvements to the Dockerfile:

- `Dockerfile.apache` is split in a couple more `RUN`s so that rebuilding the image locally can reuse cached steps for each
- `apt-get` and PHP clean up are done in their respective steps, instead of at the end
- `php artisan horizon:publish` is removed because this already happens in `contrib/docker/start.apache.sh`
- `.dockerignore` now ignores more unneeded files to keep the image compact