### PR TITLE
4790 4791 add recently deleted post to collection no page reloading invalidate cache after adding

### DIFF
--- a/app/Http/Controllers/CollectionController.php
+++ b/app/Http/Controllers/CollectionController.php
@@ -166,11 +166,7 @@ class CollectionController extends Controller
             'order'         => $count,
         ]);
 
-        CollectionService::addItem(
-        	$collection->id,
-        	$status->id,
-        	$count
-        );
+        CollectionService::deleteCollection($collection->id);
 
         $collection->updated_at = now();
         $collection->save();

--- a/resources/assets/js/components/CollectionComponent.vue
+++ b/resources/assets/js/components/CollectionComponent.vue
@@ -619,6 +619,9 @@ export default {
 			this.posts = this.posts.filter(post => {
 				return post.id != id;
 			});
+			this.ids = this.ids.filter(post_id => {
+				return post_id != id;
+			});
 		},
 
 		addRecentId(post) {
@@ -630,6 +633,7 @@ export default {
 				// window.location.reload();
 				this.closeModals();
 				this.posts.push(res.data);
+				this.ids.push(post.id);
 				this.collection.post_count++;
 			}).catch(err => {
 				swal('Oops!', 'An error occured, please try selecting another post.', 'error');


### PR DESCRIPTION
This PR fixes two issues: #4790 and #4791 

For [Invalidating cache (CollectionController) after adding a collection item to get consistent data ](https://github.com/pixelfed/pixelfed/issues/4791) it removes adding collection's item to cache. Instead, it's doing the cache invalidation after adding an item to a collection, so after it a collection's items would come from DB, and data consistency will be preserved.

For [User experience: add a post to a collection just right after deleting it from there ](https://github.com/pixelfed/pixelfed/issues/4790) it takes care of tracking which items have been removed from a collection