### PR TITLE
Added `following_since` attribute to `/api/v1/accounts/relationships`…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Added
 - Post edits ([#4416](https://github.com/pixelfed/pixelfed/pull/4416)) ([98cf8f3](https://github.com/pixelfed/pixelfed/commit/98cf8f3))
 
+### API Changes
+- Added `following_since` attribute to `/api/v1/accounts/relationships` endpoint when `_pe=1` (pixelfed entity) parameter is present ([992d910b](https://github.com/pixelfed/pixelfed/commit/992d910b))
+
 ### Updates
 - Update StatusService, fix bug in getFull method ([4d8b4dcf](https://github.com/pixelfed/pixelfed/commit/4d8b4dcf))
 - Update Config, bump version for post edit support without having to clear cache ([c0190d84](https://github.com/pixelfed/pixelfed/commit/c0190d84))

--- a/app/Http/Controllers/Api/ApiV1Controller.php
+++ b/app/Http/Controllers/Api/ApiV1Controller.php
@@ -905,13 +905,16 @@ class ApiV1Controller extends Controller
 			'id'    => 'required|array|min:1|max:20',
 			'id.*'  => 'required|integer|min:1|max:' . PHP_INT_MAX
 		]);
+		$napi = $request->has(self::PF_API_ENTITY_KEY);
 		$pid = $request->user()->profile_id ?? $request->user()->profile->id;
 		$res = collect($request->input('id'))
 			->filter(function($id) use($pid) {
 				return intval($id) !== intval($pid);
 			})
-			->map(function($id) use($pid) {
-				return RelationshipService::get($pid, $id);
+			->map(function($id) use($pid, $napi) {
+				return $napi ?
+				 RelationshipService::getWithDate($pid, $id) :
+				 RelationshipService::get($pid, $id);
 		});
 		return $this->json($res);
 	}

--- a/app/Services/RelationshipService.php
+++ b/app/Services/RelationshipService.php
@@ -52,6 +52,7 @@ class RelationshipService
 
 	public static function delete($aid, $tid)
 	{
+		Cache::forget(self::key("wd:a_{$aid}:t_{$tid}"));
 		return Cache::forget(self::key("a_{$aid}:t_{$tid}"));
 	}
 
@@ -84,5 +85,25 @@ class RelationshipService
 	protected static function key($suffix)
 	{
 		return self::CACHE_KEY . $suffix;
+	}
+
+	public static function getWithDate($aid, $tid)
+	{
+		$res = self::get($aid, $tid);
+
+		if(!$res || !$res['following']) {
+			$res['following_since'] = null;
+			return $res;
+		}
+
+		return Cache::remember(self::key("wd:a_{$aid}:t_{$tid}"), 1209600, function() use($aid, $tid, $res) {
+			$tmp = Follower::whereProfileId($aid)->whereFollowingId($tid)->first();
+			if(!$tmp) {
+				$res['following_since'] = null;
+				return $res;
+			}
+			$res['following_since'] = str_replace('+00:00', 'Z', $tmp->created_at->format(DATE_RFC3339_EXTENDED));
+			return $res;
+		});
 	}
 }


### PR DESCRIPTION
… endpoint when `_pe=1` (pixelfed entity) parameter is present