### PR TITLE
Pixelfed as cross-domain Openwebauth server

### DIFF
--- a/app/Http/Controllers/OpenWebAuthController.php
+++ b/app/Http/Controllers/OpenWebAuthController.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Services\BouncerService;
+
+class OpenWebAuthController extends Controller
+{
+    public function showLoginForm() {
+
+		if(config('pixelfed.bouncer.cloud_ips.ban_logins')) {
+			abort_if(BouncerService::checkIp(request()->ip()), 404);
+		}
+
+        return view('auth.openwebauth');
+    }
+
+    public function openWebAuth(Request $request) {
+        $handle = $request->input('handle');
+
+        \Log::debug('Entered web-based remote openweb authentication for handle ' . $handle);
+        return redirect('/?zid=' . $handle);
+    }
+}

--- a/app/Http/Controllers/OwaController.php
+++ b/app/Http/Controllers/OwaController.php
@@ -1,0 +1,308 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+
+use App\Profile;
+
+use App\Services\WebfingerService;
+
+class OwaController extends Controller
+{
+    /**
+     * Handle the incoming request.
+     */
+    public function __invoke(Request $request)
+    {
+	    \Log::info('Owa controller invoked');
+
+	    $ret_response = [ 'success' => false ];
+
+	    $auth_header = $request->header('Authorization');
+	    \Log::debug('Auth header: ' . print_r($auth_header, true));
+
+	    if (!str_starts_with(trim($auth_header), 'Signature')) {
+		    \Log::debug('Missing Signature Authorization header, auth header = ' . print_r($auth_header, true));
+		    return response()->json($ret_response);
+	    }
+	    $sigblock = self::parse_sigheader($auth_header);
+
+	    if ($sigblock) {
+		    \Log::debug('Signature block parsed OK');
+		    $keyId = $sigblock['keyId'];
+		    \Log::debug('KeyId = ' . print_r($keyId, true));
+		    if ($keyId) {
+			    // try to find user by keyId
+			    $keyId = str_replace('acct:', '', $keyId);
+
+                // strip all fragments and query parameters from the key_id
+                $parsed = parse_url($keyId);
+                if (str_starts_with($parsed['scheme'],'http')) {
+                    unset($parsed['fragment']);
+                    unset($parsed['query']);
+                    $keyId = self::unparse_url($parsed);
+                }
+                else {
+                    $keyId = str_replace('acct:', '', $keyId);
+                }
+
+			    \Log::debug('Looking for user with matching keyId ' . print_r($keyId, true));
+			    $r = Profile::where('remote_url', $keyId)->first();
+			    \Log::debug('Found profile: ' . print_r($r, true));
+			    if (!$r) {
+				    // discover for no pre-existing relationship or keyId does not match a remote URL
+				    // The principals involved in the authentication may or may not have any pre-existing relationship
+				    \Log::debug('Profile not found => discover resource');
+
+				    $wf_account = WebfingerService::lookup($keyId);
+				    \Log::debug('Webfinger returned ' . print_r($wf_account, true));
+
+				    $r = Profile::where('remote_url', $keyId /*$wf_account['url']*/)->first();
+				    \Log::debug('Found profile: ' . print_r($r, true));
+
+				    if (!$r) {
+					    \Log::debug('Not found - returning success = false');    
+					    return response()->json($ret_response);
+				    }
+			    }
+			    // verify the signature header
+			    $verified = self::sig_verify($request, $sigblock, $keyId, $r->public_key);
+			    \Log::debug('Verification output: ' . print_r($verified, true));
+				if ($verified && $verified['header_signed'] && $verified['header_valid'] && ($verified['content_valid'] || (!$verified['content_signed']))) {
+				    $ret_response['success'] = true;
+				    $token = self::random_string(32);
+				    DB::insert('INSERT into owa_verifications (token, remote_url, created_at) values (?,?,?)', [$token, $r->remote_url, now()]);
+				    $result = '';
+				    openssl_public_encrypt($token, $result, $r->public_key);
+				    $ret_response['encrypted_token'] = self::base64url_encode($result);
+				} else {
+				    \Log::info('OWA fail for ' . $r->remote_url);
+				}
+
+		    }
+	    }
+
+	    return response()->json($ret_response);
+    }
+
+    // this should probably belong in a HTTP Signature helper
+    /**
+     * @brief
+     *
+     * @param string $header
+     * @return array associate array with
+     *   - \e string \b keyID
+     *   - \e string \b algorithm
+     *   - \e array  \b headers
+     *   - \e string \b signature
+     */
+    private function parse_sigheader($header) {
+        $ret = [];
+        $matches = [];
+
+        if (preg_match('/keyId="(.*?)"/ism', $header, $matches)) {
+            $ret['keyId'] = $matches[1];
+        }
+        if (preg_match('/created=([0-9]*)/ism', $header, $matches)) {
+            $ret['(created)'] = $matches[1];
+        }
+        if (preg_match('/expires=([0-9]*)/ism', $header, $matches)) {
+            $ret['(expires)'] = $matches[1];
+        }
+        if (preg_match('/algorithm="(.*?)"/ism', $header, $matches)) {
+            $ret['algorithm'] = $matches[1];
+        }
+        if (preg_match('/headers="(.*?)"/ism', $header, $matches)) {
+            $ret['headers'] = explode(' ', $matches[1]);
+        }
+        if (preg_match('/signature="(.*?)"/ism', $header, $matches)) {
+            $ret['signature'] = base64_decode(preg_replace('/\s+/', '', $matches[1]));
+        }
+
+        if (($ret['signature']) && ($ret['algorithm']) && (!$ret['headers'])) {
+            $ret['headers'] = ['date'];
+        }
+
+        return $ret;
+    }
+
+    // See draft-cavage-http-signatures-10
+    private function sig_verify($request, $sig_block = null, $signer = null, $public_key = '') {
+        \Log::debug('Trying to verify the signature now...');
+        $result = [
+            'signer' => '',
+            'portable_id' => '',
+            'header_signed' => false,
+            'header_valid' => false,
+            'content_signed' => false,
+            'content_valid' => false
+        ];
+
+        // we have the headers already in the request, but we need to add the pseudo-header (request-target) again
+        $request->headers->add([ '(request-target)' => strtolower($request->method()) . ' /' . $request->path() ]);
+
+        if (is_null($sig_block)) {
+            $header_sig = $request->header('Signature');
+            $header_auth = $request->header('Authorization');
+            if ($header_sig) {
+                $sig_block = self::parse_sigheader($header_sig);
+            } elseif ($header_auth) {
+                $sig_block = self::parse_sigheader($header_auth);
+            }
+            if (!$sig_block) {
+                \Log::info('no signature provided.');
+                return $result;
+            }
+        }
+
+        $result['header_signed'] = true;
+
+        $signed_headers = $sig_block['headers'];
+        if (!$signed_headers) {
+            $signed_headers = ['date'];
+        }
+
+        \Log::debug('Signed headers: ' . print_r($signed_headers, true));
+        $signed_data = '';
+        foreach ($signed_headers as $h) {
+            $h_val = $request->header($h);
+            \Log::debug('Checking header ' . print_r($h, true) . ' = ' . print_r($h_val, true));
+            if ($h_val) {
+                $signed_data .= $h . ': ' . $h_val . "\n";
+            }
+            if ($h === '(created)') {
+                if ((!isset($sig_block['(created)'])) || (!intval($sig_block['(created)'])) || intval($sig_block['(created)']) > time()) {
+                    \Log::debug('created in future');
+                    return $result;
+                }
+                $signed_data .= '(created): ' . $sig_block['(created)'] . "\n";
+            }
+            if ($h === '(expires)') {
+                if ((!isset($sig_block['(expires)'])) || (!intval($sig_block['(expires)'])) || intval($sig_block['(expires)']) < time()) {
+                    \Log::debug('signature expired');
+                    return $result;
+                }
+                $signed_data .= '(expires): ' . $sig_block['(expires)'] . "\n";
+            }
+            if ($h === 'date') {
+                $d = new DateTime($headers[$h]);
+                $d->setTimeZone(new DateTimeZone('UTC'));
+                $dplus = datetime_convert('UTC', 'UTC', 'now + 1 day');
+                $dminus = datetime_convert('UTC', 'UTC', 'now - 1 day');
+                $c = $d->format('Y-m-d H:i:s');
+                if ($c > $dplus || $c < $dminus) {
+                    \Log::debug('bad time: ' . $c);
+                    return $result;
+                }
+            }
+        }
+        $signed_data = rtrim($signed_data, "\n");
+        \Log::debug('Signed data : ' . print_r($signed_data, true));
+
+        $algorithm = null;
+
+        if ($sig_block['algorithm'] === 'rsa-sha256') {
+            $algorithm = 'sha256';
+        }
+        if ($sig_block['algorithm'] === 'rsa-sha512') {
+            $algorithm = 'sha512';
+        }
+
+        if (!array_key_exists('keyId', $sig_block)) {
+            return $result;
+        }
+
+        if (is_null($signer) && str_starts_with($sig_block['keyId'], 'http')) {
+            $parsed = parse_url($sig_block['keyId']);
+            unset($parsed['query']);
+	        unset($parsed['fragment']);
+            $signer = self::unparse_url($parsed);
+        }
+        \Log::debug('signer: ' . print_r($signer, true));
+
+        $result['signer'] = $signer;
+        $fkey = [];
+            $fkey['public_key'] = $public_key;
+            if (!($fkey && $fkey['public_key'])) {
+                return $result;
+            }
+
+        \Log::debug('Going to crypto verify the signature now...');	
+        $x = self::crypto_verify($signed_data, $sig_block['signature'], $fkey['public_key'], $algorithm);
+
+        \Log::info('verified: ' . intval($x));
+
+        if (!$x) {
+            \Log::debug('Verify failed');
+            return $result;
+        }
+
+        $result['header_valid'] = true;
+
+        return $result;
+    }
+
+    private function crypto_verify($data, $sig, $key, $alg = 'sha256')
+    {
+
+        \Log::debug('Crypto verify: data = ' . print_r($data ,true) . ' / key = ' . print_r($key, true) . ' / alg = ' . print_r($alg, true));
+        if (! $key) {
+            return false;
+        }
+        // check for passed/provided $alg that is empty
+        if (! $alg) {
+            $alg = 'sha256';
+        }
+
+        try {
+            $verify = openssl_verify($data, $sig, $key, $alg);
+        } catch (Exception $e) {
+            $verify = (-1);
+        }
+
+        if ($verify === (-1)) {
+            while ($msg = openssl_error_string()) {
+                \Log::debug('openssl_verify: ' . $msg);
+            }
+            \Log::debug('openssl_verify: key: ' . $key);
+        }
+
+        return (($verify > 0) ? true : false);
+    }
+
+    private function random_string($size = 64)
+	{
+	    // generate a bit of entropy and run it through the whirlpool
+	    $s = hash('whirlpool', rand() . uniqid(rand(), true) . rand(), false);
+
+	    return(substr($s, 0, $size));
+	}
+
+    private function base64url_encode($s, $strip_padding = true)
+	{
+
+	    $s = strtr(base64_encode($s), '+/', '-_');
+
+	    if ($strip_padding) {
+		$s = str_replace('=', '', $s);
+	    }
+
+	    return $s;
+	}
+
+    private function unparse_url($parsed_url)
+    {
+        $scheme   = isset($parsed_url['scheme']) ? $parsed_url['scheme'] . '://' : '';
+        $host     = isset($parsed_url['host']) ? $parsed_url['host'] : '';
+        $port     = ((isset($parsed_url['port']) && intval($parsed_url['port'])) ? ':' . intval($parsed_url['port']) : '');
+        $user     = isset($parsed_url['user']) ? $parsed_url['user'] : '';
+        $pass     = isset($parsed_url['pass']) ? ':' . $parsed_url['pass']  : '';
+        $pass     = ($user || $pass) ? "$pass@" : '';
+        $path     = isset($parsed_url['path']) ? $parsed_url['path'] : '';
+        $query    = isset($parsed_url['query']) ? '?' . $parsed_url['query'] : '';
+        $fragment = isset($parsed_url['fragment']) ? '#' . $parsed_url['fragment'] : '';
+        return "$scheme$user$pass$host$port$path$query$fragment";
+    }
+}

