### PR TITLE
Provide the error message if a file to upload is too large, issue #3596

### DIFF
--- a/resources/assets/js/components/ComposeModal.vue
+++ b/resources/assets/js/components/ComposeModal.vue
@@ -1068,6 +1068,16 @@ export default {
 			return App.util.format.timeAgo(ts);
 		},
 
+		formatBytes(bytes, decimals = 2) {
+			if (!+bytes) {
+				return '0 Bytes'
+			}
+			const dec = decimals < 0 ? 0 : decimals
+			const units = ['Bytes', 'KB', 'MB', 'GB', 'TB'];
+			const quotient = Math.floor(Math.log(bytes) / Math.log(1024))
+			return `${parseFloat((bytes / Math.pow(1024, quotient)).toFixed(dec))} ${units[quotient]}`
+		},
+
 		fetchProfile() {
 			let tags = {
 				public: 'Public',
@@ -1178,6 +1188,13 @@ export default {
 					}, 300);
 				}).catch(function(e) {
 					switch(e.response.status) {
+						case 413:
+							self.uploading = false;
+							io.value = null;
+							swal('File is too large', 'The file you uploaded has the size of ' + self.formatBytes(io.size) + '. Unfortunately, only images up to ' + self.formatBytes(self.config.uploader.max_photo_size  * 1024) + ' are supported.\nPlease resize the file and try again.', 'error');
+							self.page = 2;
+							break;
+
 						case 451:
 							self.uploading = false;
 							io.value = null;


### PR DESCRIPTION
Hello!
This PR refers to the issue [Non-explanatory error message when uploading media above 2MB#3596](https://github.com/pixelfed/pixelfed/issues/3596) .

It handles the case of 413 HTTP status code when uploaded file is too large, adds the explicit error message that the file user is trying to upload is X size, while only files of Y size are supported.