### PR TITLE
Add Redis prefix

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Database\DBAL\TimestampType;
+use Illuminate\Support\Str;
 
 return [
     /*

--- a/config/database.php
+++ b/config/database.php
@@ -113,6 +113,11 @@ return [
     'redis' => [
 
         'client' => env('REDIS_CLIENT', 'predis'),
+		
+		'options' => [
+            'cluster' => env('REDIS_CLUSTER', 'redis'),
+            'prefix' => env('REDIS_PREFIX', Str::slug(env('APP_NAME', 'pixelfed'), '_').'_database_'),
+        ],
 
         'default' => [
             'scheme'   => env('REDIS_SCHEME', 'tcp'),


### PR DESCRIPTION
When you have multiple Laravel projects on the server and a Redis server, running `php artisan horizon` will execute jobs from other Laravel projects that also have queue/horizon.

To avoid this, we need to set a Redis prefix in `config/database.php`, which is what I did.