--- a/app/Http/Controllers/OwaController.php
+++ b/app/Http/Controllers/OwaController.php
@@ -59,7 +59,7 @@ class OwaController extends Controller
 				    $wf_account = WebfingerService::lookup($keyId);
 				    \Log::debug('Webfinger returned ' . print_r($wf_account, true));
 
-				    $r = Profile::where('remote_url', $keyId /*$wf_account['url']*/)->first();
+				    $r = Profile::where('remote_url', $keyId)->first();
 				    \Log::debug('Found profile: ' . print_r($r, true));
 
 				    if (!$r) {
@@ -87,7 +87,6 @@ class OwaController extends Controller
 	    return response()->json($ret_response);
     }
 
-    // this should probably belong in a HTTP Signature helper
     /**
      * @brief
      *
@@ -251,7 +250,6 @@ class OwaController extends Controller
         if (! $key) {
             return false;
         }
-        // check for passed/provided $alg that is empty
         if (! $alg) {
             $alg = 'sha256';
         }

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -38,6 +38,8 @@ class Kernel extends HttpKernel
             \App\Http\Middleware\VerifyCsrfToken::class,
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
             \Laravel\Passport\Http\Middleware\CreateFreshApiToken::class,
+            \App\Http\Middleware\AttemptRemoteAuthentication::class,
+            \App\Http\Middleware\ValidateRemoteAuthentication::class,
             // 'restricted',
         ],
 

--- a/app/Http/Middleware/AttemptRemoteAuthentication.php
+++ b/app/Http/Middleware/AttemptRemoteAuthentication.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+use App\Profile;
+use App\Services\FollowerService;
+
+class AttemptRemoteAuthentication
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+	\Log::info('In handler for Remote Authentication Attempt');
+	$zid = $request->query('zid');
+	if (!isset($zid) || preg_match('/^.+@.+$/i', $zid) === false) {
+		return $next($request);
+	}
+	// strip possible leading "@" to get typical user@domain handle
+	if (strncmp($zid, '@', 1) !== 0) {
+		$zid = '@' . $zid;
+	}
+	\Log::info('Remote user (zid) = ' . print_r($zid, true));
+	$fullUrl = $request->fullUrlWithoutQuery(['zid']);
+	\Log::debug('Full url = ' . $fullUrl);
+	$remoteDest = $fullUrl;
+
+	// TODO this would make it impossible for remote destination like https://magic.example.com
+	if (strstr($remoteDest, '/magic')) {
+		\Log::info('Destination already contains the /magic endpoint - avoiding recursion - not going to attempt remote auth');
+		return $next($request);
+	}
+	\Log::info('dest = ' . print_r($remoteDest, true));
+	$domain = substr(strrchr($zid, '@'), 1);
+	$remoteUrl = 'https://' . $domain . '/magic' . '?f=&rev=1&owa=1&bdest=' . bin2hex($remoteDest);
+	\Log::info('Remote url = ' . print_r($remoteUrl, true));
+
+	return redirect()->away($remoteUrl);
+    }
+}

--- a/app/Http/Middleware/AttemptRemoteAuthentication.php
+++ b/app/Http/Middleware/AttemptRemoteAuthentication.php
@@ -32,7 +32,7 @@ class AttemptRemoteAuthentication
 	\Log::debug('Remote destination = ' . $remoteDest);
 
     $path = parse_url($remoteDest, PHP_URL_PATH);
-	if (str_starts_with($path, '/magic')) {
+	if ($path == '/magic') {
 		\Log::info('Destination already contains the /magic endpoint - avoiding recursion - not going to attempt remote auth');
 		return $next($request);
 	}

--- a/app/Http/Middleware/ValidateRemoteAuthentication.php
+++ b/app/Http/Middleware/ValidateRemoteAuthentication.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Auth;
+
+use App\Profile;
+use App\User;
+
+class ValidateRemoteAuthentication
+{
+
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        \Log::info('In handler for Remote Authentication Validation based on token');
+		$owt = $request->query('owt');
+        if (!isset($owt)) {
+                return $next($request);
+		}
+
+		// https://codeberg.org/streams/streams/src/branch/dev/spec/OpenWebAuth/Home.md
+		//  The OpenWebAuth token service MUST discard tokens after first use and SHOULD discard unused tokens within a few minutes of generation.
+		\Log::debug('owt token provided');
+		// purge tokens older than 3 minutes
+		self::purge(3);
+		// find out which user to log in based on owt token
+		$owtMatchDb = DB::table('owa_verifications')->where('token', $owt);
+		$r = $owtMatchDb->first();
+		if (!$r) {
+			\Log::info('Token not found');
+			return next($request);
+		}
+		$owtMatchDb->delete();
+		
+		\Log::debug('Found this as token in our DB: ' . print_r($r, true));
+		$remote_profile = $r->remote_url;	
+		
+		\Log::debug('Trying to log in in as ' . $remote_profile);
+		$p = Profile::where('remote_url', $remote_profile)->first();
+		if (!$p) {
+			\Log::info('Failed to locate the profile in DB');
+			return next($request);
+		}
+
+		$username = $p->username;
+		\Log::info('Trying to log in username ' . $username);
+
+		$user = User::whereUsername($username)->first();
+		if (!$user) {
+			\Log::info('User not found as an OpenWebAuth visitor - adding now');
+			$user = User::create([ 
+				'username' => $username,
+				'name' => $p->name,
+				'email' => $username,  // not an email address but a unique id must be filled as email in the DB
+				'password' => substr(str_shuffle('0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'), 0, 32), // password cannot be NULL
+			]);
+
+			// these attributes are not mass assignable so saving them here separately
+			$user->register_source = 'owa';
+			$user->profile_id = $p->id;
+			$user->save();
+
+			$p->user_id = $user->id;
+			$p->save();
+		} else {
+			if ($user->register_source === 'owa') {
+				\Log::info('User found as a visitor');
+			} else {
+				\Log::info('User found with register source = ' . $user->register_source);
+			}
+		}
+
+		\Log::info('Logging user <' . $user->name . '> in now');
+		Auth::login($user);
+		\Log::info('user logged in');
+
+		// avoid session fixation attack by regenerating a new session ID
+		$request->session()->regenerate();
+
+		return $next($request);
+    }
+
+    private function purge($minutes) {
+	    $purged = DB::table('owa_verifications')->where('created_at', '<', now()->subMinutes($minutes)->toDateTimeString())->delete();
+	    \Log::debug('Purged ' . print_r($purged, true) . ' token(s)');
+    }
+}

--- a/app/Http/Middleware/VerifyCsrfToken.php
+++ b/app/Http/Middleware/VerifyCsrfToken.php
@@ -12,6 +12,7 @@ class VerifyCsrfToken extends Middleware
      * @var array
      */
     protected $except = [
-        '/api/v1/*'
+        '/api/v1/*',
+        '/owa'
     ];
 }

