### PR TITLE
fix: Instagram import broken UTF8 characters

### DIFF
--- a/resources/assets/components/AccountImport.vue
+++ b/resources/assets/components/AccountImport.vue
@@ -348,8 +348,16 @@
                 }, 500);
             },
 
+			// Facebook and Instagram are encoding UTF8 characters in a weird way in their json
+			// here is a good explanation what's going wrong https://sorashi.github.io/fix-facebook-json-archive-encoding
+			fixFacebookEncoding(string) {
+				const replaced = string.replace(/\\u00([a-f0-9]{2})/g, (x) => String.fromCharCode(parseInt(x.slice(2), 16)));
+				const buffer = Array.from(replaced, (c) => c.charCodeAt(0));
+				return new TextDecoder().decode(new Uint8Array(buffer));
+			},
+
             filterPostMeta(media) {
-                let json = JSON.parse(media);
+                let json = JSON.parse(this.fixFacebookEncoding(media));
                 let res = json.filter(j => {
                     let ids = j.media.map(m => m.uri).filter(m => {
                         if(this.config.allow_video_posts == true) {
@@ -396,12 +404,14 @@
                     this.filterPostMeta(media);
 
                     let imgs = await Promise.all(entries.filter(entry => {
-                        return entry.filename.startsWith('media/posts/') && (entry.filename.endsWith('.png') || entry.filename.endsWith('.jpg') || entry.filename.endsWith('.mp4'));
+                        return (entry.filename.startsWith('media/posts/') || entry.filename.startsWith('media/other/')) && (entry.filename.endsWith('.png') || entry.filename.endsWith('.jpg') || entry.filename.endsWith('.mp4'));
                     })
                     .map(async entry => {
                         if(
-                            entry.filename.startsWith('media/posts/') &&
-                            (
+							(
+								entry.filename.startsWith('media/posts/') ||
+								entry.filename.startsWith('media/other/')
+							) && (
                                 entry.filename.endsWith('.png') ||
                                 entry.filename.endsWith('.jpg') ||
                                 entry.filename.endsWith('.mp4')


### PR DESCRIPTION
As discussed in #4479, and #4638 if you import your posts from Instagram you might encounter issues as soon as there are UTF8 characters involved.

This is due to a wrongly encoded JSON which is apparently common for all Meta companies like Facebook and Instagram. A good explanation what's actually going wrong you can find from @ sorashi [here](https://sorashi.github.io/fix-facebook-json-archive-encoding)

To fix this you need to decode and re-encode the text before lettig a JSON parser parse it.

Also slightly unrelated fix is also in here - some media files can be found in the "media/other" folder as well. So i added that to the filter matches

Since it's not wanted to check in compiled/minified JS code i've not included it here. For testing purposes you can check out the [insta-import-utf8](https://github.com/paulexyz/pixelfed/tree/compiled/insta-import-utf8) branch in my repo