### PR TITLE
Fixing Dockerfiles not building with 8.1 and bullseye

### DIFF
--- a/contrib/docker/Dockerfile.apache
+++ b/contrib/docker/Dockerfile.apache
@@ -1,4 +1,4 @@
-FROM php:8.1-apache-bullseye
+FROM php:8.2-apache-bookworm
 
 ENV COMPOSER_MEMORY_LIMIT=-1
 ARG DEBIAN_FRONTEND=noninteractive

--- a/contrib/docker/Dockerfile.apache
+++ b/contrib/docker/Dockerfile.apache
@@ -5,7 +5,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 WORKDIR /var/www/
 
 # Get Composer binary
-COPY --from=composer:2.4.4 /usr/bin/composer /usr/bin/composer
+COPY --from=composer:2.6 /usr/bin/composer /usr/bin/composer
 
 # Install package dependencies
 RUN apt-get update \

--- a/contrib/docker/Dockerfile.fpm
+++ b/contrib/docker/Dockerfile.fpm
@@ -1,4 +1,4 @@
-FROM php:8.1-fpm-bullseye
+FROM php:8.2-fpm-bookworm
 
 ENV COMPOSER_MEMORY_LIMIT=-1
 ARG DEBIAN_FRONTEND=noninteractive

--- a/contrib/docker/Dockerfile.fpm
+++ b/contrib/docker/Dockerfile.fpm
@@ -5,7 +5,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 WORKDIR /var/www/
 
 # Get Composer binary
-COPY --from=composer:2.4.4 /usr/bin/composer /usr/bin/composer
+COPY --from=composer:2.6 /usr/bin/composer /usr/bin/composer
 
 # Install package dependencies
 RUN apt-get update \

--- a/contrib/nginx.conf
+++ b/contrib/nginx.conf
@@ -31,7 +31,7 @@ server {
 
     location ~ \.php$ {
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/var/run/php/php8.1-fpm.sock;
+        fastcgi_pass unix:/var/run/php/php8.2-fpm.sock;
         fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
         fastcgi_param   QUERY_STRING        $query_string;
         fastcgi_param   REQUEST_METHOD      $request_method;


### PR DESCRIPTION
Docker images have been failing on dependencies since last week. Here is an action with the error:
https://github.com/Murazaki/pixelfed/actions/runs/7228527192

I managed to build with php 8.2 and debian bookworm locally. The remote build is going here:
https://github.com/Murazaki/pixelfed/actions/runs/7228705478