--- a/app/Util/ActivityPub/Helpers.php
+++ b/app/Util/ActivityPub/Helpers.php
@@ -183,16 +183,9 @@ class Helpers {
                 return false;
             }
 
-            // a valid URL could contain '://' twice like in a webfinger URL for a web resource
-            // "exactly once" is true in case of Mastodon, but not in all cases
-            // e.g. https://example.tld/.well-known/webfinger?resource=https://example.tld/user/joe is correct
-            // so the generic test should be "at least once"
-            // now this test becomes redundant given the check just above for "https://"
-            /*
             if(substr_count($url, '://') !== 1) {
                 return false;
             }
-            */
 
             if(mb_substr($url, 0, 8) !== 'https://') {
                 $url = 'https://' . substr($url, 8);

--- a/app/Util/ActivityPub/Helpers.php
+++ b/app/Util/ActivityPub/Helpers.php
@@ -183,9 +183,16 @@ class Helpers {
                 return false;
             }
 
+            // a valid URL could contain '://' twice like in a webfinger URL for a web resource
+            // "exactly once" is true in case of Mastodon, but not in all cases
+            // e.g. https://example.tld/.well-known/webfinger?resource=https://example.tld/user/joe is correct
+            // so the generic test should be "at least once"
+            // now this test becomes redundant given the check just above for "https://"
+            /*
             if(substr_count($url, '://') !== 1) {
                 return false;
             }
+            */
 
             if(mb_substr($url, 0, 8) !== 'https://') {
                 $url = 'https://' . substr($url, 8);

--- a/app/Util/Webfinger/Webfinger.php
+++ b/app/Util/Webfinger/Webfinger.php
@@ -11,7 +11,8 @@ class Webfinger
 
 	public function __construct($user)
 	{
-		$this->subject = 'acct:'.$user->username.'@'.parse_url(config('app.url'), PHP_URL_HOST);
+		$baseurl = config('app.url');
+		$this->subject = 'acct:'.$user->username.'@'.parse_url($baseurl, PHP_URL_HOST);
 		$this->aliases = [
 			$user->url(),
 			$user->permalink(),
@@ -31,6 +32,16 @@ class Webfinger
 				'rel'  => 'self',
 				'type' => 'application/activity+json',
 				'href' => $user->permalink(),
+			],
+			[
+				'rel'  => 'http://purl.org/openwebauth/v1',
+				'type' => 'application/json',
+				'href' => $baseurl . '/owa',
+			],
+			[
+				'rel'  => 'http://purl.org/openwebauth/v1#redirect',
+				'type' => 'application/json',
+				'href' =>  $baseurl . '/magic',
 			],
 		];
 	}

--- a/app/Util/Webfinger/WebfingerUrl.php
+++ b/app/Util/Webfinger/WebfingerUrl.php
@@ -8,11 +8,33 @@ class WebfingerUrl
 {
     public static function generateWebfingerUrl($url)
     {
-        $url = Nickname::normalizeProfileUrl($url);
-        $domain = $url['domain'];
-        $username = $url['username'];
-        $path = "https://{$domain}/.well-known/webfinger?resource=acct:{$username}@{$domain}";
+        $handle = Nickname::normalizeProfileUrl($url);
+        if (is_array($handle)) {
+            // the url was a user handle
+            $domain = $handle['domain'];
+            $username = $handle['username'];
+            $resource = "acct:{$username}@{$domain}";
+        } else {
+            // it could be an actual URL https://domain/endpoint
+            $resource = $url;
+            if (str_starts_with($resource, 'http')) {
+                $m = parse_url($resource);
+                if ($m) {
+                    if ($m['scheme'] !== 'https') {
+                        return false;
+                    }
+                    if (!array_key_exists('host', $m)) {
+                        return false;
+                    }
+                    $domain = $m['host'] . (array_key_exists('port', $m) ? ':' . $m['port'] : '');
+                } else {
+                    return false;
+                }
+            }
 
+        }
+
+        $path = "https://{$domain}/.well-known/webfinger?resource={$resource}";
         return $path;
     }
 }

--- a/app/Util/Webfinger/WebfingerUrl.php
+++ b/app/Util/Webfinger/WebfingerUrl.php
@@ -31,8 +31,11 @@ class WebfingerUrl
                     return false;
                 }
             }
