### PR TITLE
Update navbar.vue

### DIFF
--- a/resources/assets/components/partials/navbar.vue
+++ b/resources/assets/components/partials/navbar.vue
@@ -1,7 +1,7 @@
 <template>
 	<nav class="metro-nav navbar navbar-expand navbar-light navbar-laravel sticky-top shadow-none py-1">
 		<div class="container-fluid">
-				<a class="navbar-brand d-flex align-items-center" href="/i/web" title="Logo" style="width:50px">
+				<a class="navbar-brand d-flex align-items-center" href="/i/web" title="Logo">
 					<img src="/img/pixelfed-icon-color.svg" height="30px" class="px-2" loading="eager" alt="Pixelfed logo">
 					<span class="font-weight-bold mb-0 d-none d-sm-block" style="font-size:20px;">
 						{{ brandName }}


### PR DESCRIPTION
![image](https://github.com/pixelfed/pixelfed/assets/17537000/d976045d-bb0b-4f0c-a8f1-fb01ef7dcad4)

Removes that 50px limit so the full logo and text is a link