### PR TITLE
Fix: dockerfile libwebp issues

### DIFF
--- a/contrib/docker/Dockerfile.apache
+++ b/contrib/docker/Dockerfile.apache
@@ -8,80 +8,78 @@ WORKDIR /var/www/
 COPY --from=composer:2.6 /usr/bin/composer /usr/bin/composer
 
 # Install package dependencies
-RUN apt-get update \
-  && apt-get upgrade -y \
-#  && apt-get install -y --no-install-recommends apt-utils \
-  && apt-get install -y --no-install-recommends \
-## Standard
-      locales \
-      locales-all \
-      git \
-      gosu \
-      zip \
-      unzip \
-      libzip-dev \
-      libcurl4-openssl-dev \
-## Image Optimization
-      optipng \
-      pngquant \
-      jpegoptim \
-      gifsicle \
-## Image Processing
-      libjpeg62-turbo-dev \
-      libpng-dev \
-      libmagickwand-dev \
-# Required for GD
-      libxpm4 \
-      libxpm-dev \
-      libwebp7 \
-      libwebp-dev \
-## Video Processing
-      ffmpeg \
-## Database
-#      libpq-dev \
-#      libsqlite3-dev \
-      mariadb-client \
-# Locales Update
+RUN \
+  # Apt update & upgrade to check for security updates to Debian image
+  apt-get update; \
+  apt-get dist-upgrade -yq; \
+  # Install necessary components
+  apt-get install -y --no-install-recommends \
+  ## Standard
+  wget \
+  locales \
+  locales-all \
+  git \
+  gosu \
+  zip \
+  unzip \
+  libzip-dev \
+  libcurl4-openssl-dev \
+  ## Image Optimization
+  optipng \
+  pngquant \
+  jpegoptim \
+  gifsicle \
+  ## Image Processing
+  libjpeg62-turbo-dev \
+  libpng-dev \
+  libmagickwand-dev \
+  # Required for GD
+  libxpm4 \
+  libxpm-dev \
+  libwebp-dev \
+  ## Video Processing
+  ffmpeg \
+  ## Database
+  libpq-dev \
+  libsqlite3-dev \
+  mariadb-client \
+  # Locales Update
   && sed -i '/en_US/s/^#//g' /etc/locale.gen \
   && locale-gen \
   && update-locale \
-# Install PHP extensions
+  # Install PHP extensions
   && docker-php-source extract \
-#PHP Imagemagick extensions
+  #PHP Imagemagick extensions
   && pecl install imagick \
   && docker-php-ext-enable imagick \
-# PHP GD extensions
+  # PHP GD extensions
   && docker-php-ext-configure gd \
-      --with-freetype \
-      --with-jpeg \
-      --with-webp \
-      --with-xpm \
+  --with-freetype \
+  --with-jpeg \
+  --with-webp \
+  --with-xpm \
   && docker-php-ext-install -j$(nproc) gd \
-#PHP Redis extensions
+  #PHP Redis extensions
   && pecl install redis \
   && docker-php-ext-enable redis \
-#PHP Database extensions
+  #PHP Database extensions
   && docker-php-ext-install pdo_mysql \
-#pdo_pgsql pdo_sqlite \
-#PHP extensions (dependencies)
+  #pdo_pgsql pdo_sqlite \
+  #PHP extensions (dependencies)
   && docker-php-ext-configure intl \
   && docker-php-ext-install -j$(nproc) intl bcmath zip pcntl exif curl \
-#APACHE Bootstrap
+  #APACHE Bootstrap
   && a2enmod rewrite remoteip \
- && {\
-     echo RemoteIPHeader X-Real-IP ;\
-     echo RemoteIPTrustedProxy 10.0.0.0/8 ;\
-     echo RemoteIPTrustedProxy 172.16.0.0/12 ;\
-     echo RemoteIPTrustedProxy 192.168.0.0/16 ;\
-     echo SetEnvIf X-Forwarded-Proto "https" HTTPS=on ;\
-    } > /etc/apache2/conf-available/remoteip.conf \
- && a2enconf remoteip \
-#Cleanup
-  && docker-php-source delete \
-  && apt-get autoremove --purge -y \
-  && apt-get clean \
-  && rm -rf /var/cache/apt \
-  && rm -rf /var/lib/apt/lists/
+  && {\
+  echo RemoteIPHeader X-Real-IP ;\
+  echo RemoteIPTrustedProxy 10.0.0.0/8 ;\
+  echo RemoteIPTrustedProxy 172.16.0.0/12 ;\
+  echo RemoteIPTrustedProxy 192.168.0.0/16 ;\
+  echo SetEnvIf X-Forwarded-Proto "https" HTTPS=on ;\
+  } > /etc/apache2/conf-available/remoteip.conf \
+  && a2enconf remoteip \
+  #Cleanup
+  && docker-php-source delete
 
 # Use the default production configuration
 COPY contrib/docker/php.production.ini "$PHP_INI_DIR/php.ini"

--- a/contrib/docker/Dockerfile.apache
+++ b/contrib/docker/Dockerfile.apache
@@ -1,11 +1,11 @@
-FROM php:8.1-apache-bullseye
+FROM php:8.2-apache-bullseye
 
 ENV COMPOSER_MEMORY_LIMIT=-1
 ARG DEBIAN_FRONTEND=noninteractive
 WORKDIR /var/www/
 
 # Get Composer binary
-COPY --from=composer:2.4.4 /usr/bin/composer /usr/bin/composer
+COPY --from=composer:2.6 /usr/bin/composer /usr/bin/composer
 
 # Install package dependencies
 RUN apt-get update \