+            $resource = urlencode($resource);
 
         }
+
+        \Log::debug('WebfingerUrl generated resource = ' . $resource);
 
         $path = "https://{$domain}/.well-known/webfinger?resource={$resource}";
         return $path;

--- a/database/migrations/2023_12_03_create_owa_verifications_table.php
+++ b/database/migrations/2023_12_03_create_owa_verifications_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+	Schema::create('owa_verifications', function (Blueprint $table) {
+		$table->string('token')->index();
+		$table->string('remote_url');
+		$table->timestamp('created_at');
+	});	
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('owa_verifications'); 
+    }
+};

--- a/resources/assets/components/partials/navbar.vue
+++ b/resources/assets/components/partials/navbar.vue
@@ -230,7 +230,7 @@
 													</div>
 												</router-link>
 
-												<router-link class="nav-link text-center px-3" :to="'/i/web/profile/' + user.id">
+												<router-link v-if="canEditProfile" class="nav-link text-center px-3" :to="'/i/web/profile/' + user.id">
 													<div class="icon text-lighter">
 														<i class="far fa-user"></i>
 													</div>
@@ -240,7 +240,7 @@
 											<hr class="mb-0" style="margin-top: -5px;opacity: 0.4;" />
 										</li>
 
-										<li class="nav-item">
+										<li v-if="canCompose" class="nav-item">
 											<router-link class="nav-link" to="/i/web/compose">
 												<span class="icon text-lighter"><i class="far fa-plus-square"></i></span>
 												{{ $t('navmenu.compose') }}
