### PR TITLE
If not applying migrations, early exit before waiting for the database

### DIFF
--- a/docker/shared/root/docker/entrypoint.d/12-migrations.sh
+++ b/docker/shared/root/docker/entrypoint.d/12-migrations.sh
@@ -9,6 +9,13 @@ entrypoint-set-script-name "$0"
 # Allow automatic applying of outstanding/new migrations on startup
 : "${DB_APPLY_NEW_MIGRATIONS_AUTOMATICALLY:=0}"
 
+if is-false "${DB_APPLY_NEW_MIGRATIONS_AUTOMATICALLY}"; then
+    log-info "Automatic applying of new database migrations is disabled"
+    log-info "Please set [DB_APPLY_NEW_MIGRATIONS_AUTOMATICALLY=1] in your [.env] file to enable this."
+
+    exit 0
+fi
+
 # Wait for the database to be ready
 await-database-ready
 
@@ -32,11 +39,5 @@ log-warning "New migrations available"
 # Print the output
 echo "$output"
 
-if is-false "${DB_APPLY_NEW_MIGRATIONS_AUTOMATICALLY}"; then
-    log-info "Automatic applying of new database migrations is disabled"
-    log-info "Please set [DB_APPLY_NEW_MIGRATIONS_AUTOMATICALLY=1] in your [.env] file to enable this."
-
-    exit 0
-fi
 
 run-as-runtime-user php artisan migrate --force


### PR DESCRIPTION
If we're not going to apply the migrations, there's no point in waiting for the database to be available, just quick-start the service.

Otherwise there's no way to opt-out of `await-database-ready` without skipping every single entrypoint file