### PR TITLE
Docker fixes for composer install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -256,16 +256,25 @@ COPY --link --from=composer-image /usr/bin/composer /usr/bin/composer
 #! Changing user to runtime user
 USER ${RUNTIME_UID}:${RUNTIME_GID}
 
+
 # Install composer dependencies
 # NOTE: we skip the autoloader generation here since we don't have all files avaliable (yet)
-RUN --mount=type=cache,id=pixelfed-composer-${PHP_VERSION},sharing=locked,target=/cache/composer \
+RUN --mount=type=cache,id=pixelfed-composer-${PHP_VERSION},sharing=locked,uid=${RUNTIME_UID},gid=${RUNTIME_GID},target=/cache/composer \
     --mount=type=bind,source=composer.json,target=/var/www/composer.json \
     --mount=type=bind,source=composer.lock,target=/var/www/composer.lock \
     set -ex \
-    && composer install --prefer-dist --no-autoloader --ignore-platform-reqs
+    && composer install --prefer-dist --no-autoloader --ignore-platform-reqs --no-scripts
 
 # Copy all other files over
 COPY --chown=${RUNTIME_UID}:${RUNTIME_GID} . /var/www/
+
+# Generate optimized autoloader now that we have all files around
+RUN set -ex \
+    && ENABLE_CONFIG_CACHE=false composer dump-autoload --optimize
+
+# Now we can run the post-install scripts
+RUN set -ex \
+    && composer run-script post-update-cmd
 
 #######################################################
 # Runtime: base
@@ -285,13 +294,6 @@ COPY --link --from=gomplate-image /usr/local/bin/gomplate /usr/local/bin/gomplat
 COPY --link --from=composer-image /usr/bin/composer /usr/bin/composer
 COPY --link --from=composer-and-src --chown=${RUNTIME_UID}:${RUNTIME_GID} /var/www /var/www
 COPY --link --from=frontend-build --chown=${RUNTIME_UID}:${RUNTIME_GID} /var/www/public /var/www/public
-
-#! Changing user to runtime user
-USER ${RUNTIME_UID}:${RUNTIME_GID}
-
-# Generate optimized autoloader now that we have all files around
-RUN set -ex \
-    && ENABLE_CONFIG_CACHE=false composer dump-autoload --optimize
 
 USER root
 


### PR DESCRIPTION
This implements two fixes: First, it copies over all source files before running composer install. This is needed because some post-install steps use artisan, which requires the source to be present Second, this fixes the permissions of /cache/composer. Otherwise, it is owned by root, and is not writeable