@@ -254,7 +254,7 @@
 											</router-link>
 										</li> -->
 
-										<li class="nav-item">
+										<li v-if="canAccessDirectMessages" class="nav-item">
 											<router-link class="nav-link d-flex justify-content-between align-items-center" to="/i/web/direct">
 												<span>
 													<span class="icon text-lighter">
@@ -305,7 +305,7 @@
 											</a>
 										</li>
 
-										<li class="nav-item">
+										<li v-if="canSwitchToOldUI" class="nav-item">
 											<hr class="mt-n1" style="opacity: 0.4;margin-bottom: 0;" />
 											<a class="nav-link" href="/">
 												<span class="icon text-lighter">
@@ -446,7 +446,12 @@
 				user: window._sharedData.user,
 				profileLayoutModel: 'grid',
 				hasLocalTimeline: true,
-				hasNetworkTimeline: false
+				hasNetworkTimeline: false,
+				canEditProfile: true,
+				canCompose: true,
+				canViewDirectMessages: true,
+				canSwitchToOldUI: true,
+				canAccessDirectMessages: true 
 			}
 		},
 
@@ -526,6 +531,14 @@
 			}
 
 			this.brandName = window.App.config.site.name;
+
+			if (this.user.register_source == 'owa') {
+				this.canEditProfile = false;
+				this.canCompose = false;
+				this.canViewDirectMessages = false;
+				this.canSwitchToOldUI = false;
+				this.canAccessDirectMessages = false;
+			} 
 		},
 
 		methods: {

--- a/resources/assets/components/partials/profile/ProfileHoverCard.vue
+++ b/resources/assets/components/partials/profile/ProfileHoverCard.vue
@@ -3,8 +3,8 @@
 		<div class="profile-hover-card-inner">
 			<div class="d-flex justify-content-between align-items-start" style="max-width: 240px;">
 				<a
-					:href="profile.url"
-					@click.prevent="goToProfile()">
+					:href="canEditProfile && profile.url"
+					@click.prevent="canEditProfile && goToProfile()">
 					<img
 						:src="profile.avatar"
 						width="50"
@@ -13,11 +13,11 @@
 						onerror="this.onerror=null;this.src='/storage/avatars/default.png?v=0';">
 				</a>
 
-				<div v-if="user.id == profile.id">
+				<div v-if="canEditProfile && (user.id == profile.id)">
 					<a class="btn btn-outline-primary px-3 py-1 font-weight-bold rounded-pill" href="/settings/home">Edit Profile</a>
 				</div>
 
-				<div v-if="user.id != profile.id && relationship">
+				<div v-if="canUpdateFollowing && (user.id != profile.id && relationship)">
 					<button
 						v-if="relationship.following"
 						class="btn btn-outline-primary px-3 py-1 font-weight-bold rounded-pill"
@@ -42,17 +42,17 @@
 
 			<p class="display-name">
 				<a
-					:href="profile.url"
-					@click.prevent="goToProfile()"
+					:href="canOpenRemoteProfile && profile.url"
+					@click.prevent="canOpenRemoteProfile && goToProfile()"
 					v-html="getDisplayName()">
 				</a>
 			</p>
 
 			<div class="username">
 				<a
-					:href="profile.url"
+					:href="canOpenRemoteProfile && profile.url"
 					class="username-link"
-					@click.prevent="goToProfile()">
+					@click.prevent="canOpenRemoteProfile && goToProfile()">
 					&commat;{{ getUsername() }}
 				</a>
 
@@ -106,7 +106,10 @@
 				user: window._sharedData.user,
 				bio: undefined,
 				isLoading: false,
-				relationship: undefined
+				relationship: undefined,
+				canEditProfile: true,
+				canUpdateFollowing: true,
+				canOpenRemoteProfile: true
 			};
 		},
 
