### PR TITLE
Autospam Live Filters - block remote activities based on comma separated keywords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased](https://github.com/pixelfed/pixelfed/compare/v0.11.11...dev)
 
+### Features
+- Autospam Live Filters - block remote activities based on comma separated keywords ([40b45b2a](https://github.com/pixelfed/pixelfed/commit/40b45b2a))
+
 ### Updated
 
 - Update ApiV1Controller, fix network timeline ([0faf59e3](https://github.com/pixelfed/pixelfed/commit/0faf59e3))

--- a/app/Util/ActivityPub/Helpers.php
+++ b/app/Util/ActivityPub/Helpers.php
@@ -315,6 +315,23 @@ class Helpers {
             return;
         }
 
+        if(config('autospam.live_filters.enabled')) {
+            $filters = config('autospam.live_filters.filters');
+            if(!empty($filters) && isset($res['content']) && !empty($res['content']) && strlen($filters) > 3) {
+                $filters = array_map('trim', explode(',', $filters));
+                $content = $res['content'];
+                foreach($filters as $filter) {
+                    $filter = trim($filter);
+                    if(!$filter || !strlen($filter)) {
+                        continue;
+                    }
+                    if(str_contains($content, $filter)) {
+                        return;
+                    }
+                }
+            }
+        }
+
         if(isset($res['object'])) {
             $activity = $res;
         } else {

--- a/app/Util/ActivityPub/Inbox.php
+++ b/app/Util/ActivityPub/Inbox.php
@@ -197,6 +197,22 @@ class Inbox
     public function handleCreateActivity()
     {
         $activity = $this->payload['object'];
+        if(config('autospam.live_filters.enabled')) {
+            $filters = config('autospam.live_filters.filters');
+            if(!empty($filters) && isset($activity['content']) && !empty($activity['content']) && strlen($filters) > 3) {
+                $filters = array_map('trim', explode(',', $filters));
+                $content = $activity['content'];
+                foreach($filters as $filter) {
+                    $filter = trim($filter);
+                    if(!$filter || !strlen($filter)) {
+                        continue;
+                    }
+                    if(str_contains($content, $filter)) {
+                        return;
+                    }
+                }
+            }
+        }
         $actor = $this->actorFirstOrCreate($this->payload['actor']);
         if(!$actor || $actor->domain == null) {
             return;

--- a/config/autospam.php
+++ b/config/autospam.php
@@ -33,5 +33,10 @@ return [
     'nlp' => [
     	'enabled' => false,
     	'spam_sample_limit' => env('PF_AUTOSPAM_NLP_SPAM_SAMPLE_LIMIT', 200),
+    ],
+
+    'live_filters' => [
+        'enabled' => env('PF_AUTOSPAM_LIVE_FILTERS_ENABLED', false),
+        'filters' => env('PF_AUTOSPAM_LIVE_FILTERS_CSV', ''),
     ]
 ];


### PR DESCRIPTION
Allows admins to easily block activities containing specific keywords, helpful to mitigate spam attacks.

### How to enable

1) Set `PF_AUTOSPAM_LIVE_FILTERS_ENABLED=true` in .env

2) Set comma separated keyword(s) in .env, as demonstrated below

```
PF_AUTOSPAM_LIVE_FILTERS_CSV="のプロフ 見て,Another blocked phrase"
```

3) Re-deploy