### PR TITLE
Added an informative UI error message for attempt to create a mixed media album

### DIFF
--- a/resources/assets/js/components/ComposeModal.vue
+++ b/resources/assets/js/components/ComposeModal.vue
@@ -1094,6 +1094,16 @@ export default {
 			return `${parseFloat((bytes / Math.pow(1024, quotient)).toFixed(dec))} ${units[quotient]}`
 		},
 
+		defineErrorMessage(errObject) {
+			if (errObject.response) {
+				let msg = errObject.response.data.message ? errObject.response.data.message : 'An unexpected error occured.';
+			}
+			else {
+				let msg = errObject.message;
+			}
+			return swal('Oops, something went wrong!', msg, 'error');
+		},
+
 		fetchProfile() {
 			let tags = {
 				public: 'Public',
@@ -1395,15 +1405,23 @@ export default {
 							location.href = res.data;
 						}
 					}).catch(err => {
-						if(err.response) {
-							let msg = err.response.data.message ? err.response.data.message : 'An unexpected error occured.'
-							swal('Oops, something went wrong!', msg, 'error');
-						} else {
-							swal('Oops, something went wrong!', err.message, 'error');
-						}
-					});
-					return;
-				break;
+                        switch(err.response.status) {
+                            case 400:
+                                if (err.response.data.error == "Must contain a single photo or video or multiple photos.") {
+                                    swal("Wrong types of mixed media", "The album must contain a single photo or video or multiple photos.", 'error');
+                                }
+								else {
+									this.defineErrorMessage(err);
+								}
+                            break;
+
+                            default:
+								this.defineErrorMessage(err);
+                            break;
+                        }
+                    });
+                    return;
+                break;
 
 				case 'delete' :
 					this.ids = [];


### PR DESCRIPTION
Fixes #4882 : adds an informative UI error message when user is attempting to create an album with wrong types of media types (i.e. video + photo, multiple videos). 
Because right only photo or video, or photo album media types allowed to create a post: see ComposeController.php@store
```
   if(in_array($mediaType, ['photo', 'video', 'photo:album']) == false) {
            abort(400, __('exception.compose.invalid.album'));
        }
```
So for the sake of user experience I think it would be good to have an informative error message explaining what went wrong (before we had just generic error "'Oops, something went wrong! An unexpected error occured", as you can see in the related issue).

Please see the screenshots with the fix in my local environment (more informative error message and the type of media I used to reproduce: video + photo)

![Screen Shot 2024-01-30 at 11 16 48 AM](https://github.com/pixelfed/pixelfed/assets/7782090/7312e573-54ea-435f-b9b6-4fed7a6507f0)
![Screen Shot 2024-01-30 at 11 17 58 AM](https://github.com/pixelfed/pixelfed/assets/7782090/aefc8ad0-a508-4d13-9edd-08a3019cd0fc)
