### PR TITLE
Add check if collection is empty in Edit Collection before publishing

### DIFF
--- a/resources/assets/js/components/CollectionComponent.vue
+++ b/resources/assets/js/components/CollectionComponent.vue
@@ -205,11 +205,19 @@
 
 				<div v-else class="float-right">
 					<button
+					    v-if="posts.length > 0"
 						type="button"
 						class="btn btn-outline-primary btn-sm py-1 font-weight-bold px-3"
 						@click.prevent="publishCollection">
 						Publish
 					</button>
+
+					<button
+						v-else
+						type="button"
+						class="btn btn-outline-primary btn-sm py-1 font-weight-bold px-3 disabled" disabled>
+						Publish
+				    </button>
 
 					<button
 						type="button"
@@ -527,6 +535,11 @@ export default {
 		},
 
 		publishCollection() {
+			if (this.posts.length === 0) {
+				swal('Error', 'You cannot publish an empty collection');
+				return;
+			}
+
 			if(this.owner == false) {
 				return;
 			}
@@ -541,7 +554,9 @@ export default {
 				.then(res => {
 					console.log(res.data);
 					// window.location.href = res.data.url;
-				});
+				}).catch(err => {
+					swal('Something went wrong', 'There was a problem with your request, please try again later.', 'error')
+			    });
 			} else {
 				return;
 			}


### PR DESCRIPTION
#4708 
Fix for the issue [Attempt to publish an empty collection through Edit Collections returns 404 response code, not handled in UI ](https://github.com/pixelfed/pixelfed/issues/4708)
Add a check if the collection is not empty in the publishCollection() method as well as setting the condition for "Publish" button to be enabled/disabled depends on check if collection is empty (hope it's not overkill) in CollectionComponent.vue.

As for now I can see that the collections with "Draft" visibility can be published if not empty, but they would be visible only to creators, so I kept such behavior, but please let me know if it's desirable to not publish draft collections at all.

How the fix looks like in my local server ("Publish" button is disabled for an empty collection, enabled for non-empty collection, able to publish the non-empty collection):
![Screen Shot 2023-10-20 at 3 03 06 PM](https://github.com/pixelfed/pixelfed/assets/7782090/33ae8368-6e13-4584-a3fe-13fdcb81be7d)

![Screen Shot 2023-10-20 at 3 03 40 PM](https://github.com/pixelfed/pixelfed/assets/7782090/5dbeddce-42f2-49fb-bee8-d432bedd97f5)

![Screen Shot 2023-10-20 at 3 04 07 PM](https://github.com/pixelfed/pixelfed/assets/7782090/c60176c6-712c-4086-a47e-c8ee3f6c5847)

![Screen Shot 2023-10-20 at 3 04 23 PM](https://github.com/pixelfed/pixelfed/assets/7782090/ee23cb50-d3cc-4cd2-85f4-b2dca25bf3a5)
