### PR TITLE
Adjust CORS configuration to support API & OAuth Routes

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -14,12 +14,12 @@ class Kernel extends HttpKernel
      * @var array
      */
     protected $middleware = [
+        \Illuminate\Http\Middleware\HandleCors::class,
         \Illuminate\Foundation\Http\Middleware\CheckForMaintenanceMode::class,
         \Illuminate\Foundation\Http\Middleware\ValidatePostSize::class,
+        \App\Http\Middleware\TrustProxies::class,
         \App\Http\Middleware\TrimStrings::class,
         \Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull::class,
-        \App\Http\Middleware\TrustProxies::class,
-        \Illuminate\Http\Middleware\HandleCors::class,
     ];
 
     /**

--- a/config/cors.php
+++ b/config/cors.php
@@ -22,7 +22,9 @@ return [
      * Example: ['api/*']
      */
     'paths' => [
-        '.well-known/*'
+        '.well-known/*',
+        'api/*',
+        'oauth/*'
     ],
 
     /*
@@ -48,7 +50,8 @@ return [
     /*
      * Sets the Access-Control-Expose-Headers response header with these headers.
      */
-    'exposed_headers' => [],
+    // TODO: Add support for rate-limit related headers
+    'exposed_headers' => ['Link'],
 
     /*
      * Sets the Access-Control-Max-Age response header when > 0.


### PR DESCRIPTION
Fixes #4411 and #3381

Tested and the response was:

```
< HTTP/1.1 200 OK
< Server: nginx/1.22.1
< Content-Type: application/json
< Transfer-Encoding: chunked
< Connection: keep-alive
< Cache-Control: no-cache, private
< Date: Mon, 18 Mar 2024 00:41:48 GMT
< Access-Control-Allow-Origin: *
< Access-Control-Expose-Headers: Link
< X-Frame-Options: SAMEORIGIN
< X-XSS-Protection: 1; mode=block
< X-Content-Type-Options: nosniff
< 
```