### PR TITLE
Modify the www-data user and group id to match the RUNTIME_UID/GID

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -132,6 +132,10 @@ ENV DEBIAN_FRONTEND="noninteractive"
 # Ensure we run all scripts through 'bash' rather than 'sh'
 SHELL ["/bin/bash", "-c"]
 
+# Set www-data to be RUNTIME_UID/RUNTIME_GID
+RUN groupmod --gid ${RUNTIME_GID} www-data \
+    && usermod --uid ${RUNTIME_UID} --gid ${RUNTIME_GID} www-data
+
 RUN set -ex \
     && mkdir -pv /var/www/ \
     && chown -R ${RUNTIME_UID}:${RUNTIME_GID} /var/www


### PR DESCRIPTION
The dockerfile allows users to customize the RUNTIME_UID/GID (which is great for e.g matching the user/group perms to something outside the container).

The problem is that it's not exactly useful as-is, because if the user doesn't exist inside the docker container, then the container won't run.

The fix is to use groupmod and usermod to set www-data to the RUNTIME_UID and GID. By default, this is 33, so this should be a no-op.

However, if a user sets RUNTIME_UID=1000, then this would change the www-data user/group to be 1000