### PR TITLE
Docker: Allow setting the DB root password separately

### DIFF
--- a/.env.docker
+++ b/.env.docker
@@ -1202,6 +1202,14 @@ DOCKER_DB_HOST_PORT="${DB_PORT:?error}"
 # @dottie/validate required,number
 DOCKER_DB_CONTAINER_PORT="${DB_PORT:?error}"
 
+# root password for the database. By default uses DB_PASSWORD
+# but can be changed in situations where you are migrating
+# to the included docker-compose and have a different password
+# set already
+#
+# @dottie/validate required
+DOCKER_DB_ROOT_PASSWORD="${DB_PASSWORD:?error}"
+
 # How often Docker health check should run for [db] service
 # @dottie/validate required
 DOCKER_DB_HEALTHCHECK_INTERVAL="${DOCKER_ALL_DEFAULT_HEALTHCHECK_INTERVAL:?error}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -166,12 +166,12 @@ services:
     environment:
       TZ: "${TZ:?error}"
       # MySQL (Oracle) - "Environment Variables" at https://hub.docker.com/_/mysql
-      MYSQL_ROOT_PASSWORD: "${DB_PASSWORD:?error}"
+      MYSQL_ROOT_PASSWORD: "${DOCKER_DB_ROOT_PASSWORD:?error}"
       MYSQL_USER: "${DB_USERNAME:?error}"
       MYSQL_PASSWORD: "${DB_PASSWORD:?error}"
       MYSQL_DATABASE: "${DB_DATABASE:?error}"
       # MySQL (MariaDB) - "Start a mariadb server instance with user, password and database" at https://hub.docker.com/_/mariadb
-      MARIADB_ROOT_PASSWORD: "${DB_PASSWORD:?error}"
+      MARIADB_ROOT_PASSWORD: "${DOCKER_DB_ROOT_PASSWORD:?error}"
       MARIADB_USER: "${DB_USERNAME:?error}"
       MARIADB_PASSWORD: "${DB_PASSWORD:?error}"
       MARIADB_DATABASE: "${DB_DATABASE:?error}"


### PR DESCRIPTION
Fixes https://github.com/pixelfed/pixelfed/issues/4980

### Updating

* Pull in the new changes into your fork/repo/project 
* Run `./docker/dottie sync` to update your `.env` file with the new changes
* Run `./docker/dottie set DOCKER_DB_ROOT_PASSWORD=your-existing-root-password` to change the value