### PR TITLE
Docker: Use rsync container image that supports arm64 and amd64

### DIFF
--- a/docker-compose.migrate.yml
+++ b/docker-compose.migrate.yml
@@ -3,7 +3,7 @@ version: "3"
 
 services:
   migrate:
-    image: "secoresearch/rsync"
+    image: "servercontainers/rsync"
     entrypoint: ""
     working_dir: /migrate
     command: 'bash -c "exit 1"'


### PR DESCRIPTION
Fixes #4979
Fixes #4978

#### Updating

* Pull in the change to your project/fork/repo/project
* Follow the migration guide on your ARM device