### PR TITLE
Fix: create mixed media album and dispplay it in profile grid

### DIFF
--- a/app/Http/Controllers/ComposeController.php
+++ b/app/Http/Controllers/ComposeController.php
@@ -558,7 +558,7 @@ class ComposeController extends Controller
 
         $mediaType = StatusController::mimeTypeCheck($mimes);
 
-        if(in_array($mediaType, ['photo', 'video', 'photo:album']) == false) {
+        if(in_array($mediaType, ['photo', 'video', 'photo:album', 'video:album', 'photo:video:album']) == false) {
             abort(400, __('exception.compose.invalid.album'));
         }
 

--- a/app/Http/Controllers/PublicApiController.php
+++ b/app/Http/Controllers/PublicApiController.php
@@ -683,7 +683,7 @@ class PublicApiController extends Controller
         $limit = $request->limit ?? 9;
         $max_id = $request->max_id;
         $min_id = $request->min_id;
-        $scope = ['photo', 'photo:album', 'video', 'video:album'];
+        $scope = ['photo', 'photo:album', 'video', 'video:album', 'photo:video:album'];
         $onlyMedia = $request->input('only_media', true);
 
         if(!$min_id && !$max_id) {


### PR DESCRIPTION
That PR fixes issues #4870 and #4900 
It provides the functionality to create a post with more than 1 video or with mixed media (both photo and video media types in one post), see the issue #4900. Also it makes posts appear in profile grid, see issue #4870.

Please see the screenshots from my local deployment with created mixed media post and post with two videos (see the type of objects in 'media_attachments' list on screenshots), also the post with mixed media can be seen in my profile grid.

![Screen Shot 2024-02-06 at 6 57 46 PM](https://github.com/pixelfed/pixelfed/assets/7782090/410cdba6-09b4-44f9-a421-5417f4fd64e0)
![Screen Shot 2024-02-06 at 6 59 21 PM](https://github.com/pixelfed/pixelfed/assets/7782090/97cf61b9-c950-4ff2-a370-4420f509539b)