--- a/contrib/docker/Dockerfile.fpm
+++ b/contrib/docker/Dockerfile.fpm
@@ -8,70 +8,68 @@ WORKDIR /var/www/
 COPY --from=composer:2.6 /usr/bin/composer /usr/bin/composer
 
 # Install package dependencies
-RUN apt-get update \
-  && apt-get upgrade -y \
-#  && apt-get install -y --no-install-recommends apt-utils \
-  && apt-get install -y --no-install-recommends \
-## Standard
-      locales \
-      locales-all \
-      git \
-      gosu \
-      zip \
-      unzip \
-      libzip-dev \
-      libcurl4-openssl-dev \
-## Image Optimization
-      optipng \
-      pngquant \
-      jpegoptim \
-      gifsicle \
-## Image Processing
-      libjpeg62-turbo-dev \
-      libpng-dev \
-      libmagickwand-dev \
-# Required for GD
-      libxpm4 \
-      libxpm-dev \
-      libwebp7 \
-      libwebp-dev \
-## Video Processing
-      ffmpeg \
-## Database
-#      libpq-dev \
-#      libsqlite3-dev \
-      mariadb-client \
-# Locales Update
+RUN \
+  # Apt update & upgrade to check for security updates to Debian image
+  apt-get update; \
+  apt-get dist-upgrade -yq; \
+  # Install other necessary components
+  apt-get install -y --no-install-recommends \
+  ## Standard
+  wget \
+  locales \
+  locales-all \
+  git \
+  gosu \
+  zip \
+  unzip \
+  libzip-dev \
+  libcurl4-openssl-dev \
+  ## Image Optimization
+  optipng \
+  pngquant \
+  jpegoptim \
+  gifsicle \
+  ## Image Processing
+  libjpeg62-turbo-dev \
+  libpng-dev \
+  libmagickwand-dev \
+  # Required for GD
+  libxpm4 \
+  libxpm-dev \
+  libwebp-dev \
+  ## Video Processing
+  ffmpeg \
+  ## Database
+  libpq-dev \
+  libsqlite3-dev \
+  mariadb-client \
+  # Locales Update
   && sed -i '/en_US/s/^#//g' /etc/locale.gen \
   && locale-gen \
   && update-locale \
-# Install PHP extensions
+  # Install PHP extensions
   && docker-php-source extract \
-#PHP Imagemagick extensions
+  #PHP Imagemagick extensions
   && pecl install imagick \
   && docker-php-ext-enable imagick \
-# PHP GD extensions
+  # PHP GD extensions
   && docker-php-ext-configure gd \
-      --with-freetype \
-      --with-jpeg \
-      --with-webp \
-      --with-xpm \
+  --with-freetype \
+  --with-jpeg \
+  --with-webp \
+  --with-xpm \
   && docker-php-ext-install -j$(nproc) gd \
-#PHP Redis extensions
+  #PHP Redis extensions
   && pecl install redis \
   && docker-php-ext-enable redis \
-#PHP Database extensions
+  #PHP Database extensions
   && docker-php-ext-install pdo_mysql \
-#pdo_pgsql pdo_sqlite \
-#PHP extensions (dependencies)
+  #pdo_pgsql pdo_sqlite \
+  #PHP extensions (dependencies)
   && docker-php-ext-configure intl \
   && docker-php-ext-install -j$(nproc) intl bcmath zip pcntl exif curl \
-#Cleanup
-  && docker-php-source delete \
-  && apt-get autoremove --purge -y \
-  && apt-get clean \
-  && rm -rf /var/cache/apt \
-  && rm -rf /var/lib/apt/lists/
+  #Cleanup
+  && docker-php-source delete
 
 # Use the default production configuration
 COPY contrib/docker/php.production.ini "$PHP_INI_DIR/php.ini"
@@ -87,4 +85,4 @@ RUN php artisan horizon:publish
 
 VOLUME /var/www/storage /var/www/bootstrap
 
-CMD ["/var/www/contrib/docker/start.fpm.sh"]
+CMD [ "/var/www/contrib/docker/start.fpm.sh" ]

--- a/contrib/docker/Dockerfile.fpm
+++ b/contrib/docker/Dockerfile.fpm
@@ -1,11 +1,11 @@
-FROM php:8.1-fpm-bullseye
+FROM php:8.2-fpm-bullseye
 
 ENV COMPOSER_MEMORY_LIMIT=-1
 ARG DEBIAN_FRONTEND=noninteractive
 WORKDIR /var/www/
 
 # Get Composer binary
-COPY --from=composer:2.4.4 /usr/bin/composer /usr/bin/composer
+COPY --from=composer:2.6 /usr/bin/composer /usr/bin/composer
 
 # Install package dependencies
 RUN apt-get update \

--- a/contrib/nginx.conf
+++ b/contrib/nginx.conf
@@ -31,7 +31,7 @@ server {
 
     location ~ \.php$ {
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/var/run/php/php8.1-fpm.sock;
+        fastcgi_pass unix:/var/run/php/php8.2-fpm.sock;
         fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
         fastcgi_param   QUERY_STRING        $query_string;
         fastcgi_param   REQUEST_METHOD      $request_method;


### PR DESCRIPTION
See the two individual commits for details; Unfortunately some auto-formatting happened on the dockerfiles so they're a little hard to compare. I've basically removed libwebp7 as a dependency, added wget, enabled the additional database drivers, and changed `apt-get upgrade` to `apt-get dist-upgrade`

Along side this, I took the opportunity to update composer and php to 2.6 and 8.2 respectively. PHP 8.3 isn't compatible with imagick at this time.