### PR TITLE
Fix environment variables

### DIFF
--- a/docker/shared/root/docker/entrypoint.d/01-permissions.sh
+++ b/docker/shared/root/docker/entrypoint.d/01-permissions.sh
@@ -17,7 +17,7 @@ run-as-current-user chown --verbose --recursive "${RUNTIME_UID}:${RUNTIME_GID}" 
 : "${DOCKER_APP_ENSURE_OWNERSHIP_PATHS:=""}"
 
 declare -a ensure_ownership_paths=()
-IFS=' ' read -ar ensure_ownership_paths <<<"${DOCKER_APP_ENSURE_OWNERSHIP_PATHS}"
+IFS=' ' read -r -a ensure_ownership_paths <<<"${DOCKER_APP_ENSURE_OWNERSHIP_PATHS}"
 
 if [[ ${#ensure_ownership_paths[@]} == 0 ]]; then
     log-info "No paths has been configured for ownership fixes via [\$DOCKER_APP_ENSURE_OWNERSHIP_PATHS]."

--- a/docker/shared/root/docker/entrypoint.sh
+++ b/docker/shared/root/docker/entrypoint.sh
@@ -28,7 +28,7 @@ entrypoint-set-script-name "entrypoint.sh"
 # Convert ENTRYPOINT_SKIP_SCRIPTS into a native bash array for easier lookup
 declare -a skip_scripts
 # shellcheck disable=SC2034
-IFS=' ' read -ar skip_scripts <<< "$ENTRYPOINT_SKIP_SCRIPTS"
+IFS=' ' read -r -a skip_scripts <<< "$ENTRYPOINT_SKIP_SCRIPTS"
 
 # Ensure the entrypoint root folder exists
 mkdir -p "${ENTRYPOINT_D_ROOT}"


### PR DESCRIPTION
When a bash array is read into a variable, the syntax must be read -r -a <variable name> not read -ar This fixes ENTRYPOINT_SKIP_SCRIPTS as well as DOCKER_APP_ENSURE_OWNERSHIP_PATHS


Currently, if you try to set the ENTRYPOINT_SKIP_SCRIPTS variable, you'll see that nothing is skipped. From debugging this is because the skip_scripts array is never initialized