### PR TITLE
fix: video upload broken

### DIFF
--- a/app/Http/Controllers/ComposeController.php
+++ b/app/Http/Controllers/ComposeController.php
@@ -542,7 +542,7 @@ class ComposeController extends Controller
 
 		$mediaType = StatusController::mimeTypeCheck($mimes);
 
-		if(in_array($mediaType, ['photo', 'video', 'photo:album']) == false) {
+		if(in_array($mediaType, ['photo', 'video', 'photo:album', 'video:album', 'photo:video:album']) == false) {
 			abort(400, __('exception.compose.invalid.album'));
 		}
 


### PR DESCRIPTION
This fixes the upload of:
- multiple videos
- multiple photos + videos

The `ComposeController.php` only checks for the possible media types "photo", "video" and "photo:album". The types "video:album" and "photo:video:album" are missing here.

I added these types to allow for the upload of multiple videos in a single post and mixed posts with photos & videos.