### PR TITLE
Provide an informative error message when account size limit is reached

### DIFF
--- a/resources/assets/js/components/ComposeModal.vue
+++ b/resources/assets/js/components/ComposeModal.vue
@@ -1204,12 +1204,19 @@ export default {
 					}, 300);
 				}).catch(function(e) {
 					switch(e.response.status) {
+						case 403:
+							self.uploading = false;
+							io.value = null;
+							swal('Account size limit reached', 'Contact your admin for assistance.', 'error');
+							self.page = 2;
+						break;
+
 						case 413:
 							self.uploading = false;
 							io.value = null;
 							swal('File is too large', 'The file you uploaded has the size of ' + self.formatBytes(io.size) + '. Unfortunately, only images up to ' + self.formatBytes(self.config.uploader.max_photo_size  * 1024) + ' are supported.\nPlease resize the file and try again.', 'error');
 							self.page = 2;
-							break;
+						break;
 
 						case 451:
 							self.uploading = false;


### PR DESCRIPTION
This PR fixes the issue #4845: it adds an informative error message when account limit size is reached.

To reproduce the issue and test the fix, I set up set up an "Account Limit" value in Admin dashboard - Settings - Users in my local deployment to the value smaller than the "Storage" parameter of "Profiles" in Admin dashboard already has to intentionally get the error.

Please see the screenshot of the error message that provides this fix when the account size limit is reached:

<img width="1241" alt="Screen Shot 2024-01-08 at 8 35 27 PM" src="https://github.com/pixelfed/pixelfed/assets/7782090/28325773-1ea6-4d79-a9c9-b55ec7a74962">
