### PR TITLE
Add "Previous" and "Next" navigation controls to album presenters (WIP)

### DIFF
--- a/resources/assets/js/components/presenter/MixedAlbumPresenter.vue
+++ b/resources/assets/js/components/presenter/MixedAlbumPresenter.vue
@@ -50,7 +50,7 @@
 
 			</b-carousel-slide>
 		</b-carousel> -->
-		<carousel ref="carousel" :centerMode="true" :loop="false" :per-page="1" :paginationPosition="'bottom-overlay'" paginationActiveColor="#3897f0" paginationColor="#dbdbdb" class="p-0 m-0">
+		<carousel ref="carousel" :navigationEnabled="true" :centerMode="true" :loop="false" :per-page="1" :paginationPosition="'bottom-overlay'" paginationActiveColor="#3897f0" paginationColor="#dbdbdb" class="p-0 m-0">
 			<slide v-for="(media, index) in status.media_attachments" :key="'px-carousel-'+media.id + '-' + index" class="w-100 h-100 d-block mx-auto text-center" style="background: #000; display: flex;align-items: center;">
 
 				<video v-if="media.type == 'video'" class="embed-responsive-item" preload="none" controls loop :title="media.description" width="100%" height="100%">

--- a/resources/assets/js/components/presenter/PhotoAlbumPresenter.vue
+++ b/resources/assets/js/components/presenter/PhotoAlbumPresenter.vue
@@ -22,7 +22,7 @@
 			:alt="altText(status)"/>
 	</div>
 	<div v-else class="w-100 h-100 p-0 album-wrapper">
-		<carousel ref="carousel" :centerMode="true" :loop="false" :per-page="1" :paginationPosition="'bottom-overlay'" paginationActiveColor="#3897f0" paginationColor="#dbdbdb" class="p-0 m-0" :id="'carousel-' + status.id">
+		<carousel ref="carousel" :navigationEnabled="true" :centerMode="true" :loop="false" :per-page="1" :paginationPosition="'bottom-overlay'" paginationActiveColor="#3897f0" paginationColor="#dbdbdb" class="p-0 m-0" :id="'carousel-' + status.id">
 			<slide v-for="(img, index) in status.media_attachments" :key="'px-carousel-'+img.id + '-' + index" class="" style="background: #000; display: flex;align-items: center;" :title="img.description">
 
 				<img

--- a/resources/assets/js/components/presenter/PhotoAlbumPresenter.vue
+++ b/resources/assets/js/components/presenter/PhotoAlbumPresenter.vue
@@ -186,3 +186,22 @@
 	position: relative;
   }
 </style>
+
+<style>
+.VueCarousel-navigation-button {
+  &.VueCarousel-navigation-prev {
+	    color: white;
+	    opacity: 0.5;
+		position: relative;
+        left: 30px;
+		bottom: 480px;
+  }
+  &.VueCarousel-navigation-next {
+	    color: white;
+	    opacity: 0.5;
+	    position: relative;
+        left: 615px; 
+		bottom: 480px;
+  }
+}
+</style>

--- a/resources/assets/js/components/presenter/PhotoAlbumPresenter.vue
+++ b/resources/assets/js/components/presenter/PhotoAlbumPresenter.vue
@@ -189,19 +189,26 @@
 
 <style>
 .VueCarousel-navigation-button {
+  top: 0 !important;
+  width: 25%;
+  height: 100%;
+  color: white !important;
+  opacity: 0.0 !important;
+  transform: none !important;
+}
+
+.VueCarousel-navigation-button:hover:not(.VueCarousel-navigation--disabled) {
+  opacity: 0.5 !important;
+}
+
+.VueCarousel-navigation-button {
   &.VueCarousel-navigation-prev {
-	    color: white;
-	    opacity: 0.5;
-		position: relative;
-        left: 30px;
-		bottom: 480px;
+    left: 0;
+    text-align: left;
   }
   &.VueCarousel-navigation-next {
-	    color: white;
-	    opacity: 0.5;
-	    position: relative;
-        left: 615px; 
-		bottom: 480px;
+    right: 0;
+    text-align: right;
   }
 }
 </style>


### PR DESCRIPTION
The PR addresses the feature request #4880, adds a navigation arrows to the carousel component in PhotoAlbumPresenter.vue and MixedAlbumPresenter.vue.

Also, was thinking, would it be good to have navigation arrows as a user setting? I hesitated, because it seems to me as probably insignificant setting among a lot of another settings, but let's discuss, if you have an another opinion.

Please feel free to suggest a changes/improvements to this feature and just feel free to discuss and ask any questions 🙂
Edit: increased the target area around navigation arrows, now it's along the whole picture sides accordingly; made navigation arrows appear only when hovering above them.

See the screenshot from my local deployment with navigation arrows for photo album:
![Screen Shot 2024-02-02 at 3 53 13 PM](https://github.com/pixelfed/pixelfed/assets/7782090/879c05b0-f5ff-4a44-b76d-09488a9215ff)