@@ -123,6 +126,12 @@
 					this.relationship = res.data[0];
 					this.$store.commit('updateRelationship', res.data);
 				})
+			}
+
+			if (this.user.register_source == 'owa') {
+				this.canEditProfile = false;
+				this.canUpdateFollowing = false;
+				this.canOpenRemoteProfile = false;
 			}
 		},
 

--- a/resources/assets/components/partials/sidebar.vue
+++ b/resources/assets/components/partials/sidebar.vue
@@ -6,8 +6,8 @@
 			<div class="card-body p-2">
 				<div class="media user-card user-select-none">
 					<div style="position: relative;">
-						<img :src="user.avatar" class="avatar shadow cursor-pointer" draggable="false" onerror="this.onerror=null;this.src='/storage/avatars/default.png?v=0';" @click="gotoMyProfile()">
-						<button class="btn btn-light btn-sm avatar-update-btn" @click="updateAvatar()">
+						<img :src="user.avatar" :class="canEditProfile ? 'avatar shadow cursor-pointer' : 'avatar shadow'" draggable="false" onerror="this.onerror=null;this.src='/storage/avatars/default.png?v=0';" @click="canEditProfile && gotoMyProfile()">
+						<button v-if="canUpdateAvatar" class="btn btn-light btn-sm avatar-update-btn" @click="updateAvatar()">
 							<span class="avatar-update-btn-icon"></span>
 						</button>
 					</div>
