### PR TITLE
buzz/laravel-h-captcha: allow semantic range to make `composer validate` happy

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
 		"bacon/bacon-qr-code": "^2.0.3",
 		"beyondcode/laravel-websockets": "^1.13",
 		"brick/math": "^0.9.3",
-		"buzz/laravel-h-captcha": "1.0.4",
+		"buzz/laravel-h-captcha": "^1.0.4",
 		"doctrine/dbal": "^3.0",
 		"intervention/image": "^2.4",
 		"jenssegers/agent": "^2.6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "00f283796faf6517a8d98f9080440b7f",
+    "content-hash": "57bb452a3c9527c1876d829a9deaa1ba",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -11058,6 +11058,7 @@
                     "type": "patreon"
                 }
             ],
+            "abandoned": "web-token/jwt-library",
             "time": "2022-08-04T21:04:09+00:00"
         },
         {
@@ -11136,6 +11137,7 @@
                     "type": "patreon"
                 }
             ],
+            "abandoned": "web-token/jwt-library",
             "time": "2023-02-02T17:25:26+00:00"
         },
         {
@@ -11213,6 +11215,7 @@
                     "type": "patreon"
                 }
             ],
+            "abandoned": "web-token/jwt-library",
             "time": "2023-02-02T17:25:26+00:00"
         },
         {
@@ -11283,6 +11286,7 @@
                     "type": "patreon"
                 }
             ],
+            "abandoned": "web-token/jwt-library",
             "time": "2022-08-04T21:04:09+00:00"
         },
         {
@@ -11356,6 +11360,7 @@
                     "type": "patreon"
                 }
             ],
+            "abandoned": "web-token/jwt-library",
             "time": "2024-01-02T17:55:33+00:00"
         },
         {


### PR DESCRIPTION
Currently `composer validate` complains about the exact version constraint on this package. Looking at the `git log` the constraint does not seem to exist for a specific reason.

No functional changes expected.

```
$ composer validate
./composer.json is valid, but with a few warnings
See https://getcomposer.org/doc/04-schema.md for details on the schema
- require.buzz/laravel-h-captcha : exact version constraints (1.0.4) should be avoided if the package follows semantic versioning
```