### PR TITLE
Update DirectMessageController, add 72 hour delay for new accounts before they can send media directly

### DIFF
--- a/app/Http/Controllers/DirectMessageController.php
+++ b/app/Http/Controllers/DirectMessageController.php
@@ -587,6 +587,7 @@ class DirectMessageController extends Controller
 
         $user = $request->user();
         abort_if($user->has_roles && !UserRoleService::can('can-direct-message', $user->id), 403, 'Invalid permissions for this action');
+        abort_if($user->created_at->gt(now()->subHours(72)), 400, 'You need to wait a bit before you can DM another account');
         $profile = $user->profile;
         $recipient = Profile::where('id', '!=', $profile->id)->findOrFail($request->input('to_id'));
         abort_if(in_array($profile->id, $recipient->blockedIds()->toArray()), 403);


### PR DESCRIPTION
I was trying to send a text message along with a photo via DM. The photo was sent, but the text resulted in a 400 error. I think both text and media should follow the same rule.