### PR TITLE
fix: Unable to delete server rules

### DIFF
--- a/app/Http/Controllers/Admin/AdminSettingsController.php
+++ b/app/Http/Controllers/Admin/AdminSettingsController.php
@@ -69,7 +69,7 @@ trait AdminSettingsController
             'type_mp4' => 'nullable',
             'type_webp' => 'nullable',
             'admin_account_id' => 'nullable',
-            'regs' => 'required|in:open,filtered,closed',
+            'regs' => 'nullable|in:open,filtered,closed',
             'account_migration' => 'nullable',
         ]);
 


### PR DESCRIPTION
When attempting to delete a rule, the server responds with an error saying that regs is required . Look like an invalid validation for the delete rule rest route.

The request to delete is only sent with <kbd>{"rule_delete":"2"}</kbd>

![image](https://github.com/pixelfed/pixelfed/assets/19898499/4386b1d9-9347-4496-a24c-10711dc7fe3a)

Fixes: #4990 

For this PR I just change the rule for <kbd>regs</kbd> which is required and change that to <kbd>nullable</kbd>. Verify it from the frontend also only the <kbd>rule_delete</kbd> is passing in post parameters. 