### PR TITLE
Check for oauth keys from the config, as well as from disk

### DIFF
--- a/app/Http/Controllers/Admin/AdminDirectoryController.php
+++ b/app/Http/Controllers/Admin/AdminDirectoryController.php
@@ -67,7 +67,9 @@ trait AdminDirectoryController
         $res['community_guidelines'] = config_cache('app.rules') ? json_decode(config_cache('app.rules'), true) : [];
         $res['curated_onboarding'] = (bool) config_cache('instance.curated_registration.enabled');
         $res['open_registration'] = (bool) config_cache('pixelfed.open_registration');
-        $res['oauth_enabled'] = (bool) config_cache('pixelfed.oauth_enabled') && file_exists(storage_path('oauth-public.key')) && file_exists(storage_path('oauth-private.key'));
+        $res['oauth_enabled'] = (bool) config_cache('pixelfed.oauth_enabled') &&
+            (file_exists(storage_path('oauth-public.key')) || config_cache('passport.public_key')) &&
+            (file_exists(storage_path('oauth-private.key')) || config_cache('passport.private_key'));
 
         $res['activitypub_enabled'] = (bool) config_cache('federation.activitypub.enabled');
 

--- a/app/Http/Controllers/Admin/AdminSettingsController.php
+++ b/app/Http/Controllers/Admin/AdminSettingsController.php
@@ -195,7 +195,9 @@ trait AdminSettingsController
             if ($key == 'mobile_apis' &&
                 $active &&
                 ! file_exists(storage_path('oauth-public.key')) &&
-                ! file_exists(storage_path('oauth-private.key'))
+                ! config_cache('passport.public_key') &&
+                ! file_exists(storage_path('oauth-private.key')) &&
+                ! config_cache('passport.private_key')
             ) {
                 Artisan::call('passport:keys');
                 Artisan::call('route:cache');

--- a/app/Http/Controllers/PixelfedDirectoryController.php
+++ b/app/Http/Controllers/PixelfedDirectoryController.php
@@ -90,7 +90,8 @@ class PixelfedDirectoryController extends Controller
 
         $oauthEnabled = ConfigCache::whereK('pixelfed.oauth_enabled')->first();
         if ($oauthEnabled) {
-            $keys = file_exists(storage_path('oauth-public.key')) && file_exists(storage_path('oauth-private.key'));
+            $keys = (file_exists(storage_path('oauth-public.key')) || config_cache('passport.public_key')) &&
+                (file_exists(storage_path('oauth-private.key')) || config_cache('passport.private_key'));
             $res['oauth_enabled'] = (bool) $oauthEnabled && $keys;
         }
 


### PR DESCRIPTION
The OAuth detection code for the directory listing is incomplete. It doesn't properly detect the case where the OAuth public/private keys are set via environment variable.

This is especially useful for ensuring the correct keys across deployments, as otherwise this file needs to be specially backed-up. Otherwise, existing mobile apps would become invalid if the key is ever regenerated.


This is followup from https://github.com/pixelfed/pixelfed/pull/4257
At the time, it only fixed the diagnostics page. However, there are other pages (such as the directory listing page) which also need updating

## Test plan
I am running this here: https://github.com/intentionally-left-nil/pixelfed/pkgs/container/pixelfed-fpm/259651499?tag=0.12.3-oauth

and have verified that with this change:
1. The directory page correctly lists oauth as working
2. The settings page works correctly
3. The diagnostics page still works correctly