### PR TITLE
Strip tags from bio in embeds

### DIFF
--- a/resources/views/profile/show.blade.php
+++ b/resources/views/profile/show.blade.php
@@ -20,7 +20,7 @@
 
 @endsection
 
-@push('meta')<meta property="og:description" content="{{$profile->bio}}">
+@push('meta')<meta property="og:description" content="{{strip_tags($profile->bio)}}">
 	@if(false == $settings['crawlable'] || $profile->remote_url)
 	<meta name="robots" content="noindex, nofollow">
 	@else  <meta property="og:image" content="{{$profile->avatarUrl()}}">


### PR DESCRIPTION
Strip tags from the bio when a user has put html formatting in; this appears when a user drops a profile link into apps such as Telegram, Signal, Discord and such - and only some of them render HTML (most dont). 