### PR TITLE
Correctly handle visiting the website with a fully qualified username

### DIFF
--- a/app/Http/Controllers/SiteController.php
+++ b/app/Http/Controllers/SiteController.php
@@ -142,6 +142,10 @@ class SiteController extends Controller
 
 	public function legacyWebfingerRedirect(Request $request, $username, $domain)
 	{
+		if($domain == config('pixelfed.domain.app')) {
+			# If the user visits domain/@user@domain, treat it the same as visiting domain/@user
+			return SiteController::legacyProfileRedirect($request, $username);
+		}
 		$un = '@'.$username.'@'.$domain;
 		$profile = Profile::whereUsername($un)
 			->firstOrFail();

--- a/app/Services/AccountService.php
+++ b/app/Services/AccountService.php
@@ -171,6 +171,12 @@ class AccountService
 			if($s->contains('@') && !$s->startsWith('@')) {
 				$username = "@{$username}";
 			}
+			if(preg_match('/^@([^@]+)@'.preg_quote(config('pixelfed.domain.app')).'$/i', $username, $matches)) {
+				# The username is the fully qualified @user@example.com and the pixelfed site is example.com
+				# Normalize this username to just user
+				$username = $matches[1];
+			}
+
 			$profile = DB::table('profiles')
 				->whereUsername($username)
 				->first();


### PR DESCRIPTION
Problem:
When you tag someone on the fediverse with their full username - e.g. @myuser@example.com

When the pixelfed website, or mastodon websites or apps tries to visit `example.com/@myuser@example.com`, currently pixelfed returns a 404.
This patch changes the behavior such that both `example.com/@myuser` and `example.com/@myuser@example.com` both return the same content.

## Test plan
visited: domain.com/user, domain.com/@user, domain.com/@user@domain.com
logged in and visited: domain.com/i/web/username/user, domain.com/i/web/username/@user@domain.com

and verified that all the url's load correctly

I also deployed the fix to my pixelfed and validated that clicking a tagged username at least loads the correct webpage!