### PR TITLE
Run config:cache first

### DIFF
--- a/contrib/docker/start.apache.sh
+++ b/contrib/docker/start.apache.sh
@@ -5,11 +5,11 @@ cp -r storage.skel/* storage/
 chown -R www-data:www-data storage/ bootstrap/
 
 # Refresh the environment
+php artisan config:cache
 php artisan storage:link
 php artisan horizon:publish
 php artisan route:cache
 php artisan view:cache
-php artisan config:cache
 
 # Finally run Apache
 apache2-foreground

--- a/contrib/docker/start.fpm.sh
+++ b/contrib/docker/start.fpm.sh
@@ -5,11 +5,11 @@ cp -r storage.skel/* storage/
 chown -R www-data:www-data storage/ bootstrap/
 
 # Refresh the environment
+php artisan config:cache
 php artisan storage:link
 php artisan horizon:publish
 php artisan route:cache
 php artisan view:cache
-php artisan config:cache
 
 # Finally run FPM
 php-fpm


### PR DESCRIPTION
When updating config variables, such as the APP_URL, the values need to be propagated before calling e.g. route:cache/view:cache Otherwise those commands will first run with the old config cache.


1) Previously run config:cache with an initial state (APP_URL=https://example.com)
2) Shut down the docker container
3) Change the .env file to have a different state (APP_URL=https://different.example.com)
4) Run the docker container

Before this fix: Pixelfed doesn't run properly as the routes still return https://example.com as the app_url
After this fix: Pixelfed properly returns https://different.example.com when visiting the page