### PR TITLE
Make story API more consistent

### DIFF
--- a/app/Http/Controllers/Stories/StoryApiV1Controller.php
+++ b/app/Http/Controllers/Stories/StoryApiV1Controller.php
@@ -115,7 +115,6 @@ class StoryApiV1Controller extends Controller
 				})
 				->sortBy('id')
 				->values();
-			$selfProfile = AccountService::get($pid, true);
 			$res['self']['nodes'] = $selfStories;
 		}
 		return response()->json($res, 200, [], JSON_PRETTY_PRINT|JSON_UNESCAPED_SLASHES);

--- a/app/Http/Controllers/Stories/StoryApiV1Controller.php
+++ b/app/Http/Controllers/Stories/StoryApiV1Controller.php
@@ -83,11 +83,22 @@ class StoryApiV1Controller extends Controller
 		->sortBy('seen')
 		->values();
 
+		$selfProfile = AccountService::get($pid, true);
 		$res = [
-			'self' => [],
+			'self' => [
+				'user' => [
+					'id' => (string) $selfProfile['id'],
+					'username' => $selfProfile['acct'],
+					'avatar' => $selfProfile['avatar'],
+					'local' => $selfProfile['local'],
+					'is_author' => true
+				],
+
+				'nodes' => [],
+			],
 			'nodes' => $nodes,
 		];
-
+		
 		if(Story::whereProfileId($pid)->whereActive(true)->exists()) {
 			$selfStories = Story::whereProfileId($pid)
 				->whereActive(true)
@@ -105,17 +116,7 @@ class StoryApiV1Controller extends Controller
 				->sortBy('id')
 				->values();
 			$selfProfile = AccountService::get($pid, true);
-			$res['self'] = [
-				'user' => [
-					'id' => (string) $selfProfile['id'],
-					'username' => $selfProfile['acct'],
-					'avatar' => $selfProfile['avatar'],
-					'local' => $selfProfile['local'],
-					'is_author' => true
-				],
-
-				'nodes' => $selfStories,
-			];
+			$res['self']['nodes'] = $selfStories;
 		}
 		return response()->json($res, 200, [], JSON_PRETTY_PRINT|JSON_UNESCAPED_SLASHES);
 	}


### PR DESCRIPTION
As of now, the story carousel API will return an empty array for `self` when the user has no stories of their own, but otherwise will return an object. That doesn't make much sense.

This PR makes it so `self` always returns an object describing the user, and the `nodes` array inside `self` will be empty instead.