### PR TITLE
[Bugfix] #4518: SQL query that generates the report list in the admin view needs to include the 'id' field

### DIFF
--- a/app/Http/Controllers/Admin/AdminReportController.php
+++ b/app/Http/Controllers/Admin/AdminReportController.php
@@ -643,7 +643,7 @@ trait AdminReportController
 				$q->whereNull('admin_seen') :
 				$q->whereNotNull('admin_seen');
 			})
-			->groupBy(['object_id', 'object_type'])
+			->groupBy(['id', 'object_id', 'object_type'])
 			->cursorPaginate(6)
 			->withQueryString()
 		);

--- a/app/Http/Controllers/ComposeController.php
+++ b/app/Http/Controllers/ComposeController.php
@@ -415,7 +415,7 @@ class ComposeController extends Controller
 		$results = Profile::select('id','domain','username')
 			->whereNotIn('id', $blocked)
 			->where('username','like','%'.$q.'%')
-			->groupBy('domain')
+			->groupBy('id', 'domain')
 			->limit(15)
 			->get()
 			->map(function($profile) {


### PR DESCRIPTION
See #4518 for the problem - the SQL query is missing a field in the `GROUP BY` clause.