### PR TITLE
Fix diagnostic confirmation of passport oauth key

### DIFF
--- a/resources/views/admin/diagnostics/home.blade.php
+++ b/resources/views/admin/diagnostics/home.blade.php
@@ -74,11 +74,11 @@
 		</li>
 		<li>
 			<strong><span class="badge badge-primary">OAUTH</span> public key exists: </strong>
-			<span>{{ file_exists(storage_path('oauth-public.key')) ? '✅ true' : '❌ false' }}</span>
+			<span>{{ file_exists(storage_path('oauth-public.key')) || config_cache('passport.public_key') ? '✅ true' : '❌ false' }}</span>
 		</li>
 		<li>
 			<strong><span class="badge badge-primary">OAUTH</span> private key exists: </strong>
-			<span>{{ file_exists(storage_path('oauth-private.key')) ? '✅ true' : '❌ false' }}</span>
+			<span>{{ file_exists(storage_path('oauth-private.key')) || config_cache('passport.private_key') ? '✅ true' : '❌ false' }}</span>
 		</li>		
 		
 		<hr>


### PR DESCRIPTION
The ouath public/private keys can either be specified as a file or as an environment variable. Check both places in the diagnostic page

See https://github.com/laravel/passport/issues/997

Setting PASSPORT_PRIVATE_KEY has been supported since laravel 5.8. I have validated that oauth works properly in pixelfed just with setting this variable (and not having the file).

However, without this PR, even though oauth is working, the diagnostic page indicates that the oauth keys are not set. The fix is to check the existing passport config, which pulls in the environment variable