@@ -27,7 +27,7 @@
 			</div>
 		</div>
 
-		<div class="btn-group btn-group-lg btn-block mb-4">
+		<div v-if="canCompose" class="btn-group btn-group-lg btn-block mb-4">
 			<!-- <button type="button" class="btn btn-outline-primary btn-block font-weight-bold" style="border-top-left-radius: 18px;border-bottom-left-radius:18px;font-size:18px;font-weight:300!important" @click="createNewPost()">
 				<i class="fal fa-arrow-circle-up mr-1"></i> {{ $t('navmenu.compose') }} Post
 			</button> -->
@@ -119,7 +119,7 @@
 					</router-link>
 				</li>
 
-				<li class="nav-item">
+				<li v-if="canViewDirectMessages" class="nav-item">
 					<router-link class="nav-link d-flex justify-content-between align-items-center" to="/i/web/direct">
 						<span>
 							<span class="icon text-lighter">
@@ -163,7 +163,7 @@
 					</router-link>
 				</li>
 
-				<li class="nav-item">
+				<li v-if="canEditProfile" class="nav-item">
 					<hr class="mt-n1" style="opacity: 0.4;margin-bottom: 0;" />
 
 					<router-link class="nav-link" :to="'/i/web/profile/' + user.id">
@@ -214,7 +214,7 @@
 					</a>
 				</li>
 
-				<li class="nav-item">
+				<li v-if="canSwitchToOldUI" class="nav-item">
 					<hr class="mt-n1" style="opacity: 0.4;margin-bottom: 0;" />
 					<a class="nav-link" href="/?force_old_ui=1">
 						<span class="icon text-lighter">
@@ -426,6 +426,11 @@
 				hasNetworkTimeline: false,
 				hasLiveStreams: false,
                 hasStories: false,
+				canEditProfile: true,
+				canUpdateAvatar: true,
+				canCompose: true,
+				canViewDirectMessages: true,
+				canSwitchToOldUI: true,
 			}
 		},
 
