### PR TITLE
Update Inbox and StatusObserver, fix silently rejected direct message…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Update ApiV1Controller, implement better limit logic to gracefully handle requests with limits that exceed the max ([1f74a95d](https://github.com/pixelfed/pixelfed/commit/1f74a95d))
 - Update AdminCuratedRegisterController, show oldest applications first ([c4dde641](https://github.com/pixelfed/pixelfed/commit/c4dde641))
 - Update Directory logic, add curated onboarding support ([59c70239](https://github.com/pixelfed/pixelfed/commit/59c70239))
+- Update Inbox and StatusObserver, fix silently rejected direct messages due to saveQuietly which failed to generate a snowflake id ([089ba3c4](https://github.com/pixelfed/pixelfed/commit/089ba3c4))
 -  ([](https://github.com/pixelfed/pixelfed/commit/))
 
 ## [v0.11.12 (2024-02-16)](https://github.com/pixelfed/pixelfed/compare/v0.11.11...v0.11.12)

--- a/app/Observers/StatusObserver.php
+++ b/app/Observers/StatusObserver.php
@@ -38,6 +38,10 @@ class StatusObserver
      */
     public function updated(Status $status)
     {
+        if(!in_array($status->scope, ['public', 'unlisted', 'private'])) {
+            return;
+        }
+
         if(config('instance.timeline.home.cached')) {
             Cache::forget('pf:timelines:home:' . $status->profile_id);
         }
@@ -55,6 +59,10 @@ class StatusObserver
      */
     public function deleted(Status $status)
     {
+        if(!in_array($status->scope, ['public', 'unlisted', 'private'])) {
+            return;
+        }
+
         if(config('instance.timeline.home.cached')) {
             Cache::forget('pf:timelines:home:' . $status->profile_id);
         }

--- a/app/Util/ActivityPub/Inbox.php
+++ b/app/Util/ActivityPub/Inbox.php
@@ -423,7 +423,7 @@ class Inbox
         $status->uri = $activity['id'];
         $status->object_url = $activity['id'];
         $status->in_reply_to_profile_id = $profile->id;
-        $status->saveQuietly();
+        $status->save();
 
         $dm = new DirectMessage;
         $dm->to_id = $profile->id;


### PR DESCRIPTION
…s due to saveQuietly which failed to generate a snowflake id