@@ -438,6 +443,14 @@
             if(window.App.config.features.hasOwnProperty('stories')) {
                 this.hasStories = App.config.features.stories;
             }
+			if (this.user.register_source == 'owa') {
+				this.canEditProfile = false;
+				this.canUpdateAvatar = false;
+				this.canCompose = false;
+				this.canViewDirectMessages = false;
+				this.hasLiveStreams = false;
+				this.canSwitchToOldUI = false;
+			} 
 			// if(!this.user.username) {
 			// 	this.user = window._sharedData.user;
 			// }

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -70,6 +70,9 @@
                                     {{ __('Login') }}
                                 </button>
 
+                                <a href="/openwebauth" class="btn btn-success btn-block btn-lg font-weight-bold">
+                                    {{ __('Remote Open Web Authentication') }}
+                                </a>
                             </div>
                         </div>
 

--- a/resources/views/auth/openwebauth.blade.php
+++ b/resources/views/auth/openwebauth.blade.php
@@ -1,0 +1,34 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container mt-4">
+    <div class="row justify-content-center">
+        <div class="col-lg-5">
+            <div class="">
+                <div class="card-header bg-transparent p-3 text-center font-weight-bold h3">{{ __('Remote OpenWeb Authentication') }}</div>
+
+                <div class="card-body">
+                    <form method="POST" action="{{ route('openwebauth') }}">
+                        @csrf
+
+                        <div class="form-group row">
+
+                            <div class="col-md-12">
+                                <input name="handle" type="email" class="form-control" placeholder="{{__('Fediverse handle e.g. me@example.org')}}" required autofocus>
+                            </div>
+                        </div>
+
+                        <div class="form-group row mb-0">
+                            <div class="col-md-12">
+                                <button type="submit" class="btn btn-primary btn-block btn-lg font-weight-bold">
+                                    {{ __('Enter') }}
+                                </button>
+                            </div>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection

--- a/resources/views/layouts/spa.blade.php
+++ b/resources/views/layouts/spa.blade.php
@@ -29,7 +29,7 @@
 	<script type="text/javascript">
 		window._sharedData = {
 			curUser: {},
-			user: {!! json_encode(\App\Services\ProfileService::get(request()->user()->profile_id)) !!},
+			user: {!! json_encode(array_merge(request()->user()->attributesToArray(), \App\Services\ProfileService::get(request()->user()->profile_id))) !!},
 			version: 0
 		};
 		window.App = {

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,5 +1,13 @@
 <?php
 
+use App\Http\Controllers\OwaController;
+
+Route::domain(config('pixelfed.domain.app'))->group(function() {
+	Route::match(['GET','POST'], '/owa', OwaController::class);
+	Route::get('/openwebauth', 'OpenWebAuthController@showLoginForm');
+	Route::post('/openwebauth', 'OpenWebAuthController@openWebAuth')->name('openwebauth');
+});
+
 Route::domain(config('pixelfed.domain.admin'))->prefix('i/admin')->group(function () {
 	Route::redirect('/', '/dashboard');
 	Route::redirect('timeline', config('app.url').'/timeline');


### PR DESCRIPTION
This PR turns Pixelfed into an [OpenWebAuth ](https://zotlabs.org/page/zot/specs+openwebauth) server, meaning that any service with OpenWebAuth client support can log in to a Pixelfed instance as a user that did not previously exist on the Pixelfed instance.
Examples: another Pixelfed server [with OpenWebAuth client support](https://github.com/pixelfed/pixelfed/pull/4339), Hubzilla, (streams), Friendica, Mastodon [with OpenWebAuth client support](https://github.com/mastodon/mastodon/pull/25012), and more will follow.

The immediate value is that it solves issues regarding people on other Pixelfed servers not being able to see older posts since they started following someone, like [here](https://github.com/pixelfed/pixelfed/issues/4369), [here](https://github.com/pixelfed/pixelfed/issues/3679) or [here](https://github.com/pixelfed/pixelfed/issues/4385).
It also respects 'Private' accounts out of the box.
All this is demo-ed in [this video](https://vimeo.com/877251006).

In the longer run, all OpenWebAuth servers/clients could make up for a giant intranet of Fediverse services only requiring a single sign on.

What I am unsure of, is the functionality that could or should be provided, like commenting, following etc. for users logged in through OpenWebAuth. Some functionalities are already disabled in this PR (like editing the profile) to indicate that not everything a local user can do makes sense for a remotely logged in user in the current state of Pixelfed; however it is still possible through the user interface to perform actions that don't make sense to me at this moment so that part is incomplete. I was hoping that this PR could start a discussion that provides insights how to progress on this - although not actually part of the remote login feature.
