### PR TITLE
Fix Move inbox handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 - Implement Admin Domain Blocks API (Mastodon API Compatible) [ThisIsMissEm](https://github.com/ThisIsMissEm) ([#5021](https://github.com/pixelfed/pixelfed/pull/5021))
 - Authorize Interaction support (for handling remote interactions) ([4ca7c6c3](https://github.com/pixelfed/pixelfed/commit/4ca7c6c3))
 
+### Federation
+- Add ActiveSharedInboxService, for efficient sharedInbox caching ([1a6a3397](https://github.com/pixelfed/pixelfed/commit/1a6a3397))
+- Add MovePipeline queue jobs ([9904d05f](https://github.com/pixelfed/pixelfed/commit/9904d05f))
+- Add ActivityPub Move validator ([909a6c72](https://github.com/pixelfed/pixelfed/commit/909a6c72))
+- Add delay to move handler to allow for remote cache invalidation ([8a362c12](https://github.com/pixelfed/pixelfed/commit/8a362c12))
+
 ### Updates
 - Update ApiV1Controller, add support for notification filter types ([f61159a1](https://github.com/pixelfed/pixelfed/commit/f61159a1))
 - Update ApiV1Dot1Controller, fix mutual api ([a8bb97b2](https://github.com/pixelfed/pixelfed/commit/a8bb97b2))
@@ -17,6 +23,11 @@
 - Update AdminSettings component, add link to Custom CSS settings ([958daac4](https://github.com/pixelfed/pixelfed/commit/958daac4))
 - Update ApiV1Controller, fix v1/instance stats, force cast to int ([dcd95d68](https://github.com/pixelfed/pixelfed/commit/dcd95d68))
 - Update BeagleService, disable discovery if AP is disabled ([6cd1cbb4](https://github.com/pixelfed/pixelfed/commit/6cd1cbb4))
+- Update NodeinfoService, fix typo ([edad436d](https://github.com/pixelfed/pixelfed/commit/edad436d))
+- Update ActivityPubFetchService, reduce cache ttl from 1 hour to 7.5 mins and add uncached fetchRequest method ([21da2b64](https://github.com/pixelfed/pixelfed/commit/21da2b64))
+- Update UserAccountDelete command, increase sharedInbox ttl from 12h to 14d ([be02f48a](https://github.com/pixelfed/pixelfed/commit/be02f48a))
+- Update HttpSignature, add signRaw method and improve error checking ([d4cf9181](https://github.com/pixelfed/pixelfed/commit/d4cf9181))
+- Update AP helpers, add forceBanCheck param to validateUrl method ([42424028](https://github.com/pixelfed/pixelfed/commit/42424028))
 -  ([](https://github.com/pixelfed/pixelfed/commit/))
 
 ## [v0.12.3 (2024-07-01)](https://github.com/pixelfed/pixelfed/compare/v0.12.2...v0.12.3)

--- a/app/Console/Commands/UserAccountDelete.php
+++ b/app/Console/Commands/UserAccountDelete.php
@@ -74,14 +74,14 @@ class UserAccountDelete extends Command
         $activity = $fractal->createData($resource)->toArray();
 
         $audience = Instance::whereNotNull(['shared_inbox', 'nodeinfo_last_fetched'])
-            ->where('nodeinfo_last_fetched', '>', now()->subHours(12))
+            ->where('nodeinfo_last_fetched', '>', now()->subDays(14))
             ->distinct()
             ->pluck('shared_inbox');
 
         $payload = json_encode($activity);
 
         $client = new Client([
-            'timeout' => 10,
+            'timeout' => 5,
         ]);
 
         $version = config('pixelfed.version');

--- a/app/Http/Controllers/Admin/AdminDirectoryController.php
+++ b/app/Http/Controllers/Admin/AdminDirectoryController.php
@@ -67,7 +67,9 @@ trait AdminDirectoryController
         $res['community_guidelines'] = config_cache('app.rules') ? json_decode(config_cache('app.rules'), true) : [];
         $res['curated_onboarding'] = (bool) config_cache('instance.curated_registration.enabled');
         $res['open_registration'] = (bool) config_cache('pixelfed.open_registration');
-        $res['oauth_enabled'] = (bool) config_cache('pixelfed.oauth_enabled') && file_exists(storage_path('oauth-public.key')) && file_exists(storage_path('oauth-private.key'));
+        $res['oauth_enabled'] = (bool) config_cache('pixelfed.oauth_enabled') &&
+            (file_exists(storage_path('oauth-public.key')) || config_cache('passport.public_key')) &&
+            (file_exists(storage_path('oauth-private.key')) || config_cache('passport.private_key'));
 
         $res['activitypub_enabled'] = (bool) config_cache('federation.activitypub.enabled');
 

--- a/app/Http/Controllers/Admin/AdminSettingsController.php
+++ b/app/Http/Controllers/Admin/AdminSettingsController.php
@@ -195,7 +195,9 @@ trait AdminSettingsController
             if ($key == 'mobile_apis' &&
                 $active &&
                 ! file_exists(storage_path('oauth-public.key')) &&
-                ! file_exists(storage_path('oauth-private.key'))
+                ! config_cache('passport.public_key') &&
+                ! file_exists(storage_path('oauth-private.key')) &&
+                ! config_cache('passport.private_key')
             ) {
                 Artisan::call('passport:keys');
                 Artisan::call('route:cache');

--- a/app/Http/Controllers/PixelfedDirectoryController.php
+++ b/app/Http/Controllers/PixelfedDirectoryController.php
@@ -90,7 +90,8 @@ class PixelfedDirectoryController extends Controller
 
         $oauthEnabled = ConfigCache::whereK('pixelfed.oauth_enabled')->first();
         if ($oauthEnabled) {
-            $keys = file_exists(storage_path('oauth-public.key')) && file_exists(storage_path('oauth-private.key'));
+            $keys = (file_exists(storage_path('oauth-public.key')) || config_cache('passport.public_key')) &&
+                (file_exists(storage_path('oauth-private.key')) || config_cache('passport.private_key'));
             $res['oauth_enabled'] = (bool) $oauthEnabled && $keys;
         }
 

--- a/app/Jobs/MovePipeline/CleanupLegacyAccountMovePipeline.php
+++ b/app/Jobs/MovePipeline/CleanupLegacyAccountMovePipeline.php
@@ -3,6 +3,8 @@
 namespace App\Jobs\MovePipeline;
 
 use App\Follower;
+use App\Profile;
+use App\Services\AccountService;
 use App\Util\ActivityPub\Helpers;
 use DateTime;
 use Exception;
@@ -83,5 +85,14 @@ class CleanupLegacyAccountMovePipeline implements ShouldQueue
         }
 
         Follower::whereFollowingId($actorAccount['id'])->delete();
+
+        $oldProfile = Profile::find($actorAccount['id']);
+
+        if ($oldProfile) {
+            $oldProfile->moved_to_profile_id = $targetAccount['id'];
+            $oldProfile->save();
+            AccountService::del($oldProfile->id);
+            AccountService::del($targetAccount['id']);
+        }
     }
 }

--- a/app/Jobs/MovePipeline/CleanupLegacyAccountMovePipeline.php
+++ b/app/Jobs/MovePipeline/CleanupLegacyAccountMovePipeline.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace App\Jobs\MovePipeline;
+
+use App\Follower;
+use App\Util\ActivityPub\Helpers;
+use Exception;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Queue\Middleware\WithoutOverlapping;
+
+class CleanupLegacyAccountMovePipeline implements ShouldQueue
+{
+    use Queueable;
+
+    public $target;
+
+    public $activity;
+
+    /**
+     * The number of times the job may be attempted.
+     *
+     * @var int
+     */
+    public $tries = 6;
+
+    /**
+     * The maximum number of unhandled exceptions to allow before failing.
+     *
+     * @var int
+     */
+    public $maxExceptions = 3;
+
+    /**
+     * Create a new job instance.
+     */
+    public function __construct($target, $activity)
+    {
+        $this->target = $target;
+        $this->activity = $activity;
+    }
+
+    /**
+     * Get the middleware the job should pass through.
+     *
+     * @return array<int, object>
+     */
+    public function middleware(): array
+    {
+        return [
+            new WithoutOverlapping('process-move-cleanup-legacy-followers:'.$this->activity),
+            (new ThrottlesExceptions(2, 5 * 60))->backoff(5),
+        ];
+    }
+
+    /**
+     * Determine the time at which the job should timeout.
+     */
+    public function retryUntil(): DateTime
+    {
+        return now()->addMinutes(15);
+    }
+
+    /**
+     * Get the middleware the job should pass through.
+     *
+     * @return array<int, object>
+     */
+    public function middleware(): array
+    {
+        return [new WithoutOverlapping($this->target)];
+    }
+
+    /**
+     * Execute the job.
+     */
+    public function handle(): void
+    {
+        if (config('app.env') !== 'production' || (bool) config_cache('federation.activitypub.enabled') == false) {
+            throw new Exception('Activitypub not enabled');
+        }
+
+        $target = $this->target;
+        $actor = $this->activity;
+
+        $targetAccount = Helpers::profileFetch($target);
+        $actorAccount = Helpers::profileFetch($actor);
+
+        if (! $targetAccount || ! $actorAccount) {
+            throw new Exception('Invalid move accounts');
+        }
+
+        Follower::whereFollowingId($actorAccount['id'])->delete();
+    }
+}

--- a/app/Jobs/MovePipeline/CleanupLegacyAccountMovePipeline.php
+++ b/app/Jobs/MovePipeline/CleanupLegacyAccountMovePipeline.php
@@ -59,7 +59,7 @@ class CleanupLegacyAccountMovePipeline implements ShouldQueue
      */
     public function retryUntil(): DateTime
     {
-        return now()->addMinutes(15);
+        return now()->addMinutes(5);
     }
 
     /**

--- a/app/Jobs/MovePipeline/CleanupLegacyAccountMovePipeline.php
+++ b/app/Jobs/MovePipeline/CleanupLegacyAccountMovePipeline.php
@@ -48,7 +48,7 @@ class CleanupLegacyAccountMovePipeline implements ShouldQueue
     public function middleware(): array
     {
         return [
-            new WithoutOverlapping('process-move-cleanup-legacy-followers:'.$this->activity),
+            new WithoutOverlapping('process-move-cleanup-legacy-followers:'.$this->target),
             (new ThrottlesExceptions(2, 5 * 60))->backoff(5),
         ];
     }
@@ -59,16 +59,6 @@ class CleanupLegacyAccountMovePipeline implements ShouldQueue
     public function retryUntil(): DateTime
     {
         return now()->addMinutes(15);
-    }
-
-    /**
-     * Get the middleware the job should pass through.
-     *
-     * @return array<int, object>
-     */
-    public function middleware(): array
-    {
-        return [new WithoutOverlapping($this->target)];
     }
 
     /**

--- a/app/Jobs/MovePipeline/CleanupLegacyAccountMovePipeline.php
+++ b/app/Jobs/MovePipeline/CleanupLegacyAccountMovePipeline.php
@@ -4,11 +4,12 @@ namespace App\Jobs\MovePipeline;
 
 use App\Follower;
 use App\Util\ActivityPub\Helpers;
+use DateTime;
 use Exception;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Queue\Middleware\ThrottlesExceptions;
 use Illuminate\Queue\Middleware\WithoutOverlapping;
-use DateTime;
 
 class CleanupLegacyAccountMovePipeline implements ShouldQueue
 {

--- a/app/Jobs/MovePipeline/CleanupLegacyAccountMovePipeline.php
+++ b/app/Jobs/MovePipeline/CleanupLegacyAccountMovePipeline.php
@@ -5,6 +5,7 @@ namespace App\Jobs\MovePipeline;
 use App\Follower;
 use App\Profile;
 use App\Services\AccountService;
+use App\UserFilter;
 use App\Util\ActivityPub\Helpers;
 use DateTime;
 use Exception;
@@ -83,6 +84,10 @@ class CleanupLegacyAccountMovePipeline implements ShouldQueue
         if (! $targetAccount || ! $actorAccount) {
             throw new Exception('Invalid move accounts');
         }
+
+        UserFilter::where('filterable_type', 'App\Profile')
+            ->where('filterable_id', $actorAccount['id'])
+            ->update(['filterable_id' => $targetAccount['id']]);
 
         Follower::whereFollowingId($actorAccount['id'])->delete();
 

--- a/app/Jobs/MovePipeline/CleanupLegacyAccountMovePipeline.php
+++ b/app/Jobs/MovePipeline/CleanupLegacyAccountMovePipeline.php
@@ -8,6 +8,7 @@ use Exception;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Queue\Middleware\WithoutOverlapping;
+use DateTime;
 
 class CleanupLegacyAccountMovePipeline implements ShouldQueue
 {

--- a/app/Jobs/MovePipeline/MoveMigrateFollowersPipeline.php
+++ b/app/Jobs/MovePipeline/MoveMigrateFollowersPipeline.php
@@ -14,50 +14,26 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Queue\Middleware\ThrottlesExceptionsWithRedis;
 use Illuminate\Queue\Middleware\WithoutOverlapping;
+use Illuminate\Support\Facades\Log;
+use GuzzleHttp\Psr7\Request;
 
 class MoveMigrateFollowersPipeline implements ShouldQueue
 {
     use Queueable;
 
-    public $target;
+    public string $target;
+    public string $activity;
 
-    public $activity;
+    public int $tries = 15;
+    public int $maxExceptions = 5;
+    public int $timeout = 900;
 
-    /**
-     * The number of times the job may be attempted.
-     *
-     * @var int
-     */
-    public $tries = 15;
-
-    /**
-     * The maximum number of unhandled exceptions to allow before failing.
-     *
-     * @var int
-     */
-    public $maxExceptions = 5;
-
-    /**
-     * The number of seconds the job can run before timing out.
-     *
-     * @var int
-     */
-    public $timeout = 900;
-
-    /**
-     * Create a new job instance.
-     */
-    public function __construct($target, $activity)
+    public function __construct(string $target, string $activity)
     {
         $this->target = $target;
         $this->activity = $activity;
     }
 
-    /**
-     * Get the middleware the job should pass through.
-     *
-     * @return array<int, object>
-     */
     public function middleware(): array
     {
         return [
@@ -66,39 +42,110 @@ class MoveMigrateFollowersPipeline implements ShouldQueue
         ];
     }
 
-    /**
-     * Determine the time at which the job should timeout.
-     */
     public function retryUntil(): DateTime
     {
         return now()->addMinutes(15);
     }
 
-    /**
-     * Execute the job.
-     */
     public function handle(): void
     {
-        if (config('app.env') !== 'production' || (bool) config_cache('federation.activitypub.enabled') == false) {
-            throw new Exception('Activitypub not enabled');
+        try {
+            $this->validateEnvironment();
+
+            $targetAccount = $this->fetchProfile($this->target);
+            $actorAccount = $this->fetchProfile($this->activity);
+
+            if (!$targetAccount || !$actorAccount) {
+                throw new Exception('Invalid move accounts');
+            }
+
+            $client = $this->createHttpClient();
+            $targetInbox = $targetAccount['sharedInbox'] ?? $targetAccount['inbox_url'];
+            $targetPid = $targetAccount['id'];
+
+            DB::table('followers')
+                ->join('profiles', 'followers.profile_id', '=', 'profiles.id')
+                ->where('followers.following_id', $actorAccount['id'])
+                ->whereNotNull('profiles.user_id')
+                ->whereNull('profiles.deleted_at')
+                ->select('profiles.id', 'profiles.user_id', 'profiles.username', 'profiles.private_key', 'profiles.status')
+                ->chunkById(100, function ($followers) use ($client, $targetInbox, $targetPid) {
+                    $this->processFollowerChunk($followers, $client, $targetInbox, $targetPid);
+                }, 'id');
+        } catch (Exception $e) {
+            Log::error('MoveMigrateFollowersPipeline failed', [
+                'target' => $this->target,
+                'activity' => $this->activity,
+                'error' => $e->getMessage()
+            ]);
+            throw $e;
         }
+    }
 
-        $target = $this->target;
-        $actor = $this->activity;
-
-        $targetAccount = Helpers::profileFetch($target);
-        $actorAccount = Helpers::profileFetch($actor);
-
-        if (! $targetAccount || ! $actorAccount) {
-            throw new Exception('Invalid move accounts');
+    private function validateEnvironment(): void
+    {
+        if (config('app.env') !== 'production' || !(bool)config('federation.activitypub.enabled')) {
+            throw new Exception('ActivityPub not enabled');
         }
+    }
 
+    private function fetchProfile(string $url): ?array
+    {
+        return Helpers::profileFetch($url);
+    }
+
+    private function createHttpClient(): Client
+    {
+        return new Client([
+            'timeout' => config('federation.activitypub.delivery.timeout'),
+        ]);
+    }
+
+    private function processFollowerChunk($followers, Client $client, string $targetInbox, int $targetPid): void
+    {
+        $requests = $this->generateRequests($followers, $targetInbox, $targetPid);
+
+        $pool = new Pool($client, $requests, [
+            'concurrency' => config('federation.activitypub.delivery.concurrency'),
+            'fulfilled' => function ($response, $index) {
+                // Log success if needed
+            },
+            'rejected' => function ($reason, $index) {
+                Log::error('Failed to process follower', ['reason' => $reason, 'index' => $index]);
+            },
+        ]);
+
+        $pool->promise()->wait();
+    }
+
+    private function generateRequests($followers, string $targetInbox, int $targetPid): \Generator
+    {
+        foreach ($followers as $follower) {
+            if (!$this->isValidFollower($follower)) {
+                continue;
+            }
+
+            yield $this->createFollowRequest($follower, $targetInbox, $targetPid);
+        }
+    }
+
+    private function isValidFollower($follower): bool
+    {
+        return $follower->private_key && $follower->username && $follower->user_id && $follower->status !== 'delete';
+    }
+
+    private function createFollowRequest($follower, string $targetInbox, int $targetPid): \GuzzleHttp\Psr7\Request
+    {
+        $permalink = 'https://'.config('pixelfed.domain.app').'/users/'.$follower->username;
         $activity = [
             '@context' => 'https://www.w3.org/ns/activitystreams',
             'type' => 'Follow',
-            'actor' => null,
-            'object' => $target,
+            'actor' => $permalink,
+            'object' => $this->target,
         ];
+
+        $keyId = $permalink.'#main-key';
+        $payload = json_encode($activity);
 
         $version = config('pixelfed.version');
         $appUrl = config('app.url');
@@ -107,59 +154,14 @@ class MoveMigrateFollowersPipeline implements ShouldQueue
             'Content-Type' => 'application/ld+json; profile="https://www.w3.org/ns/activitystreams"',
             'User-Agent' => $userAgent,
         ];
-        $targetInbox = $targetAccount['sharedInbox'] ?? $targetAccount['inbox_url'];
-        $targetPid = $targetAccount['id'];
 
-        DB::table('followers')
-            ->join('profiles', 'followers.profile_id', '=', 'profiles.id')
-            ->where('followers.following_id', $actorAccount['id'])
-            ->whereNotNull('profiles.user_id')
-            ->whereNull('profiles.deleted_at')
-            ->select('profiles.id', 'profiles.user_id', 'profiles.username', 'profiles.private_key', 'profiles.status')
-            ->chunkById(100, function ($followers) use ($addlHeaders, $targetInbox, $targetPid, $target) {
-                $client = new Client([
-                    'timeout' => config('federation.activitypub.delivery.timeout'),
-                ]);
-                $requests = function ($followers) use ($client, $target, $addlHeaders, $targetInbox, $targetPid) {
-                    $activity = [
-                        '@context' => 'https://www.w3.org/ns/activitystreams',
-                        'type' => 'Follow',
-                        'actor' => null,
-                        'object' => $target,
-                    ];
-                    foreach ($followers as $follower) {
-                        if (! $follower->private_key || ! $follower->username || ! $follower->user_id || $follower->status === 'delete') {
-                            continue;
-                        }
-                        $permalink = 'https://'.config('pixelfed.domain.app').'/users/'.$follower->username;
-                        $activity['actor'] = $permalink;
-                        $keyId = $permalink.'#main-key';
-                        $payload = json_encode($activity);
-                        $url = $targetInbox;
-                        $headers = HttpSignature::signRaw($follower->private_key, $keyId, $targetInbox, $activity, $addlHeaders);
-                        Follower::updateOrCreate([
-                            'profile_id' => $follower->id,
-                            'following_id' => $targetPid,
-                        ]);
-                        yield new $client->postAsync($url, [
-                            'curl' => [
-                                CURLOPT_HTTPHEADER => $headers,
-                                CURLOPT_POSTFIELDS => $payload,
-                                CURLOPT_HEADER => true,
-                            ],
-                        ]);
-                    }
-                };
+        $headers = HttpSignature::signRaw($follower->private_key, $keyId, $targetInbox, $activity, $addlHeaders);
 
-                $pool = new Pool($client, $requests($followers), [
-                    'concurrency' => config('federation.activitypub.delivery.concurrency'),
-                    'fulfilled' => function ($response, $index) {},
-                    'rejected' => function ($reason, $index) {},
-                ]);
+        Follower::updateOrCreate([
+            'profile_id' => $follower->id,
+            'following_id' => $targetPid,
+        ]);
 
-                $promise = $pool->promise();
-
-                $promise->wait();
-            }, 'id');
+        return new Request('POST', $targetInbox, $headers, $payload);
     }
 }

--- a/app/Jobs/MovePipeline/MoveMigrateFollowersPipeline.php
+++ b/app/Jobs/MovePipeline/MoveMigrateFollowersPipeline.php
@@ -66,16 +66,6 @@ class MoveMigrateFollowersPipeline implements ShouldQueue
     }
 
     /**
-     * Get the middleware the job should pass through.
-     *
-     * @return array<int, object>
-     */
-    public function middleware(): array
-    {
-        return [new WithoutOverlapping($this->target)];
-    }
-
-    /**
      * Execute the job.
      */
     public function handle(): void

--- a/app/Jobs/MovePipeline/MoveMigrateFollowersPipeline.php
+++ b/app/Jobs/MovePipeline/MoveMigrateFollowersPipeline.php
@@ -10,22 +10,25 @@ use DB;
 use Exception;
 use GuzzleHttp\Client;
 use GuzzleHttp\Pool;
+use GuzzleHttp\Psr7\Request;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Queue\Middleware\ThrottlesExceptionsWithRedis;
 use Illuminate\Queue\Middleware\WithoutOverlapping;
 use Illuminate\Support\Facades\Log;
-use GuzzleHttp\Psr7\Request;
 
 class MoveMigrateFollowersPipeline implements ShouldQueue
 {
     use Queueable;
 
     public string $target;
+
     public string $activity;
 
     public int $tries = 15;
+
     public int $maxExceptions = 5;
+
     public int $timeout = 900;
 
     public function __construct(string $target, string $activity)
@@ -55,7 +58,7 @@ class MoveMigrateFollowersPipeline implements ShouldQueue
             $targetAccount = $this->fetchProfile($this->target);
             $actorAccount = $this->fetchProfile($this->activity);
 
-            if (!$targetAccount || !$actorAccount) {
+            if (! $targetAccount || ! $actorAccount) {
                 throw new Exception('Invalid move accounts');
             }
 
@@ -76,7 +79,7 @@ class MoveMigrateFollowersPipeline implements ShouldQueue
             Log::error('MoveMigrateFollowersPipeline failed', [
                 'target' => $this->target,
                 'activity' => $this->activity,
-                'error' => $e->getMessage()
+                'error' => $e->getMessage(),
             ]);
             throw $e;
         }
@@ -84,7 +87,7 @@ class MoveMigrateFollowersPipeline implements ShouldQueue
 
     private function validateEnvironment(): void
     {
-        if (config('app.env') !== 'production' || !(bool)config('federation.activitypub.enabled')) {
+        if (config('app.env') !== 'production' || ! (bool) config('federation.activitypub.enabled')) {
             throw new Exception('ActivityPub not enabled');
         }
     }
@@ -121,7 +124,7 @@ class MoveMigrateFollowersPipeline implements ShouldQueue
     private function generateRequests($followers, string $targetInbox, int $targetPid): \Generator
     {
         foreach ($followers as $follower) {
-            if (!$this->isValidFollower($follower)) {
+            if (! $this->isValidFollower($follower)) {
                 continue;
             }
 

--- a/app/Jobs/MovePipeline/MoveMigrateFollowersPipeline.php
+++ b/app/Jobs/MovePipeline/MoveMigrateFollowersPipeline.php
@@ -5,14 +5,15 @@ namespace App\Jobs\MovePipeline;
 use App\Follower;
 use App\Util\ActivityPub\Helpers;
 use App\Util\ActivityPub\HttpSignature;
+use DateTime;
 use DB;
 use Exception;
 use GuzzleHttp\Client;
 use GuzzleHttp\Pool;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Queue\Middleware\ThrottlesExceptions;
 use Illuminate\Queue\Middleware\WithoutOverlapping;
-use DateTime;
 
 class MoveMigrateFollowersPipeline implements ShouldQueue
 {

--- a/app/Jobs/MovePipeline/MoveMigrateFollowersPipeline.php
+++ b/app/Jobs/MovePipeline/MoveMigrateFollowersPipeline.php
@@ -63,7 +63,7 @@ class MoveMigrateFollowersPipeline implements ShouldQueue
      */
     public function retryUntil(): DateTime
     {
-        return now()->addMinutes(15);
+        return now()->addMinutes(5);
     }
 
     /**

--- a/app/Jobs/MovePipeline/MoveMigrateFollowersPipeline.php
+++ b/app/Jobs/MovePipeline/MoveMigrateFollowersPipeline.php
@@ -1,0 +1,157 @@
+<?php
+
+namespace App\Jobs\MovePipeline;
+
+use App\Follower;
+use App\Util\ActivityPub\Helpers;
+use App\Util\ActivityPub\HttpSignature;
+use DB;
+use Exception;
+use GuzzleHttp\Client;
+use GuzzleHttp\Pool;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Queue\Middleware\WithoutOverlapping;
+
+class MoveMigrateFollowersPipeline implements ShouldQueue
+{
+    use Queueable;
+
+    public $target;
+
+    public $activity;
+
+    /**
+     * The number of times the job may be attempted.
+     *
+     * @var int
+     */
+    public $tries = 6;
+
+    /**
+     * The maximum number of unhandled exceptions to allow before failing.
+     *
+     * @var int
+     */
+    public $maxExceptions = 3;
+
+    /**
+     * Create a new job instance.
+     */
+    public function __construct($target, $activity)
+    {
+        $this->target = $target;
+        $this->activity = $activity;
+    }
+
+    /**
+     * Get the middleware the job should pass through.
+     *
+     * @return array<int, object>
+     */
+    public function middleware(): array
+    {
+        return [
+            new WithoutOverlapping('process-move-migrate-followers:'.$this->target),
+            (new ThrottlesExceptions(2, 5 * 60))->backoff(5),
+        ];
+    }
+
+    /**
+     * Determine the time at which the job should timeout.
+     */
+    public function retryUntil(): DateTime
+    {
+        return now()->addMinutes(15);
+    }
+
+    /**
+     * Get the middleware the job should pass through.
+     *
+     * @return array<int, object>
+     */
+    public function middleware(): array
+    {
+        return [new WithoutOverlapping($this->target)];
+    }
+
+    /**
+     * Execute the job.
+     */
+    public function handle(): void
+    {
+        if (config('app.env') !== 'production' || (bool) config_cache('federation.activitypub.enabled') == false) {
+            throw new Exception('Activitypub not enabled');
+        }
+
+        $target = $this->target;
+        $actor = $this->activity;
+
+        $targetAccount = Helpers::profileFetch($target);
+        $actorAccount = Helpers::profileFetch($actor);
+
+        if (! $targetAccount || ! $actorAccount) {
+            throw new Exception('Invalid move accounts');
+        }
+
+        $activity = [
+            '@context' => 'https://www.w3.org/ns/activitystreams',
+            'type' => 'Follow',
+            'actor' => null,
+            'object' => $target,
+        ];
+
+        $version = config('pixelfed.version');
+        $appUrl = config('app.url');
+        $userAgent = "(Pixelfed/{$version}; +{$appUrl})";
+        $addlHeaders = [
+            'Content-Type' => 'application/ld+json; profile="https://www.w3.org/ns/activitystreams"',
+            'User-Agent' => $userAgent,
+        ];
+        $targetInbox = $targetAccount['sharedInbox'] ?? $targetAccount['inbox_url'];
+        $targetPid = $targetAccount['id'];
+
+        DB::table('followers')
+            ->join('profiles', 'followers.profile_id', '=', 'profiles.id')
+            ->where('followers.following_id', $actorAccount['id'])
+            ->whereNotNull('profiles.user_id')
+            ->whereNull('profiles.deleted_at')
+            ->select('profiles.id', 'profiles.user_id', 'profiles.username', 'profiles.private_key')
+            ->chunkById(100, function ($followers) use ($activity, $addlHeaders, $targetInbox, $targetPid) {
+                $client = new Client([
+                    'timeout' => config('federation.activitypub.delivery.timeout'),
+                ]);
+                $requests = function ($followers) use ($client, $activity, $addlHeaders, $targetInbox, $targetPid) {
+                    foreach ($followers as $follower) {
+                        $permalink = 'https://'.config('pixelfed.domain.app').'/users/'.$follower->username;
+                        $activity['actor'] = $permalink;
+                        $keyId = $permalink.'#main-key';
+                        $payload = json_encode($activity);
+                        $url = $targetInbox;
+                        $headers = HttpSignature::signRaw($follower->private_key, $keyId, $targetInbox, $activity, $addlHeaders);
+                        Follower::updateOrCreate([
+                            'profile_id' => $follower->id,
+                            'following_id' => $targetPid,
+                        ]);
+                        yield new $client->postAsync($url, [
+                            'curl' => [
+                                CURLOPT_HTTPHEADER => $headers,
+                                CURLOPT_POSTFIELDS => $payload,
+                                CURLOPT_HEADER => true,
+                            ],
+                        ]);
+                    }
+                };
+
+                $pool = new Pool($client, $requests($followers), [
+                    'concurrency' => config('federation.activitypub.delivery.concurrency'),
+                    'fulfilled' => function ($response, $index) {},
+                    'rejected' => function ($reason, $index) {},
+                ]);
+
+                $promise = $pool->promise();
+
+                $promise->wait();
+            }, 'id');
+    }
+}

--- a/app/Jobs/MovePipeline/MoveMigrateFollowersPipeline.php
+++ b/app/Jobs/MovePipeline/MoveMigrateFollowersPipeline.php
@@ -10,33 +10,54 @@ use DB;
 use Exception;
 use GuzzleHttp\Client;
 use GuzzleHttp\Pool;
-use GuzzleHttp\Psr7\Request;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Queue\Middleware\ThrottlesExceptionsWithRedis;
 use Illuminate\Queue\Middleware\WithoutOverlapping;
-use Illuminate\Support\Facades\Log;
 
 class MoveMigrateFollowersPipeline implements ShouldQueue
 {
     use Queueable;
 
-    public string $target;
+    public $target;
 
-    public string $activity;
+    public $activity;
 
-    public int $tries = 15;
+    /**
+     * The number of times the job may be attempted.
+     *
+     * @var int
+     */
+    public $tries = 15;
 
-    public int $maxExceptions = 5;
+    /**
+     * The maximum number of unhandled exceptions to allow before failing.
+     *
+     * @var int
+     */
+    public $maxExceptions = 5;
 
-    public int $timeout = 900;
+    /**
+     * The number of seconds the job can run before timing out.
+     *
+     * @var int
+     */
+    public $timeout = 900;
 
-    public function __construct(string $target, string $activity)
+    /**
+     * Create a new job instance.
+     */
+    public function __construct($target, $activity)
     {
         $this->target = $target;
         $this->activity = $activity;
     }
 
+    /**
+     * Get the middleware the job should pass through.
+     *
+     * @return array<int, object>
+     */
     public function middleware(): array
     {
         return [
@@ -45,110 +66,39 @@ class MoveMigrateFollowersPipeline implements ShouldQueue
         ];
     }
 
+    /**
+     * Determine the time at which the job should timeout.
+     */
     public function retryUntil(): DateTime
     {
         return now()->addMinutes(15);
     }
 
+    /**
+     * Execute the job.
+     */
     public function handle(): void
     {
-        try {
-            $this->validateEnvironment();
-
-            $targetAccount = $this->fetchProfile($this->target);
-            $actorAccount = $this->fetchProfile($this->activity);
-
-            if (! $targetAccount || ! $actorAccount) {
-                throw new Exception('Invalid move accounts');
-            }
-
-            $client = $this->createHttpClient();
-            $targetInbox = $targetAccount['sharedInbox'] ?? $targetAccount['inbox_url'];
-            $targetPid = $targetAccount['id'];
-
-            DB::table('followers')
-                ->join('profiles', 'followers.profile_id', '=', 'profiles.id')
-                ->where('followers.following_id', $actorAccount['id'])
-                ->whereNotNull('profiles.user_id')
-                ->whereNull('profiles.deleted_at')
-                ->select('profiles.id', 'profiles.user_id', 'profiles.username', 'profiles.private_key', 'profiles.status')
-                ->chunkById(100, function ($followers) use ($client, $targetInbox, $targetPid) {
-                    $this->processFollowerChunk($followers, $client, $targetInbox, $targetPid);
-                }, 'id');
-        } catch (Exception $e) {
-            Log::error('MoveMigrateFollowersPipeline failed', [
-                'target' => $this->target,
-                'activity' => $this->activity,
-                'error' => $e->getMessage(),
-            ]);
-            throw $e;
+        if (config('app.env') !== 'production' || (bool) config_cache('federation.activitypub.enabled') == false) {
+            throw new Exception('Activitypub not enabled');
         }
-    }
 
-    private function validateEnvironment(): void
-    {
-        if (config('app.env') !== 'production' || ! (bool) config('federation.activitypub.enabled')) {
-            throw new Exception('ActivityPub not enabled');
+        $target = $this->target;
+        $actor = $this->activity;
+
+        $targetAccount = Helpers::profileFetch($target);
+        $actorAccount = Helpers::profileFetch($actor);
+
+        if (! $targetAccount || ! $actorAccount) {
+            throw new Exception('Invalid move accounts');
         }
-    }
 
-    private function fetchProfile(string $url): ?array
-    {
-        return Helpers::profileFetch($url);
-    }
-
-    private function createHttpClient(): Client
-    {
-        return new Client([
-            'timeout' => config('federation.activitypub.delivery.timeout'),
-        ]);
-    }
-
-    private function processFollowerChunk($followers, Client $client, string $targetInbox, int $targetPid): void
-    {
-        $requests = $this->generateRequests($followers, $targetInbox, $targetPid);
-
-        $pool = new Pool($client, $requests, [
-            'concurrency' => config('federation.activitypub.delivery.concurrency'),
-            'fulfilled' => function ($response, $index) {
-                // Log success if needed
-            },
-            'rejected' => function ($reason, $index) {
-                Log::error('Failed to process follower', ['reason' => $reason, 'index' => $index]);
-            },
-        ]);
-
-        $pool->promise()->wait();
-    }
-
-    private function generateRequests($followers, string $targetInbox, int $targetPid): \Generator
-    {
-        foreach ($followers as $follower) {
-            if (! $this->isValidFollower($follower)) {
-                continue;
-            }
-
-            yield $this->createFollowRequest($follower, $targetInbox, $targetPid);
-        }
-    }
-
-    private function isValidFollower($follower): bool
-    {
-        return $follower->private_key && $follower->username && $follower->user_id && $follower->status !== 'delete';
-    }
-
-    private function createFollowRequest($follower, string $targetInbox, int $targetPid): \GuzzleHttp\Psr7\Request
-    {
-        $permalink = 'https://'.config('pixelfed.domain.app').'/users/'.$follower->username;
         $activity = [
             '@context' => 'https://www.w3.org/ns/activitystreams',
             'type' => 'Follow',
-            'actor' => $permalink,
-            'object' => $this->target,
+            'actor' => null,
+            'object' => $target,
         ];
-
-        $keyId = $permalink.'#main-key';
-        $payload = json_encode($activity);
 
         $version = config('pixelfed.version');
         $appUrl = config('app.url');
@@ -157,14 +107,61 @@ class MoveMigrateFollowersPipeline implements ShouldQueue
             'Content-Type' => 'application/ld+json; profile="https://www.w3.org/ns/activitystreams"',
             'User-Agent' => $userAgent,
         ];
+        $targetInbox = $targetAccount['sharedInbox'] ?? $targetAccount['inbox_url'];
+        $targetPid = $targetAccount['id'];
 
-        $headers = HttpSignature::signRaw($follower->private_key, $keyId, $targetInbox, $activity, $addlHeaders);
+        DB::table('followers')
+            ->join('profiles', 'followers.profile_id', '=', 'profiles.id')
+            ->where('followers.following_id', $actorAccount['id'])
+            ->whereNotNull('profiles.user_id')
+            ->whereNull('profiles.deleted_at')
+            ->select('profiles.id', 'profiles.user_id', 'profiles.username', 'profiles.private_key', 'profiles.status')
+            ->chunkById(100, function ($followers) use ($addlHeaders, $targetInbox, $targetPid, $target) {
+                $client = new Client([
+                    'timeout' => config('federation.activitypub.delivery.timeout'),
+                ]);
+                $requests = function ($followers) use ($client, $target, $addlHeaders, $targetInbox, $targetPid) {
+                    $activity = [
+                        '@context' => 'https://www.w3.org/ns/activitystreams',
+                        'type' => 'Follow',
+                        'actor' => null,
+                        'object' => $target,
+                    ];
+                    foreach ($followers as $follower) {
+                        if (! $follower->private_key || ! $follower->username || ! $follower->user_id || $follower->status === 'delete') {
+                            continue;
+                        }
+                        $permalink = 'https://'.config('pixelfed.domain.app').'/users/'.$follower->username;
+                        $activity['actor'] = $permalink;
+                        $keyId = $permalink.'#main-key';
+                        $payload = json_encode($activity);
+                        $url = $targetInbox;
+                        $headers = HttpSignature::signRaw($follower->private_key, $keyId, $targetInbox, $activity, $addlHeaders);
+                        Follower::updateOrCreate([
+                            'profile_id' => $follower->id,
+                            'following_id' => $targetPid,
+                        ]);
+                        yield function () use ($client, $url, $headers, $payload) {
+                            return $client->postAsync($url, [
+                                'curl' => [
+                                    CURLOPT_HTTPHEADER => $headers,
+                                    CURLOPT_POSTFIELDS => $payload,
+                                    CURLOPT_HEADER => true,
+                                ],
+                            ]);
+                        };
+                    }
+                };
 
-        Follower::updateOrCreate([
-            'profile_id' => $follower->id,
-            'following_id' => $targetPid,
-        ]);
+                $pool = new Pool($client, $requests($followers), [
+                    'concurrency' => config('federation.activitypub.delivery.concurrency'),
+                    'fulfilled' => function ($response, $index) {},
+                    'rejected' => function ($reason, $index) {},
+                ]);
 
-        return new Request('POST', $targetInbox, $headers, $payload);
+                $promise = $pool->promise();
+
+                $promise->wait();
+            }, 'id');
     }
 }

--- a/app/Jobs/MovePipeline/MoveMigrateFollowersPipeline.php
+++ b/app/Jobs/MovePipeline/MoveMigrateFollowersPipeline.php
@@ -12,6 +12,7 @@ use GuzzleHttp\Pool;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Queue\Middleware\WithoutOverlapping;
+use DateTime;
 
 class MoveMigrateFollowersPipeline implements ShouldQueue
 {

--- a/app/Jobs/MovePipeline/MoveSendFollowPipeline.php
+++ b/app/Jobs/MovePipeline/MoveSendFollowPipeline.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Util\ActivityPub\HttpSignature;
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\ClientException;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Queue\Middleware\ThrottlesExceptions;
+use Illuminate\Queue\Middleware\WithoutOverlapping;
+
+class MoveSendFollowPipeline implements ShouldQueue
+{
+    use Queueable;
+
+    public $follower;
+
+    public $targetInbox;
+
+    public $targetPid;
+
+    public $target;
+
+    /**
+     * The number of times the job may be attempted.
+     *
+     * @var int
+     */
+    public $tries = 5;
+
+    /**
+     * The maximum number of unhandled exceptions to allow before failing.
+     *
+     * @var int
+     */
+    public $maxExceptions = 3;
+
+    /**
+     * Get the middleware the job should pass through.
+     *
+     * @return array<int, object>
+     */
+    public function middleware(): array
+    {
+        return [
+            new WithoutOverlapping('move-send-follow:'.$this->follower->id.':target:'.$this->target),
+            (new ThrottlesExceptions(2, 5 * 60))->backoff(5),
+        ];
+    }
+
+    /**
+     * Create a new job instance.
+     */
+    public function __construct($follower, $targetInbox, $targetPid, $target)
+    {
+        $this->follower = $follower;
+        $this->targetInbox = $targetInbox;
+        $this->targetPid = $targetPid;
+        $this->target = $target;
+    }
+
+    /**
+     * Execute the job.
+     */
+    public function handle(): void
+    {
+        $follower = $this->follower;
+        $targetPid = $this->targetPid;
+        $targetInbox = $this->targetInbox;
+        $target = $this->target;
+
+        if (! $follower->username || ! $follower->private_key) {
+            return;
+        }
+
+        $permalink = 'https://'.config('pixelfed.domain.app').'/users/'.$follower->username;
+        $version = config('pixelfed.version');
+        $appUrl = config('app.url');
+        $userAgent = "(Pixelfed/{$version}; +{$appUrl})";
+        $addlHeaders = [
+            'Content-Type' => 'application/ld+json; profile="https://www.w3.org/ns/activitystreams"',
+            'User-Agent' => $userAgent,
+        ];
+
+        $activity = [
+            '@context' => 'https://www.w3.org/ns/activitystreams',
+            'type' => 'Follow',
+            'actor' => $permalink,
+            'object' => $target,
+        ];
+
+        $keyId = $permalink.'#main-key';
+        $payload = json_encode($activity);
+        $headers = HttpSignature::signRaw($follower->private_key, $keyId, $targetInbox, $activity, $addlHeaders);
+
+        $client = new Client([
+            'timeout' => config('federation.activitypub.delivery.timeout'),
+        ]);
+
+        try {
+            $client->post($targetInbox, [
+                'curl' => [
+                    CURLOPT_HTTPHEADER => $headers,
+                    CURLOPT_POSTFIELDS => $payload,
+                    CURLOPT_HEADER => true,
+                ],
+            ]);
+        } catch (ClientException $e) {
+
+        }
+    }
+}

--- a/app/Jobs/MovePipeline/MoveSendFollowPipeline.php
+++ b/app/Jobs/MovePipeline/MoveSendFollowPipeline.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Jobs;
+namespace App\Jobs\MovePipeline;
 
 use App\Util\ActivityPub\HttpSignature;
 use GuzzleHttp\Client;

--- a/app/Jobs/MovePipeline/MoveSendUndoFollowPipeline.php
+++ b/app/Jobs/MovePipeline/MoveSendUndoFollowPipeline.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Jobs;
+namespace App\Jobs\MovePipeline;
 
 use App\Util\ActivityPub\HttpSignature;
 use GuzzleHttp\Client;

--- a/app/Jobs/MovePipeline/MoveSendUndoFollowPipeline.php
+++ b/app/Jobs/MovePipeline/MoveSendUndoFollowPipeline.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Util\ActivityPub\HttpSignature;
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\ClientException;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Queue\Middleware\ThrottlesExceptions;
+use Illuminate\Queue\Middleware\WithoutOverlapping;
+
+class MoveSendUndoFollowPipeline implements ShouldQueue
+{
+    use Queueable;
+
+    public $follower;
+
+    public $targetInbox;
+
+    public $targetPid;
+
+    public $actor;
+
+    /**
+     * The number of times the job may be attempted.
+     *
+     * @var int
+     */
+    public $tries = 5;
+
+    /**
+     * The maximum number of unhandled exceptions to allow before failing.
+     *
+     * @var int
+     */
+    public $maxExceptions = 3;
+
+    /**
+     * Get the middleware the job should pass through.
+     *
+     * @return array<int, object>
+     */
+    public function middleware(): array
+    {
+        return [
+            new WithoutOverlapping('move-send-unfollow:'.$this->follower->id.':actor:'.$this->actor),
+            (new ThrottlesExceptions(2, 5 * 60))->backoff(5),
+        ];
+    }
+
+    /**
+     * Create a new job instance.
+     */
+    public function __construct($follower, $targetInbox, $targetPid, $actor)
+    {
+        $this->follower = $follower;
+        $this->targetInbox = $targetInbox;
+        $this->targetPid = $targetPid;
+        $this->actor = $actor;
+    }
+
+    /**
+     * Execute the job.
+     */
+    public function handle(): void
+    {
+        $follower = $this->follower;
+        $targetPid = $this->targetPid;
+        $targetInbox = $this->targetInbox;
+        $actor = $this->actor;
+
+        if (! $follower->username || ! $follower->private_key) {
+            return;
+        }
+
+        $permalink = 'https://'.config('pixelfed.domain.app').'/users/'.$follower->username;
+        $version = config('pixelfed.version');
+        $appUrl = config('app.url');
+        $userAgent = "(Pixelfed/{$version}; +{$appUrl})";
+        $addlHeaders = [
+            'Content-Type' => 'application/ld+json; profile="https://www.w3.org/ns/activitystreams"',
+            'User-Agent' => $userAgent,
+        ];
+
+        $activity = [
+            '@context' => 'https://www.w3.org/ns/activitystreams',
+            'type' => 'Undo',
+            'id' => $permalink.'#follow/'.$targetPid.'/undo',
+            'actor' => $permalink,
+            'object' => [
+                'type' => 'Follow',
+                'id' => $permalink.'#follows/'.$targetPid,
+                'object' => $actor,
+                'actor' => $permalink,
+            ],
+        ];
+
+        $keyId = $permalink.'#main-key';
+        $payload = json_encode($activity);
+        $headers = HttpSignature::signRaw($follower->private_key, $keyId, $targetInbox, $activity, $addlHeaders);
+
+        $client = new Client([
+            'timeout' => config('federation.activitypub.delivery.timeout'),
+        ]);
+
+        try {
+            $client->post($targetInbox, [
+                'curl' => [
+                    CURLOPT_HTTPHEADER => $headers,
+                    CURLOPT_POSTFIELDS => $payload,
+                    CURLOPT_HEADER => true,
+                ],
+            ]);
+        } catch (ClientException $e) {
+
+        }
+    }
+}

--- a/app/Jobs/MovePipeline/ProcessMovePipeline.php
+++ b/app/Jobs/MovePipeline/ProcessMovePipeline.php
@@ -3,6 +3,7 @@
 namespace App\Jobs\MovePipeline;
 
 use App\Services\ActivityPubFetchService;
+use App\Util\ActivityPub\Helpers;
 use DateTime;
 use Exception;
 use Illuminate\Contracts\Queue\ShouldQueue;

--- a/app/Jobs/MovePipeline/ProcessMovePipeline.php
+++ b/app/Jobs/MovePipeline/ProcessMovePipeline.php
@@ -61,7 +61,7 @@ class ProcessMovePipeline implements ShouldQueue
      */
     public function retryUntil(): DateTime
     {
-        return now()->addMinutes(15);
+        return now()->addMinutes(5);
     }
 
     /**
@@ -80,7 +80,7 @@ class ProcessMovePipeline implements ShouldQueue
         if (! self::checkActor()) {
             throw new Exception('Invalid actor');
         }
-
+        return;
     }
 
     protected function checkTarget()
@@ -101,7 +101,7 @@ class ProcessMovePipeline implements ShouldQueue
         }
 
         if (is_string($res['alsoKnownAs'])) {
-            return self::lowerTrim($res['alsoKnownAs']) === self::lowerTrim($this->actor);
+            return self::lowerTrim($res['alsoKnownAs']) === self::lowerTrim($this->activity);
         }
 
         if (is_array($res['alsoKnownAs'])) {
@@ -109,7 +109,7 @@ class ProcessMovePipeline implements ShouldQueue
                 return trim(strtolower($value));
             });
 
-            $res = in_array($this->actor, $map);
+            $res = in_array($this->activity, $map);
             $debugMessage = $res ? '[AP][INBOX][MOVE] aka target is valid' : '[AP][INBOX][MOVE] aka target is invalid';
 
             Log::info($debugMessage);
@@ -122,7 +122,7 @@ class ProcessMovePipeline implements ShouldQueue
 
     protected function checkActor()
     {
-        $res = ActivityPubFetchService::fetchRequest($this->actor, true);
+        $res = ActivityPubFetchService::fetchRequest($this->activity, true);
 
         if (! $res || ! isset($res['movedTo'])) {
             Log::info('[AP][INBOX][MOVE] actor_movedTo failure');
@@ -130,7 +130,7 @@ class ProcessMovePipeline implements ShouldQueue
             return false;
         }
 
-        $res = Helpers::profileFetch($this->actor);
+        $res = Helpers::profileFetch($this->activity);
         if (! $res) {
             Log::info('[AP][INBOX][MOVE] actor fetch failure');
 

--- a/app/Jobs/MovePipeline/ProcessMovePipeline.php
+++ b/app/Jobs/MovePipeline/ProcessMovePipeline.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace App\Jobs\MovePipeline;
+
+use App\Services\ActivityPubFetchService;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Queue\Middleware\WithoutOverlapping;
+
+class ProcessMovePipeline implements ShouldQueue
+{
+    use Queueable;
+
+    public $target;
+
+    public $activity;
+
+    /**
+     * Create a new job instance.
+     */
+    public function __construct($target, $activity)
+    {
+        $this->target = $target;
+        $this->activity = $activity;
+    }
+
+    /**
+     * Get the middleware the job should pass through.
+     *
+     * @return array<int, object>
+     */
+    public function middleware(): array
+    {
+        return [new WithoutOverlapping($this->target)];
+    }
+
+    /**
+     * Execute the job.
+     */
+    public function handle(): void
+    {
+        if (! self::checkTarget()) {
+            return;
+        }
+
+        if (! self::checkActor()) {
+            return;
+        }
+    }
+
+    protected function checkTarget()
+    {
+        $res = ActivityPubFetchService::fetchRequest($this->target, true);
+
+        if (! $res || ! isset($res['alsoKnownAs'])) {
+            return false;
+        }
+
+        $res = Helpers::profileFetch($this->target);
+        if (! $res) {
+            return false;
+        }
+
+        if (is_string($res['alsoKnownAs'])) {
+            return self::lowerTrim($res['alsoKnownAs']) === self::lowerTrim($this->actor);
+        }
+
+        if (is_array($res['alsoKnownAs'])) {
+            $map = array_map(self::lowerTrim(), $res['alsoKnownAs']);
+
+            return in_array($this->actor, $map);
+        }
+
+        return false;
+    }
+
+    protected function checkActor()
+    {
+        $res = ActivityPubFetchService::fetchRequest($this->actor, true);
+
+        if (! $res || ! isset($res['movedTo'])) {
+            return false;
+        }
+
+        $res = Helpers::profileFetch($this->actor);
+        if (! $res) {
+            return false;
+        }
+
+        if (is_string($res['movedTo'])) {
+            return self::lowerTrim($res['movedTo']) === self::lowerTrim($this->target);
+        }
+
+        return false;
+    }
+
+    protected function lowerTrim($str)
+    {
+        return trim(strtolower($str));
+    }
+}

--- a/app/Jobs/MovePipeline/ProcessMovePipeline.php
+++ b/app/Jobs/MovePipeline/ProcessMovePipeline.php
@@ -8,6 +8,7 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Queue\Middleware\ThrottlesExceptions;
 use Illuminate\Queue\Middleware\WithoutOverlapping;
+use DateTime;
 
 class ProcessMovePipeline implements ShouldQueue
 {

--- a/app/Jobs/MovePipeline/ProcessMovePipeline.php
+++ b/app/Jobs/MovePipeline/ProcessMovePipeline.php
@@ -70,14 +70,17 @@ class ProcessMovePipeline implements ShouldQueue
     public function handle(): void
     {
         if (config('app.env') !== 'production' || (bool) config_cache('federation.activitypub.enabled') == false) {
+            Log::info('pmp: AP not enabled');
             throw new Exception('Activitypub not enabled');
         }
 
         if (! self::checkTarget()) {
+            Log::info('pmp: invalid target');
             throw new Exception('Invalid target');
         }
 
         if (! self::checkActor()) {
+            Log::info('pmp: invalid actor');
             throw new Exception('Invalid actor');
         }
         return;

--- a/app/Jobs/MovePipeline/ProcessMovePipeline.php
+++ b/app/Jobs/MovePipeline/ProcessMovePipeline.php
@@ -98,7 +98,8 @@ class ProcessMovePipeline implements ShouldQueue
 
     protected function checkTarget()
     {
-        $res = ActivityPubFetchService::fetchRequest($this->target, true);
+        $fetchTargetUrl = $this->target.'?cb='.time();
+        $res = ActivityPubFetchService::fetchRequest($fetchTargetUrl, true);
 
         if (! $res || ! isset($res['alsoKnownAs'])) {
             Log::info('[AP][INBOX][MOVE] target_aka failure');
@@ -135,7 +136,8 @@ class ProcessMovePipeline implements ShouldQueue
 
     protected function checkActor()
     {
-        $res = ActivityPubFetchService::fetchRequest($this->activity, true);
+        $fetchActivityUrl = $this->activity.'?cb='.time();
+        $res = ActivityPubFetchService::fetchRequest($fetchActivityUrl, true);
 
         if (! $res || ! isset($res['movedTo']) || empty($res['movedTo'])) {
             Log::info('[AP][INBOX][MOVE] actor_movedTo failure');

--- a/app/Jobs/MovePipeline/ProcessMovePipeline.php
+++ b/app/Jobs/MovePipeline/ProcessMovePipeline.php
@@ -99,8 +99,8 @@ class ProcessMovePipeline implements ShouldQueue
             return false;
         }
 
-        $res = Helpers::profileFetch($this->target);
-        if (! $res) {
+        $targetRes = Helpers::profileFetch($this->target);
+        if (! $targetRes) {
             Log::info('[AP][INBOX][MOVE] target fetch failure');
 
             return false;
@@ -136,8 +136,8 @@ class ProcessMovePipeline implements ShouldQueue
             return false;
         }
 
-        $res = Helpers::profileFetch($this->activity);
-        if (! $res) {
+        $actorRes = Helpers::profileFetch($this->activity);
+        if (! $actorRes) {
             Log::info('[AP][INBOX][MOVE] actor fetch failure');
 
             return false;

--- a/app/Jobs/MovePipeline/ProcessMovePipeline.php
+++ b/app/Jobs/MovePipeline/ProcessMovePipeline.php
@@ -9,6 +9,7 @@ use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Queue\Middleware\ThrottlesExceptions;
 use Illuminate\Queue\Middleware\WithoutOverlapping;
 use DateTime;
+use Log;
 
 class ProcessMovePipeline implements ShouldQueue
 {
@@ -86,11 +87,13 @@ class ProcessMovePipeline implements ShouldQueue
         $res = ActivityPubFetchService::fetchRequest($this->target, true);
 
         if (! $res || ! isset($res['alsoKnownAs'])) {
+            Log::info('[AP][INBOX][MOVE] target_aka failure');
             return false;
         }
 
         $res = Helpers::profileFetch($this->target);
         if (! $res) {
+            Log::info('[AP][INBOX][MOVE] target fetch failure');
             return false;
         }
 
@@ -112,11 +115,13 @@ class ProcessMovePipeline implements ShouldQueue
         $res = ActivityPubFetchService::fetchRequest($this->actor, true);
 
         if (! $res || ! isset($res['movedTo'])) {
+            Log::info('[AP][INBOX][MOVE] actor_movedTo failure');
             return false;
         }
 
         $res = Helpers::profileFetch($this->actor);
         if (! $res) {
+            Log::info('[AP][INBOX][MOVE] actor fetch failure');
             return false;
         }
 

--- a/app/Jobs/MovePipeline/UnfollowLegacyAccountMovePipeline.php
+++ b/app/Jobs/MovePipeline/UnfollowLegacyAccountMovePipeline.php
@@ -9,31 +9,47 @@ use DB;
 use Exception;
 use GuzzleHttp\Client;
 use GuzzleHttp\Pool;
-use GuzzleHttp\Psr7\Request;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Queue\Middleware\ThrottlesExceptions;
 use Illuminate\Queue\Middleware\WithoutOverlapping;
-use Illuminate\Support\Facades\Log;
 
 class UnfollowLegacyAccountMovePipeline implements ShouldQueue
 {
     use Queueable;
 
-    public string $target;
+    public $target;
 
-    public string $activity;
+    public $activity;
 
-    public int $tries = 6;
+    /**
+     * The number of times the job may be attempted.
+     *
+     * @var int
+     */
+    public $tries = 6;
 
-    public int $maxExceptions = 3;
+    /**
+     * The maximum number of unhandled exceptions to allow before failing.
+     *
+     * @var int
+     */
+    public $maxExceptions = 3;
 
-    public function __construct(string $target, string $activity)
+    /**
+     * Create a new job instance.
+     */
+    public function __construct($target, $activity)
     {
         $this->target = $target;
         $this->activity = $activity;
     }
 
+    /**
+     * Get the middleware the job should pass through.
+     *
+     * @return array<int, object>
+     */
     public function middleware(): array
     {
         return [
@@ -42,121 +58,32 @@ class UnfollowLegacyAccountMovePipeline implements ShouldQueue
         ];
     }
 
+    /**
+     * Determine the time at which the job should timeout.
+     */
     public function retryUntil(): DateTime
     {
         return now()->addMinutes(5);
     }
 
+    /**
+     * Execute the job.
+     */
     public function handle(): void
     {
-        try {
-            $this->validateEnvironment();
-
-            $targetAccount = $this->fetchProfile($this->target);
-            $actorAccount = $this->fetchProfile($this->activity);
-
-            if (! $targetAccount || ! $actorAccount) {
-                throw new Exception('Invalid move accounts');
-            }
-
-            $client = $this->createHttpClient();
-            $targetInbox = $actorAccount['sharedInbox'] ?? $actorAccount['inbox_url'];
-            $targetPid = $actorAccount['id'];
-
-            $this->processFollowers($client, $targetInbox, $targetPid);
-        } catch (Exception $e) {
-            Log::error('UnfollowLegacyAccountMovePipeline failed', [
-                'target' => $this->target,
-                'activity' => $this->activity,
-                'error' => $e->getMessage(),
-            ]);
-            throw $e;
+        if (config('app.env') !== 'production' || (bool) config_cache('federation.activitypub.enabled') == false) {
+            throw new Exception('Activitypub not enabled');
         }
-    }
 
-    private function validateEnvironment(): void
-    {
-        if (config('app.env') !== 'production' || ! (bool) config('federation.activitypub.enabled')) {
-            throw new Exception('ActivityPub not enabled');
+        $target = $this->target;
+        $actor = $this->activity;
+
+        $targetAccount = Helpers::profileFetch($target);
+        $actorAccount = Helpers::profileFetch($actor);
+
+        if (! $targetAccount || ! $actorAccount) {
+            throw new Exception('Invalid move accounts');
         }
-    }
-
-    private function fetchProfile(string $url): ?array
-    {
-        return Helpers::profileFetch($url);
-    }
-
-    private function createHttpClient(): Client
-    {
-        return new Client([
-            'timeout' => config('federation.activitypub.delivery.timeout'),
-        ]);
-    }
-
-    private function processFollowers(Client $client, string $targetInbox, int $targetPid): void
-    {
-        DB::table('followers')
-            ->join('profiles', 'followers.profile_id', '=', 'profiles.id')
-            ->where('followers.following_id', $targetPid)
-            ->whereNotNull('profiles.user_id')
-            ->whereNull('profiles.deleted_at')
-            ->select('profiles.id', 'profiles.user_id', 'profiles.username', 'profiles.private_key', 'profiles.status')
-            ->chunkById(100, function ($followers) use ($client, $targetInbox, $targetPid) {
-                $this->processFollowerChunk($followers, $client, $targetInbox, $targetPid);
-            }, 'id');
-    }
-
-    private function processFollowerChunk($followers, Client $client, string $targetInbox, int $targetPid): void
-    {
-        $requests = $this->generateRequests($followers, $targetInbox, $targetPid);
-
-        $pool = new Pool($client, $requests, [
-            'concurrency' => config('federation.activitypub.delivery.concurrency'),
-            'fulfilled' => function ($response, $index) {
-                // Log success if needed
-            },
-            'rejected' => function ($reason, $index) {
-                Log::error('Failed to process unfollow', ['reason' => $reason, 'index' => $index]);
-            },
-        ]);
-
-        $pool->promise()->wait();
-    }
-
-    private function generateRequests($followers, string $targetInbox, int $targetPid): \Generator
-    {
-        foreach ($followers as $follower) {
-            if (! $this->isValidFollower($follower)) {
-                continue;
-            }
-
-            yield $this->createUnfollowRequest($follower, $targetInbox, $targetPid);
-        }
-    }
-
-    private function isValidFollower($follower): bool
-    {
-        return $follower->private_key && $follower->username && $follower->user_id && $follower->status !== 'delete';
-    }
-
-    private function createUnfollowRequest($follower, string $targetInbox, int $targetPid): Request
-    {
-        $permalink = 'https://'.config('pixelfed.domain.app').'/users/'.$follower->username;
-        $activity = [
-            '@context' => 'https://www.w3.org/ns/activitystreams',
-            'type' => 'Undo',
-            'id' => $permalink.'#follow/'.$targetPid.'/undo',
-            'actor' => $permalink,
-            'object' => [
-                'type' => 'Follow',
-                'id' => $permalink.'#follows/'.$targetPid,
-                'object' => $this->activity,
-                'actor' => $permalink,
-            ],
-        ];
-
-        $keyId = $permalink.'#main-key';
-        $payload = json_encode($activity);
 
         $version = config('pixelfed.version');
         $appUrl = config('app.url');
@@ -165,9 +92,66 @@ class UnfollowLegacyAccountMovePipeline implements ShouldQueue
             'Content-Type' => 'application/ld+json; profile="https://www.w3.org/ns/activitystreams"',
             'User-Agent' => $userAgent,
         ];
+        $targetInbox = $actorAccount['sharedInbox'] ?? $actorAccount['inbox_url'];
+        $targetPid = $actorAccount['id'];
 
-        $headers = HttpSignature::signRaw($follower->private_key, $keyId, $targetInbox, $activity, $addlHeaders);
+        DB::table('followers')
+            ->join('profiles', 'followers.profile_id', '=', 'profiles.id')
+            ->where('followers.following_id', $actorAccount['id'])
+            ->whereNotNull('profiles.user_id')
+            ->whereNull('profiles.deleted_at')
+            ->select('profiles.id', 'profiles.user_id', 'profiles.username', 'profiles.private_key', 'profiles.status')
+            ->chunkById(100, function ($followers) use ($actor, $addlHeaders, $targetInbox, $targetPid) {
+                $client = new Client([
+                    'timeout' => config('federation.activitypub.delivery.timeout'),
+                ]);
+                $requests = function ($followers) use ($client, $actor, $addlHeaders, $targetInbox, $targetPid) {
+                    $activity = [
+                        '@context' => 'https://www.w3.org/ns/activitystreams',
+                        'type' => 'Undo',
+                        'id' => null,
+                        'actor' => null,
+                        'object' => [
+                            'type' => 'Follow',
+                            'id' => null,
+                            'object' => $actor,
+                            'actor' => null,
+                        ],
+                    ];
+                    foreach ($followers as $follower) {
+                        if (! $follower->private_key || ! $follower->username || ! $follower->user_id || $follower->status === 'delete') {
+                            continue;
+                        }
+                        $permalink = 'https://'.config('pixelfed.domain.app').'/users/'.$follower->username;
+                        $activity['id'] = $permalink.'#follow/'.$targetPid.'/undo';
+                        $activity['actor'] = $permalink;
+                        $activity['object']['id'] = $permalink.'#follows/'.$targetPid;
+                        $activity['object']['actor'] = $permalink;
+                        $keyId = $permalink.'#main-key';
+                        $payload = json_encode($activity);
+                        $url = $targetInbox;
+                        $headers = HttpSignature::signRaw($follower->private_key, $keyId, $targetInbox, $activity, $addlHeaders);
+                        yield function () use ($client, $url, $headers, $payload) {
+                            return $client->postAsync($url, [
+                                'curl' => [
+                                    CURLOPT_HTTPHEADER => $headers,
+                                    CURLOPT_POSTFIELDS => $payload,
+                                    CURLOPT_HEADER => true,
+                                ],
+                            ]);
+                        };
+                    }
+                };
 
-        return new Request('POST', $targetInbox, $headers, $payload);
+                $pool = new Pool($client, $requests($followers), [
+                    'concurrency' => config('federation.activitypub.delivery.concurrency'),
+                    'fulfilled' => function ($response, $index) {},
+                    'rejected' => function ($reason, $index) {},
+                ]);
+
+                $promise = $pool->promise();
+
+                $promise->wait();
+            }, 'id');
     }
 }

--- a/app/Jobs/MovePipeline/UnfollowLegacyAccountMovePipeline.php
+++ b/app/Jobs/MovePipeline/UnfollowLegacyAccountMovePipeline.php
@@ -3,12 +3,9 @@
 namespace App\Jobs\MovePipeline;
 
 use App\Util\ActivityPub\Helpers;
-use App\Util\ActivityPub\HttpSignature;
 use DateTime;
 use DB;
 use Exception;
-use GuzzleHttp\Client;
-use GuzzleHttp\Pool;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Queue\Middleware\ThrottlesExceptions;
@@ -101,57 +98,14 @@ class UnfollowLegacyAccountMovePipeline implements ShouldQueue
             ->whereNotNull('profiles.user_id')
             ->whereNull('profiles.deleted_at')
             ->select('profiles.id', 'profiles.user_id', 'profiles.username', 'profiles.private_key', 'profiles.status')
-            ->chunkById(100, function ($followers) use ($actor, $addlHeaders, $targetInbox, $targetPid) {
-                $client = new Client([
-                    'timeout' => config('federation.activitypub.delivery.timeout'),
-                ]);
-                $requests = function ($followers) use ($client, $actor, $addlHeaders, $targetInbox, $targetPid) {
-                    $activity = [
-                        '@context' => 'https://www.w3.org/ns/activitystreams',
-                        'type' => 'Undo',
-                        'id' => null,
-                        'actor' => null,
-                        'object' => [
-                            'type' => 'Follow',
-                            'id' => null,
-                            'object' => $actor,
-                            'actor' => null,
-                        ],
-                    ];
-                    foreach ($followers as $follower) {
-                        if (! $follower->private_key || ! $follower->username || ! $follower->user_id || $follower->status === 'delete') {
-                            continue;
-                        }
-                        $permalink = 'https://'.config('pixelfed.domain.app').'/users/'.$follower->username;
-                        $activity['id'] = $permalink.'#follow/'.$targetPid.'/undo';
-                        $activity['actor'] = $permalink;
-                        $activity['object']['id'] = $permalink.'#follows/'.$targetPid;
-                        $activity['object']['actor'] = $permalink;
-                        $keyId = $permalink.'#main-key';
-                        $payload = json_encode($activity);
-                        $url = $targetInbox;
-                        $headers = HttpSignature::signRaw($follower->private_key, $keyId, $targetInbox, $activity, $addlHeaders);
-                        yield function () use ($client, $url, $headers, $payload) {
-                            return $client->postAsync($url, [
-                                'curl' => [
-                                    CURLOPT_HTTPHEADER => $headers,
-                                    CURLOPT_POSTFIELDS => $payload,
-                                    CURLOPT_HEADER => true,
-                                ],
-                            ]);
-                        };
+            ->chunkById(100, function ($followers) use ($actor, $targetInbox, $targetPid) {
+                foreach ($followers as $follower) {
+                    if (! $follower->id || ! $follower->private_key || ! $follower->username || ! $follower->user_id || $follower->status === 'delete') {
+                        continue;
                     }
-                };
 
-                $pool = new Pool($client, $requests($followers), [
-                    'concurrency' => config('federation.activitypub.delivery.concurrency'),
-                    'fulfilled' => function ($response, $index) {},
-                    'rejected' => function ($reason, $index) {},
-                ]);
-
-                $promise = $pool->promise();
-
-                $promise->wait();
+                    MoveSendUndoFollowPipeline::dispatch($follower, $targetInbox, $targetPid, $actor)->onQueue('move');
+                }
             }, 'id');
     }
 }

--- a/app/Jobs/MovePipeline/UnfollowLegacyAccountMovePipeline.php
+++ b/app/Jobs/MovePipeline/UnfollowLegacyAccountMovePipeline.php
@@ -9,47 +9,29 @@ use DB;
 use Exception;
 use GuzzleHttp\Client;
 use GuzzleHttp\Pool;
+use GuzzleHttp\Psr7\Request;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Queue\Middleware\ThrottlesExceptions;
 use Illuminate\Queue\Middleware\WithoutOverlapping;
+use Illuminate\Support\Facades\Log;
 
 class UnfollowLegacyAccountMovePipeline implements ShouldQueue
 {
     use Queueable;
 
-    public $target;
+    public string $target;
+    public string $activity;
 
-    public $activity;
+    public int $tries = 6;
+    public int $maxExceptions = 3;
 
-    /**
-     * The number of times the job may be attempted.
-     *
-     * @var int
-     */
-    public $tries = 6;
-
-    /**
-     * The maximum number of unhandled exceptions to allow before failing.
-     *
-     * @var int
-     */
-    public $maxExceptions = 3;
-
-    /**
-     * Create a new job instance.
-     */
-    public function __construct($target, $activity)
+    public function __construct(string $target, string $activity)
     {
         $this->target = $target;
         $this->activity = $activity;
     }
 
-    /**
-     * Get the middleware the job should pass through.
-     *
-     * @return array<int, object>
-     */
     public function middleware(): array
     {
         return [
@@ -58,32 +40,121 @@ class UnfollowLegacyAccountMovePipeline implements ShouldQueue
         ];
     }
 
-    /**
-     * Determine the time at which the job should timeout.
-     */
     public function retryUntil(): DateTime
     {
         return now()->addMinutes(5);
     }
 
-    /**
-     * Execute the job.
-     */
     public function handle(): void
     {
-        if (config('app.env') !== 'production' || (bool) config_cache('federation.activitypub.enabled') == false) {
-            throw new Exception('Activitypub not enabled');
+        try {
+            $this->validateEnvironment();
+
+            $targetAccount = $this->fetchProfile($this->target);
+            $actorAccount = $this->fetchProfile($this->activity);
+
+            if (!$targetAccount || !$actorAccount) {
+                throw new Exception('Invalid move accounts');
+            }
+
+            $client = $this->createHttpClient();
+            $targetInbox = $actorAccount['sharedInbox'] ?? $actorAccount['inbox_url'];
+            $targetPid = $actorAccount['id'];
+
+            $this->processFollowers($client, $targetInbox, $targetPid);
+        } catch (Exception $e) {
+            Log::error('UnfollowLegacyAccountMovePipeline failed', [
+                'target' => $this->target,
+                'activity' => $this->activity,
+                'error' => $e->getMessage()
+            ]);
+            throw $e;
         }
+    }
 
-        $target = $this->target;
-        $actor = $this->activity;
-
-        $targetAccount = Helpers::profileFetch($target);
-        $actorAccount = Helpers::profileFetch($actor);
-
-        if (! $targetAccount || ! $actorAccount) {
-            throw new Exception('Invalid move accounts');
+    private function validateEnvironment(): void
+    {
+        if (config('app.env') !== 'production' || !(bool)config('federation.activitypub.enabled')) {
+            throw new Exception('ActivityPub not enabled');
         }
+    }
+
+    private function fetchProfile(string $url): ?array
+    {
+        return Helpers::profileFetch($url);
+    }
+
+    private function createHttpClient(): Client
+    {
+        return new Client([
+            'timeout' => config('federation.activitypub.delivery.timeout'),
+        ]);
+    }
+
+    private function processFollowers(Client $client, string $targetInbox, int $targetPid): void
+    {
+        DB::table('followers')
+            ->join('profiles', 'followers.profile_id', '=', 'profiles.id')
+            ->where('followers.following_id', $targetPid)
+            ->whereNotNull('profiles.user_id')
+            ->whereNull('profiles.deleted_at')
+            ->select('profiles.id', 'profiles.user_id', 'profiles.username', 'profiles.private_key', 'profiles.status')
+            ->chunkById(100, function ($followers) use ($client, $targetInbox, $targetPid) {
+                $this->processFollowerChunk($followers, $client, $targetInbox, $targetPid);
+            }, 'id');
+    }
+
+    private function processFollowerChunk($followers, Client $client, string $targetInbox, int $targetPid): void
+    {
+        $requests = $this->generateRequests($followers, $targetInbox, $targetPid);
+
+        $pool = new Pool($client, $requests, [
+            'concurrency' => config('federation.activitypub.delivery.concurrency'),
+            'fulfilled' => function ($response, $index) {
+                // Log success if needed
+            },
+            'rejected' => function ($reason, $index) {
+                Log::error('Failed to process unfollow', ['reason' => $reason, 'index' => $index]);
+            },
+        ]);
+
+        $pool->promise()->wait();
+    }
+
+    private function generateRequests($followers, string $targetInbox, int $targetPid): \Generator
+    {
+        foreach ($followers as $follower) {
+            if (!$this->isValidFollower($follower)) {
+                continue;
+            }
+
+            yield $this->createUnfollowRequest($follower, $targetInbox, $targetPid);
+        }
+    }
+
+    private function isValidFollower($follower): bool
+    {
+        return $follower->private_key && $follower->username && $follower->user_id && $follower->status !== 'delete';
+    }
+
+    private function createUnfollowRequest($follower, string $targetInbox, int $targetPid): Request
+    {
+        $permalink = 'https://'.config('pixelfed.domain.app').'/users/'.$follower->username;
+        $activity = [
+            '@context' => 'https://www.w3.org/ns/activitystreams',
+            'type' => 'Undo',
+            'id' => $permalink.'#follow/'.$targetPid.'/undo',
+            'actor' => $permalink,
+            'object' => [
+                'type' => 'Follow',
+                'id' => $permalink.'#follows/'.$targetPid,
+                'object' => $this->activity,
+                'actor' => $permalink,
+            ],
+        ];
+
+        $keyId = $permalink.'#main-key';
+        $payload = json_encode($activity);
 
         $version = config('pixelfed.version');
         $appUrl = config('app.url');
@@ -92,64 +163,9 @@ class UnfollowLegacyAccountMovePipeline implements ShouldQueue
             'Content-Type' => 'application/ld+json; profile="https://www.w3.org/ns/activitystreams"',
             'User-Agent' => $userAgent,
         ];
-        $targetInbox = $actorAccount['sharedInbox'] ?? $actorAccount['inbox_url'];
-        $targetPid = $actorAccount['id'];
 
-        DB::table('followers')
-            ->join('profiles', 'followers.profile_id', '=', 'profiles.id')
-            ->where('followers.following_id', $actorAccount['id'])
-            ->whereNotNull('profiles.user_id')
-            ->whereNull('profiles.deleted_at')
-            ->select('profiles.id', 'profiles.user_id', 'profiles.username', 'profiles.private_key', 'profiles.status')
-            ->chunkById(100, function ($followers) use ($actor, $addlHeaders, $targetInbox, $targetPid) {
-                $client = new Client([
-                    'timeout' => config('federation.activitypub.delivery.timeout'),
-                ]);
-                $requests = function ($followers) use ($client, $actor, $addlHeaders, $targetInbox, $targetPid) {
-                    $activity = [
-                        '@context' => 'https://www.w3.org/ns/activitystreams',
-                        'type' => 'Undo',
-                        'id' => null,
-                        'actor' => null,
-                        'object' => [
-                            'type' => 'Follow',
-                            'id' => null,
-                            'object' => $actor,
-                            'actor' => null,
-                        ],
-                    ];
-                    foreach ($followers as $follower) {
-                        if (! $follower->private_key || ! $follower->username || ! $follower->user_id || $follower->status === 'delete') {
-                            continue;
-                        }
-                        $permalink = 'https://'.config('pixelfed.domain.app').'/users/'.$follower->username;
-                        $activity['id'] = $permalink.'#follow/'.$targetPid.'/undo';
-                        $activity['actor'] = $permalink;
-                        $activity['object']['id'] = $permalink.'#follows/'.$targetPid;
-                        $activity['object']['actor'] = $permalink;
-                        $keyId = $permalink.'#main-key';
-                        $payload = json_encode($activity);
-                        $url = $targetInbox;
-                        $headers = HttpSignature::signRaw($follower->private_key, $keyId, $targetInbox, $activity, $addlHeaders);
-                        yield new $client->postAsync($url, [
-                            'curl' => [
-                                CURLOPT_HTTPHEADER => $headers,
-                                CURLOPT_POSTFIELDS => $payload,
-                                CURLOPT_HEADER => true,
-                            ],
-                        ]);
-                    }
-                };
+        $headers = HttpSignature::signRaw($follower->private_key, $keyId, $targetInbox, $activity, $addlHeaders);
 
-                $pool = new Pool($client, $requests($followers), [
-                    'concurrency' => config('federation.activitypub.delivery.concurrency'),
-                    'fulfilled' => function ($response, $index) {},
-                    'rejected' => function ($reason, $index) {},
-                ]);
-
-                $promise = $pool->promise();
-
-                $promise->wait();
-            }, 'id');
+        return new Request('POST', $targetInbox, $headers, $payload);
     }
 }

--- a/app/Jobs/MovePipeline/UnfollowLegacyAccountMovePipeline.php
+++ b/app/Jobs/MovePipeline/UnfollowLegacyAccountMovePipeline.php
@@ -51,7 +51,7 @@ class UnfollowLegacyAccountMovePipeline implements ShouldQueue
     public function middleware(): array
     {
         return [
-            new WithoutOverlapping('process-move-undo-legacy-followers:'.$this->activity),
+            new WithoutOverlapping('process-move-undo-legacy-followers:'.$this->target),
             (new ThrottlesExceptions(2, 5 * 60))->backoff(5),
         ];
     }
@@ -62,16 +62,6 @@ class UnfollowLegacyAccountMovePipeline implements ShouldQueue
     public function retryUntil(): DateTime
     {
         return now()->addMinutes(15);
-    }
-
-    /**
-     * Get the middleware the job should pass through.
-     *
-     * @return array<int, object>
-     */
-    public function middleware(): array
-    {
-        return [new WithoutOverlapping($this->target)];
     }
 
     /**

--- a/app/Jobs/MovePipeline/UnfollowLegacyAccountMovePipeline.php
+++ b/app/Jobs/MovePipeline/UnfollowLegacyAccountMovePipeline.php
@@ -21,9 +21,11 @@ class UnfollowLegacyAccountMovePipeline implements ShouldQueue
     use Queueable;
 
     public string $target;
+
     public string $activity;
 
     public int $tries = 6;
+
     public int $maxExceptions = 3;
 
     public function __construct(string $target, string $activity)
@@ -53,7 +55,7 @@ class UnfollowLegacyAccountMovePipeline implements ShouldQueue
             $targetAccount = $this->fetchProfile($this->target);
             $actorAccount = $this->fetchProfile($this->activity);
 
-            if (!$targetAccount || !$actorAccount) {
+            if (! $targetAccount || ! $actorAccount) {
                 throw new Exception('Invalid move accounts');
             }
 
@@ -66,7 +68,7 @@ class UnfollowLegacyAccountMovePipeline implements ShouldQueue
             Log::error('UnfollowLegacyAccountMovePipeline failed', [
                 'target' => $this->target,
                 'activity' => $this->activity,
-                'error' => $e->getMessage()
+                'error' => $e->getMessage(),
             ]);
             throw $e;
         }
@@ -74,7 +76,7 @@ class UnfollowLegacyAccountMovePipeline implements ShouldQueue
 
     private function validateEnvironment(): void
     {
-        if (config('app.env') !== 'production' || !(bool)config('federation.activitypub.enabled')) {
+        if (config('app.env') !== 'production' || ! (bool) config('federation.activitypub.enabled')) {
             throw new Exception('ActivityPub not enabled');
         }
     }
@@ -124,7 +126,7 @@ class UnfollowLegacyAccountMovePipeline implements ShouldQueue
     private function generateRequests($followers, string $targetInbox, int $targetPid): \Generator
     {
         foreach ($followers as $follower) {
-            if (!$this->isValidFollower($follower)) {
+            if (! $this->isValidFollower($follower)) {
                 continue;
             }
 

--- a/app/Jobs/MovePipeline/UnfollowLegacyAccountMovePipeline.php
+++ b/app/Jobs/MovePipeline/UnfollowLegacyAccountMovePipeline.php
@@ -62,7 +62,7 @@ class UnfollowLegacyAccountMovePipeline implements ShouldQueue
      */
     public function retryUntil(): DateTime
     {
-        return now()->addMinutes(15);
+        return now()->addMinutes(5);
     }
 
     /**

--- a/app/Jobs/MovePipeline/UnfollowLegacyAccountMovePipeline.php
+++ b/app/Jobs/MovePipeline/UnfollowLegacyAccountMovePipeline.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace App\Jobs\MovePipeline;
+
+use App\Util\ActivityPub\Helpers;
+use App\Util\ActivityPub\HttpSignature;
+use DB;
+use Exception;
+use GuzzleHttp\Client;
+use GuzzleHttp\Pool;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Queue\Middleware\WithoutOverlapping;
+
+class UnfollowLegacyAccountMovePipeline implements ShouldQueue
+{
+    use Queueable;
+
+    public $target;
+
+    public $activity;
+
+    /**
+     * The number of times the job may be attempted.
+     *
+     * @var int
+     */
+    public $tries = 6;
+
+    /**
+     * The maximum number of unhandled exceptions to allow before failing.
+     *
+     * @var int
+     */
+    public $maxExceptions = 3;
+
+    /**
+     * Create a new job instance.
+     */
+    public function __construct($target, $activity)
+    {
+        $this->target = $target;
+        $this->activity = $activity;
+    }
+
+    /**
+     * Get the middleware the job should pass through.
+     *
+     * @return array<int, object>
+     */
+    public function middleware(): array
+    {
+        return [
+            new WithoutOverlapping('process-move-undo-legacy-followers:'.$this->activity),
+            (new ThrottlesExceptions(2, 5 * 60))->backoff(5),
+        ];
+    }
+
+    /**
+     * Determine the time at which the job should timeout.
+     */
+    public function retryUntil(): DateTime
+    {
+        return now()->addMinutes(15);
+    }
+
+    /**
+     * Get the middleware the job should pass through.
+     *
+     * @return array<int, object>
+     */
+    public function middleware(): array
+    {
+        return [new WithoutOverlapping($this->target)];
+    }
+
+    /**
+     * Execute the job.
+     */
+    public function handle(): void
+    {
+        if (config('app.env') !== 'production' || (bool) config_cache('federation.activitypub.enabled') == false) {
+            throw new Exception('Activitypub not enabled');
+        }
+
+        $target = $this->target;
+        $actor = $this->activity;
+
+        $targetAccount = Helpers::profileFetch($target);
+        $actorAccount = Helpers::profileFetch($actor);
+
+        if (! $targetAccount || ! $actorAccount) {
+            throw new Exception('Invalid move accounts');
+        }
+
+        $activity = [
+            '@context' => 'https://www.w3.org/ns/activitystreams',
+            'type' => 'Undo',
+            'id' => null,
+            'actor' => null,
+            'object' => [
+                'type' => 'Follow',
+                'id' => null,
+                'object' => $actor,
+                'actor' => null,
+            ],
+        ];
+
+        $version = config('pixelfed.version');
+        $appUrl = config('app.url');
+        $userAgent = "(Pixelfed/{$version}; +{$appUrl})";
+        $addlHeaders = [
+            'Content-Type' => 'application/ld+json; profile="https://www.w3.org/ns/activitystreams"',
+            'User-Agent' => $userAgent,
+        ];
+        $targetInbox = $actorAccount['sharedInbox'] ?? $actorAccount['inbox_url'];
+        $targetPid = $actorAccount['id'];
+
+        DB::table('followers')
+            ->join('profiles', 'followers.profile_id', '=', 'profiles.id')
+            ->where('followers.following_id', $actorAccount['id'])
+            ->whereNotNull('profiles.user_id')
+            ->whereNull('profiles.deleted_at')
+            ->select('profiles.id', 'profiles.user_id', 'profiles.username', 'profiles.private_key')
+            ->chunkById(100, function ($followers) use ($activity, $addlHeaders, $targetInbox, $targetPid) {
+                $client = new Client([
+                    'timeout' => config('federation.activitypub.delivery.timeout'),
+                ]);
+                $requests = function ($followers) use ($client, $activity, $addlHeaders, $targetInbox, $targetPid) {
+                    foreach ($followers as $follower) {
+                        $permalink = 'https://'.config('pixelfed.domain.app').'/users/'.$follower->username;
+                        $activity['id'] = $permalink.'#follow/'.$targetPid.'/undo';
+                        $activity['actor'] = $permalink;
+                        $activity['object']['id'] = $permalink.'#follows/'.$targetPid;
+                        $activity['object']['actor'] = $permalink;
+                        $keyId = $permalink.'#main-key';
+                        $payload = json_encode($activity);
+                        $url = $targetInbox;
+                        $headers = HttpSignature::signRaw($follower->private_key, $keyId, $targetInbox, $activity, $addlHeaders);
+                        yield new $client->postAsync($url, [
+                            'curl' => [
+                                CURLOPT_HTTPHEADER => $headers,
+                                CURLOPT_POSTFIELDS => $payload,
+                                CURLOPT_HEADER => true,
+                            ],
+                        ]);
+                    }
+                };
+
+                $pool = new Pool($client, $requests($followers), [
+                    'concurrency' => config('federation.activitypub.delivery.concurrency'),
+                    'fulfilled' => function ($response, $index) {},
+                    'rejected' => function ($reason, $index) {},
+                ]);
+
+                $promise = $pool->promise();
+
+                $promise->wait();
+            }, 'id');
+    }
+}

--- a/app/Jobs/MovePipeline/UnfollowLegacyAccountMovePipeline.php
+++ b/app/Jobs/MovePipeline/UnfollowLegacyAccountMovePipeline.php
@@ -11,6 +11,7 @@ use GuzzleHttp\Pool;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Queue\Middleware\WithoutOverlapping;
+use DateTime;
 
 class UnfollowLegacyAccountMovePipeline implements ShouldQueue
 {

--- a/app/Jobs/MovePipeline/UnfollowLegacyAccountMovePipeline.php
+++ b/app/Jobs/MovePipeline/UnfollowLegacyAccountMovePipeline.php
@@ -4,14 +4,15 @@ namespace App\Jobs\MovePipeline;
 
 use App\Util\ActivityPub\Helpers;
 use App\Util\ActivityPub\HttpSignature;
+use DateTime;
 use DB;
 use Exception;
 use GuzzleHttp\Client;
 use GuzzleHttp\Pool;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Queue\Middleware\ThrottlesExceptions;
 use Illuminate\Queue\Middleware\WithoutOverlapping;
-use DateTime;
 
 class UnfollowLegacyAccountMovePipeline implements ShouldQueue
 {

--- a/app/Services/AccountService.php
+++ b/app/Services/AccountService.php
@@ -24,13 +24,13 @@ class AccountService
     public static function get($id, $softFail = false)
     {
         $res = Cache::remember(self::CACHE_KEY.$id, 43200, function () use ($id) {
-            $fractal = new Fractal\Manager();
-            $fractal->setSerializer(new ArraySerializer());
+            $fractal = new Fractal\Manager;
+            $fractal->setSerializer(new ArraySerializer);
             $profile = Profile::find($id);
             if (! $profile || $profile->status === 'delete') {
                 return null;
             }
-            $resource = new Fractal\Resource\Item($profile, new AccountTransformer());
+            $resource = new Fractal\Resource\Item($profile, new AccountTransformer);
 
             return $fractal->createData($resource)->toArray();
         });
@@ -202,7 +202,7 @@ class AccountService
         }
 
         $count = Status::whereProfileId($id)
-            ->whereNull(['in_reply_to_id','reblog_of_id'])
+            ->whereNull(['in_reply_to_id', 'reblog_of_id'])
             ->whereIn('scope', ['public', 'unlisted', 'private'])
             ->count();
 
@@ -291,7 +291,6 @@ class AccountService
             $user->save();
             Cache::put($key, 1, 14400);
         }
-
     }
 
     public static function blocksDomain($pid, $domain = false)

--- a/app/Services/NodeinfoService.php
+++ b/app/Services/NodeinfoService.php
@@ -2,32 +2,31 @@
 
 namespace App\Services;
 
-use Illuminate\Support\Str;
-use Illuminate\Support\Facades\Http;
-use Illuminate\Http\Client\RequestException;
 use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Support\Facades\Http;
 
 class NodeinfoService
 {
     public static function get($domain)
     {
-    	$version = config('pixelfed.version');
-		$appUrl = config('app.url');
-		$headers = [
-			'Accept'     => 'application/json',
-			'User-Agent' => "(Pixelfed/{$version}; +{$appUrl})",
-		];
+        $version = config('pixelfed.version');
+        $appUrl = config('app.url');
+        $headers = [
+            'Accept' => 'application/json',
+            'User-Agent' => "(Pixelfed/{$version}; +{$appUrl})",
+        ];
 
-        $url = 'https://' . $domain;
-        $wk = $url . '/.well-known/nodeinfo';
+        $url = 'https://'.$domain;
+        $wk = $url.'/.well-known/nodeinfo';
 
         try {
             $res = Http::withOptions([
                 'allow_redirects' => false,
             ])
-            ->withHeaders($headers)
-            ->timeout(5)
-            ->get($wk);
+                ->withHeaders($headers)
+                ->timeout(5)
+                ->get($wk);
         } catch (RequestException $e) {
             return false;
         } catch (ConnectionException $e) {
@@ -36,18 +35,18 @@ class NodeinfoService
             return false;
         }
 
-        if(!$res) {
+        if (! $res) {
             return false;
         }
 
         $json = $res->json();
 
-        if( !isset($json['links'])) {
+        if (! isset($json['links'])) {
             return false;
         }
 
-        if(is_array($json['links'])) {
-            if(isset($json['links']['href'])) {
+        if (is_array($json['links'])) {
+            if (isset($json['links']['href'])) {
                 $href = $json['links']['href'];
             } else {
                 $href = $json['links'][0]['href'];
@@ -59,7 +58,7 @@ class NodeinfoService
         $domain = parse_url($url, PHP_URL_HOST);
         $hrefDomain = parse_url($href, PHP_URL_HOST);
 
-        if($domain !== $hrefDomain) {
+        if ($domain !== $hrefDomain) {
             return false;
         }
 
@@ -67,9 +66,9 @@ class NodeinfoService
             $res = Http::withOptions([
                 'allow_redirects' => false,
             ])
-            ->withHeaders($headers)
-            ->timeout(5)
-            ->get($href);
+                ->withHeaders($headers)
+                ->timeout(5)
+                ->get($href);
         } catch (RequestException $e) {
             return false;
         } catch (ConnectionException $e) {
@@ -77,6 +76,7 @@ class NodeinfoService
         } catch (\Exception $e) {
             return false;
         }
+
         return $res->json();
     }
 }

--- a/app/Services/NodeinfoService.php
+++ b/app/Services/NodeinfoService.php
@@ -60,7 +60,7 @@ class NodeinfoService
         $hrefDomain = parse_url($href, PHP_URL_HOST);
 
         if($domain !== $hrefDomain) {
-            return 60;
+            return false;
         }
 
         try {

--- a/app/Services/SearchApiV2Service.php
+++ b/app/Services/SearchApiV2Service.php
@@ -11,7 +11,6 @@ use Illuminate\Support\Str;
 use League\Fractal;
 use League\Fractal\Serializer\ArraySerializer;
 
-
 class SearchApiV2Service
 {
     private $query;
@@ -119,7 +118,7 @@ class SearchApiV2Service
                 AccountService::get($res['id']);
             })
             ->filter(function ($account) {
-                return $account && isset($account['id']);
+                return $account && isset($account['id']) && ! isset($account['moved'], $account['moved']['id']);
             })
             ->values();
 
@@ -248,7 +247,7 @@ class SearchApiV2Service
 
             if ($sid = Status::whereUri($query)->first()) {
                 $s = StatusService::get($sid->id, false);
-                if (! $s) {
+                if (! $s || isset($s['account']['moved'], $s['account']['moved']['id'])) {
                     return $default;
                 }
                 if (in_array($s['visibility'], ['public', 'unlisted'])) {
@@ -359,7 +358,7 @@ class SearchApiV2Service
             ->whereUsername($query)
             ->first();
 
-        if (! $profile) {
+        if (! $profile || $profile->moved_to_profile_id) {
             return [
                 'accounts' => [],
                 'hashtags' => [],
@@ -367,9 +366,9 @@ class SearchApiV2Service
             ];
         }
 
-        $fractal = new Fractal\Manager();
-        $fractal->setSerializer(new ArraySerializer());
-        $resource = new Fractal\Resource\Item($profile, new AccountTransformer());
+        $fractal = new Fractal\Manager;
+        $fractal->setSerializer(new ArraySerializer);
+        $resource = new Fractal\Resource\Item($profile, new AccountTransformer);
 
         return [
             'accounts' => [$fractal->createData($resource)->toArray()],
@@ -393,9 +392,9 @@ class SearchApiV2Service
             ];
         }
 
-        $fractal = new Fractal\Manager();
-        $fractal->setSerializer(new ArraySerializer());
-        $resource = new Fractal\Resource\Item($profile, new AccountTransformer());
+        $fractal = new Fractal\Manager;
+        $fractal->setSerializer(new ArraySerializer);
+        $resource = new Fractal\Resource\Item($profile, new AccountTransformer);
 
         return [
             'accounts' => [$fractal->createData($resource)->toArray()],

--- a/app/Services/StatusService.php
+++ b/app/Services/StatusService.php
@@ -30,9 +30,9 @@ class StatusService
             if (! $status) {
                 return null;
             }
-            $fractal = new Fractal\Manager();
-            $fractal->setSerializer(new ArraySerializer());
-            $resource = new Fractal\Resource\Item($status, new StatusStatelessTransformer());
+            $fractal = new Fractal\Manager;
+            $fractal->setSerializer(new ArraySerializer);
+            $resource = new Fractal\Resource\Item($status, new StatusStatelessTransformer);
             $res = $fractal->createData($resource)->toArray();
             $res['_pid'] = isset($res['account']) && isset($res['account']['id']) ? $res['account']['id'] : null;
             if (isset($res['_pid'])) {
@@ -112,7 +112,7 @@ class StatusService
     {
         $status = self::get($id, false);
 
-        if (! $status) {
+        if (! $status || ! $pid) {
             return [
                 'liked' => false,
                 'shared' => false,
@@ -146,9 +146,9 @@ class StatusService
             return null;
         }
 
-        $fractal = new Fractal\Manager();
-        $fractal->setSerializer(new ArraySerializer());
-        $resource = new Fractal\Resource\Item($status, new StatusStatelessTransformer());
+        $fractal = new Fractal\Manager;
+        $fractal->setSerializer(new ArraySerializer);
+        $resource = new Fractal\Resource\Item($status, new StatusStatelessTransformer);
 
         return $fractal->createData($resource)->toArray();
     }

--- a/app/Util/ActivityPub/Helpers.php
+++ b/app/Util/ActivityPub/Helpers.php
@@ -155,7 +155,7 @@ class Helpers
         return in_array($url, $audience['to']) || in_array($url, $audience['cc']);
     }
 
-    public static function validateUrl($url = null, $disableDNSCheck = false)
+    public static function validateUrl($url = null, $disableDNSCheck = false, $forceBanCheck = false)
     {
         if (is_array($url) && ! empty($url)) {
             $url = $url[0];
@@ -212,7 +212,7 @@ class Helpers
                 }
             }
 
-            if ($disableDNSCheck !== true && app()->environment() === 'production') {
+            if ($forceBanCheck || $disableDNSCheck !== true && app()->environment() === 'production') {
                 $bannedInstances = InstanceService::getBannedDomains();
                 if (in_array($host, $bannedInstances)) {
                     return false;
@@ -739,7 +739,7 @@ class Helpers
             $width = isset($media['width']) ? $media['width'] : false;
             $height = isset($media['height']) ? $media['height'] : false;
 
-            $media = new Media();
+            $media = new Media;
             $media->blurhash = $blurhash;
             $media->remote_media = true;
             $media->status_id = $status->id;

--- a/app/Util/ActivityPub/Inbox.php
+++ b/app/Util/ActivityPub/Inbox.php
@@ -1371,12 +1371,10 @@ class Inbox
         }
 
         Bus::chain([
-            new ProcessMovePipeline,
-            new MoveMigrateFollowersPipeline,
-            new UnfollowLegacyAccountMovePipeline,
-            new CleanupLegacyAccountMovePipeline,
-        ])
-            ->onQueue('move')
-            ->dispatch($target, $activity);
+            new ProcessMovePipeline($target, $activity),
+            new MoveMigrateFollowersPipeline($target, $activity),
+            new UnfollowLegacyAccountMovePipeline($target, $activity),
+            new CleanupLegacyAccountMovePipeline($target, $activity),
+        ])->onQueue('move')->dispatch();
     }
 }

--- a/app/Util/ActivityPub/Inbox.php
+++ b/app/Util/ActivityPub/Inbox.php
@@ -1382,7 +1382,7 @@ class Inbox
                 Log::error($e);
             })
             ->onQueue('move')
-            ->delay(now()->addMinutes(random_int(5, 9)))
+            ->delay(now()->addMinutes(random_int(2, 5)))
             ->dispatch();
     }
 }

--- a/app/Util/ActivityPub/Inbox.php
+++ b/app/Util/ActivityPub/Inbox.php
@@ -2,65 +2,58 @@
 
 namespace App\Util\ActivityPub;
 
-use Cache, DB, Log, Purify, Redis, Storage, Validator;
-use Illuminate\Support\Facades\Bus;
-use App\{
-    Activity,
-    DirectMessage,
-    Follower,
-    FollowRequest,
-    Instance,
-    Like,
-    Notification,
-    Media,
-    Profile,
-    Status,
-    StatusHashtag,
-    Story,
-    StoryView,
-    UserFilter
-};
-use Carbon\Carbon;
-use App\Util\ActivityPub\Helpers;
-use Illuminate\Support\Str;
-use App\Jobs\LikePipeline\LikePipeline;
-use App\Jobs\FollowPipeline\FollowPipeline;
+use App\DirectMessage;
+use App\Follower;
+use App\FollowRequest;
+use App\Instance;
 use App\Jobs\DeletePipeline\DeleteRemoteProfilePipeline;
+use App\Jobs\FollowPipeline\FollowPipeline;
+use App\Jobs\HomeFeedPipeline\FeedRemoveRemotePipeline;
+use App\Jobs\LikePipeline\LikePipeline;
+use App\Jobs\MovePipeline\CleanupLegacyAccountMovePipeline;
+use App\Jobs\MovePipeline\MoveMigrateFollowersPipeline;
+use App\Jobs\MovePipeline\ProcessMovePipeline;
+use App\Jobs\MovePipeline\UnfollowLegacyAccountMovePipeline;
+use App\Jobs\ProfilePipeline\HandleUpdateActivity;
 use App\Jobs\StatusPipeline\RemoteStatusDelete;
+use App\Jobs\StatusPipeline\StatusRemoteUpdatePipeline;
 use App\Jobs\StoryPipeline\StoryExpire;
 use App\Jobs\StoryPipeline\StoryFetch;
-use App\Jobs\StatusPipeline\StatusRemoteUpdatePipeline;
-use App\Jobs\ProfilePipeline\HandleUpdateActivity;
-use App\Jobs\MovePipeline\ProcessMovePipeline;
-use App\Jobs\MovePipeline\MoveMigrateFollowersPipeline;
-use App\Jobs\MovePipeline\UnfollowLegacyAccountMovePipeline;
-use App\Jobs\MovePipeline\CleanupLegacyAccountMovePipeline;
-
+use App\Like;
+use App\Media;
+use App\Models\Conversation;
+use App\Models\RemoteReport;
+use App\Notification;
+use App\Profile;
+use App\Services\AccountService;
+use App\Services\FollowerService;
+use App\Services\PollService;
+use App\Services\ReblogService;
+use App\Services\UserFilterService;
+use App\Status;
+use App\Story;
+use App\StoryView;
+use App\UserFilter;
 use App\Util\ActivityPub\Validator\Accept as AcceptValidator;
-use App\Util\ActivityPub\Validator\Add as AddValidator;
 use App\Util\ActivityPub\Validator\Announce as AnnounceValidator;
 use App\Util\ActivityPub\Validator\Follow as FollowValidator;
 use App\Util\ActivityPub\Validator\Like as LikeValidator;
-use App\Util\ActivityPub\Validator\UndoFollow as UndoFollowValidator;
-use App\Util\ActivityPub\Validator\UpdatePersonValidator;
 use App\Util\ActivityPub\Validator\MoveValidator;
-
-use App\Services\AccountService;
-use App\Services\PollService;
-use App\Services\FollowerService;
-use App\Services\ReblogService;
-use App\Services\StatusService;
-use App\Services\UserFilterService;
-use App\Services\NetworkTimelineService;
-use App\Models\Conversation;
-use App\Models\RemoteReport;
-use App\Jobs\HomeFeedPipeline\FeedRemoveRemotePipeline;
+use App\Util\ActivityPub\Validator\UpdatePersonValidator;
+use Cache;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Str;
+use Purify;
+use Storage;
 
 class Inbox
 {
     protected $headers;
+
     protected $profile;
+
     protected $payload;
+
     protected $logger;
 
     public function __construct($headers, $profile, $payload)
@@ -73,7 +66,7 @@ class Inbox
     public function handle()
     {
         $this->handleVerb();
-        return;
+
     }
 
     public function handleVerb()
@@ -90,17 +83,23 @@ class Inbox
                 break;
 
             case 'Follow':
-                if(FollowValidator::validate($this->payload) == false) { return; }
+                if (FollowValidator::validate($this->payload) == false) {
+                    return;
+                }
                 $this->handleFollowActivity();
                 break;
 
             case 'Announce':
-                if(AnnounceValidator::validate($this->payload) == false) { return; }
+                if (AnnounceValidator::validate($this->payload) == false) {
+                    return;
+                }
                 $this->handleAnnounceActivity();
                 break;
 
             case 'Accept':
-                if(AcceptValidator::validate($this->payload) == false) { return; }
+                if (AcceptValidator::validate($this->payload) == false) {
+                    return;
+                }
                 $this->handleAcceptActivity();
                 break;
 
@@ -109,7 +108,9 @@ class Inbox
                 break;
 
             case 'Like':
-                if(LikeValidator::validate($this->payload) == false) { return; }
+                if (LikeValidator::validate($this->payload) == false) {
+                    return;
+                }
                 $this->handleLikeActivity();
                 break;
 
@@ -142,8 +143,9 @@ class Inbox
                 break;
 
             case 'Move':
-                if(MoveValidator::validate($this->payload) == false) {
-                    \Log::info('[AP][INBOX][MOVE] VALIDATE_FAILURE ' . json_encode($this->payload));
+                if (MoveValidator::validate($this->payload) == false) {
+                    \Log::info('[AP][INBOX][MOVE] VALIDATE_FAILURE '.json_encode($this->payload));
+
                     return;
                 }
                 $this->handleMoveActivity();
@@ -159,8 +161,8 @@ class Inbox
     {
         $activity = $this->payload['object'];
 
-        if(isset($activity['inReplyTo']) &&
-            !empty($activity['inReplyTo']) &&
+        if (isset($activity['inReplyTo']) &&
+            ! empty($activity['inReplyTo']) &&
             Helpers::validateUrl($activity['inReplyTo'])
         ) {
             // reply detected, skip attachment check
@@ -181,7 +183,7 @@ class Inbox
     {
         // stories ;)
 
-        if(!isset(
+        if (! isset(
             $this->payload['actor'],
             $this->payload['object']
         )) {
@@ -191,85 +193,86 @@ class Inbox
         $actor = $this->payload['actor'];
         $obj = $this->payload['object'];
 
-        if(!Helpers::validateUrl($actor)) {
+        if (! Helpers::validateUrl($actor)) {
             return;
         }
 
-        if(!isset($obj['type'])) {
+        if (! isset($obj['type'])) {
             return;
         }
 
-        switch($obj['type']) {
+        switch ($obj['type']) {
             case 'Story':
                 StoryFetch::dispatch($this->payload);
-            break;
+                break;
         }
 
-        return;
     }
 
     public function handleCreateActivity()
     {
         $activity = $this->payload['object'];
-        if(config('autospam.live_filters.enabled')) {
+        if (config('autospam.live_filters.enabled')) {
             $filters = config('autospam.live_filters.filters');
-            if(!empty($filters) && isset($activity['content']) && !empty($activity['content']) && strlen($filters) > 3) {
+            if (! empty($filters) && isset($activity['content']) && ! empty($activity['content']) && strlen($filters) > 3) {
                 $filters = array_map('trim', explode(',', $filters));
                 $content = $activity['content'];
-                foreach($filters as $filter) {
+                foreach ($filters as $filter) {
                     $filter = trim(strtolower($filter));
-                    if(!$filter || !strlen($filter)) {
+                    if (! $filter || ! strlen($filter)) {
                         continue;
                     }
-                    if(str_contains(strtolower($content), $filter)) {
+                    if (str_contains(strtolower($content), $filter)) {
                         return;
                     }
                 }
             }
         }
         $actor = $this->actorFirstOrCreate($this->payload['actor']);
-        if(!$actor || $actor->domain == null) {
+        if (! $actor || $actor->domain == null) {
             return;
         }
 
-        if(!isset($activity['to'])) {
+        if (! isset($activity['to'])) {
             return;
         }
         $to = isset($activity['to']) ? $activity['to'] : [];
         $cc = isset($activity['cc']) ? $activity['cc'] : [];
 
-        if($activity['type'] == 'Question') {
+        if ($activity['type'] == 'Question') {
             $this->handlePollCreate();
+
             return;
         }
 
-        if( is_array($to) &&
+        if (is_array($to) &&
             is_array($cc) &&
             count($to) == 1 &&
             count($cc) == 0 &&
             parse_url($to[0], PHP_URL_HOST) == config('pixelfed.domain.app')
         ) {
             $this->handleDirectMessage();
+
             return;
         }
 
-        if($activity['type'] == 'Note' && !empty($activity['inReplyTo'])) {
+        if ($activity['type'] == 'Note' && ! empty($activity['inReplyTo'])) {
             $this->handleNoteReply();
 
-        } elseif ($activity['type'] == 'Note' && !empty($activity['attachment'])) {
-            if(!$this->verifyNoteAttachment()) {
+        } elseif ($activity['type'] == 'Note' && ! empty($activity['attachment'])) {
+            if (! $this->verifyNoteAttachment()) {
                 return;
             }
             $this->handleNoteCreate();
         }
-        return;
+
     }
 
     public function handleNoteReply()
     {
         $activity = $this->payload['object'];
         $actor = $this->actorFirstOrCreate($this->payload['actor']);
-        if(!$actor || $actor->domain == null) {
+        if (! $actor || $actor->domain == null) {
             return;
         }
 
@@ -277,42 +280,43 @@ class Inbox
         $url = isset($activity['url']) ? $activity['url'] : $activity['id'];
 
         Helpers::statusFirstOrFetch($url, true);
-        return;
+
     }
 
     public function handlePollCreate()
     {
         $activity = $this->payload['object'];
         $actor = $this->actorFirstOrCreate($this->payload['actor']);
-        if(!$actor || $actor->domain == null) {
+        if (! $actor || $actor->domain == null) {
             return;
         }
         $url = isset($activity['url']) ? $activity['url'] : $activity['id'];
         Helpers::statusFirstOrFetch($url);
-        return;
+
     }
 
     public function handleNoteCreate()
     {
         $activity = $this->payload['object'];
         $actor = $this->actorFirstOrCreate($this->payload['actor']);
-        if(!$actor || $actor->domain == null) {
+        if (! $actor || $actor->domain == null) {
             return;
         }
 
-        if( isset($activity['inReplyTo']) &&
+        if (isset($activity['inReplyTo']) &&
             isset($activity['name']) &&
-            !isset($activity['content']) &&
-            !isset($activity['attachment']) &&
+            ! isset($activity['content']) &&
+            ! isset($activity['attachment']) &&
             Helpers::validateLocalUrl($activity['inReplyTo'])
         ) {
             $this->handlePollVote();
+
             return;
         }
 
-        if($actor->followers_count == 0) {
-            if(config('federation.activitypub.ingest.store_notes_without_followers')) {
-            } else if(FollowerService::followerCount($actor->id, true) == 0) {
+        if ($actor->followers_count == 0) {
+            if (config('federation.activitypub.ingest.store_notes_without_followers')) {
+            } elseif (FollowerService::followerCount($actor->id, true) == 0) {
                 return;
             }
         }
@@ -320,12 +324,12 @@ class Inbox
         $hasUrl = isset($activity['url']);
         $url = isset($activity['url']) ? $activity['url'] : $activity['id'];
 
-        if($hasUrl) {
-            if(Status::whereUri($url)->exists()) {
+        if ($hasUrl) {
+            if (Status::whereUri($url)->exists()) {
                 return;
             }
         } else {
-            if(Status::whereObjectUrl($url)->exists()) {
+            if (Status::whereObjectUrl($url)->exists()) {
                 return;
             }
         }
@@ -335,7 +339,7 @@ class Inbox
             $actor,
             $activity
         );
-        return;
+
     }
 
     public function handlePollVote()
@@ -343,34 +347,34 @@ class Inbox
         $activity = $this->payload['object'];
         $actor = $this->actorFirstOrCreate($this->payload['actor']);
 
-        if(!$actor) {
+        if (! $actor) {
             return;
         }
 
         $status = Helpers::statusFetch($activity['inReplyTo']);
 
-        if(!$status) {
+        if (! $status) {
             return;
         }
 
         $poll = $status->poll;
 
-        if(!$poll) {
+        if (! $poll) {
             return;
         }
 
-        if(now()->gt($poll->expires_at)) {
+        if (now()->gt($poll->expires_at)) {
             return;
         }
 
         $choices = $poll->poll_options;
         $choice = array_search($activity['name'], $choices);
 
-        if($choice === false) {
+        if ($choice === false) {
             return;
         }
 
-        if(PollVote::whereStatusId($status->id)->whereProfileId($actor->id)->exists()) {
+        if (PollVote::whereStatusId($status->id)->whereProfileId($actor->id)->exists()) {
             return;
         }
 
@@ -390,7 +394,6 @@ class Inbox
 
         PollService::del($status->id);
 
-        return;
     }
 
     public function handleDirectMessage()
@@ -401,24 +404,24 @@ class Inbox
             ->whereUsername(array_last(explode('/', $activity['to'][0])))
             ->firstOrFail();
 
-        if(!$actor || in_array($actor->id, $profile->blockedIds()->toArray())) {
+        if (! $actor || in_array($actor->id, $profile->blockedIds()->toArray())) {
             return;
         }
 
-        if(AccountService::blocksDomain($profile->id, $actor->domain) == true) {
+        if (AccountService::blocksDomain($profile->id, $actor->domain) == true) {
             return;
         }
 
         $msg = $activity['content'];
         $msgText = strip_tags($activity['content']);
 
-        if(Str::startsWith($msgText, '@' . $profile->username)) {
-            $len = strlen('@' . $profile->username);
+        if (Str::startsWith($msgText, '@'.$profile->username)) {
+            $len = strlen('@'.$profile->username);
             $msgText = substr($msgText, $len + 1);
         }
 
-        if($profile->user->settings->public_dm == false || $profile->is_private) {
-            if($profile->follows($actor) == true) {
+        if ($profile->user->settings->public_dm == false || $profile->is_private) {
+            if ($profile->follows($actor) == true) {
                 $hidden = false;
             } else {
                 $hidden = true;
@@ -450,30 +453,30 @@ class Inbox
         Conversation::updateOrInsert(
             [
                 'to_id' => $profile->id,
-                'from_id' => $actor->id
+                'from_id' => $actor->id,
             ],
             [
                 'type' => 'text',
                 'status_id' => $status->id,
                 'dm_id' => $dm->id,
-                'is_hidden' => $hidden
+                'is_hidden' => $hidden,
             ]
         );
 
-        if(count($activity['attachment'])) {
+        if (count($activity['attachment'])) {
             $photos = 0;
             $videos = 0;
             $allowed = explode(',', config_cache('pixelfed.media_types'));
             $activity['attachment'] = array_slice($activity['attachment'], 0, config_cache('pixelfed.max_album_length'));
-            foreach($activity['attachment'] as $a) {
+            foreach ($activity['attachment'] as $a) {
                 $type = $a['mediaType'];
                 $url = $a['url'];
                 $valid = Helpers::validateUrl($url);
-                if(in_array($type, $allowed) == false || $valid == false) {
+                if (in_array($type, $allowed) == false || $valid == false) {
                     continue;
                 }
 
-                $media = new Media();
+                $media = new Media;
                 $media->remote_media = true;
                 $media->status_id = $status->id;
                 $media->profile_id = $status->profile_id;
@@ -482,31 +485,31 @@ class Inbox
                 $media->remote_url = $url;
                 $media->mime = $type;
                 $media->save();
-                if(explode('/', $type)[0] == 'image') {
+                if (explode('/', $type)[0] == 'image') {
                     $photos = $photos + 1;
                 }
-                if(explode('/', $type)[0] == 'video') {
+                if (explode('/', $type)[0] == 'video') {
                     $videos = $videos + 1;
                 }
             }
 
-            if($photos && $videos == 0) {
+            if ($photos && $videos == 0) {
                 $dm->type = $photos == 1 ? 'photo' : 'photos';
                 $dm->save();
             }
-            if($videos && $photos == 0) {
+            if ($videos && $photos == 0) {
                 $dm->type = $videos == 1 ? 'video' : 'videos';
                 $dm->save();
             }
         }
 
-        if(filter_var($msgText, FILTER_VALIDATE_URL)) {
-            if(Helpers::validateUrl($msgText)) {
+        if (filter_var($msgText, FILTER_VALIDATE_URL)) {
+            if (Helpers::validateUrl($msgText)) {
                 $dm->type = 'link';
                 $dm->meta = [
                     'domain' => parse_url($msgText, PHP_URL_HOST),
                     'local' => parse_url($msgText, PHP_URL_HOST) ==
-                        parse_url(config('app.url'), PHP_URL_HOST)
+                        parse_url(config('app.url'), PHP_URL_HOST),
                 ];
                 $dm->save();
             }
@@ -518,8 +521,8 @@ class Inbox
             ->whereFilterType('dm.mute')
             ->exists();
 
-        if($profile->domain == null && $hidden == false && !$nf) {
-            $notification = new Notification();
+        if ($profile->domain == null && $hidden == false && ! $nf) {
+            $notification = new Notification;
             $notification->profile_id = $profile->id;
             $notification->actor_id = $actor->id;
             $notification->action = 'dm';
@@ -528,26 +531,25 @@ class Inbox
             $notification->save();
         }
 
-        return;
     }
 
     public function handleFollowActivity()
     {
         $actor = $this->actorFirstOrCreate($this->payload['actor']);
         $target = $this->actorFirstOrCreate($this->payload['object']);
-        if(!$actor || !$target) {
+        if (! $actor || ! $target) {
             return;
         }
 
-        if($actor->domain == null || $target->domain !== null) {
+        if ($actor->domain == null || $target->domain !== null) {
             return;
         }
 
-        if(AccountService::blocksDomain($target->id, $actor->domain) == true) {
+        if (AccountService::blocksDomain($target->id, $actor->domain) == true) {
             return;
         }
 
-        if(
+        if (
             Follower::whereProfileId($actor->id)
                 ->whereFollowingId($target->id)
                 ->exists() ||
@@ -559,16 +561,16 @@ class Inbox
         }
 
         $blocks = UserFilterService::blocks($target->id);
-        if($blocks && in_array($actor->id, $blocks)) {
+        if ($blocks && in_array($actor->id, $blocks)) {
             return;
         }
 
-        if($target->is_private == true) {
+        if ($target->is_private == true) {
             FollowRequest::updateOrCreate([
                 'follower_id' => $actor->id,
                 'following_id' => $target->id,
-            ],[
-                'activity' => collect($this->payload)->only(['id','actor','object','type'])->toArray()
+            ], [
+                'activity' => collect($this->payload)->only(['id', 'actor', 'object', 'type'])->toArray(),
             ]);
         } else {
             $follower = new Follower;
@@ -583,15 +585,15 @@ class Inbox
             // send Accept to remote profile
             $accept = [
                 '@context' => 'https://www.w3.org/ns/activitystreams',
-                'id'       => $target->permalink().'#accepts/follows/' . $follower->id,
-                'type'     => 'Accept',
-                'actor'    => $target->permalink(),
-                'object'   => [
-                    'id'        => $this->payload['id'],
-                    'actor'     => $actor->permalink(),
-                    'type'      => 'Follow',
-                    'object'    => $target->permalink()
-                ]
+                'id' => $target->permalink().'#accepts/follows/'.$follower->id,
+                'type' => 'Accept',
+                'actor' => $target->permalink(),
+                'object' => [
+                    'id' => $this->payload['id'],
+                    'actor' => $actor->permalink(),
+                    'type' => 'Follow',
+                    'object' => $target->permalink(),
+                ],
             ];
             Helpers::sendSignedObject($target, $actor->inbox_url, $accept);
             Cache::forget('profile:follower_count:'.$target->id);
@@ -600,7 +602,6 @@ class Inbox
             Cache::forget('profile:following_count:'.$actor->id);
         }
 
-        return;
     }
 
     public function handleAnnounceActivity()
@@ -608,29 +609,29 @@ class Inbox
         $actor = $this->actorFirstOrCreate($this->payload['actor']);
         $activity = $this->payload['object'];
 
-        if(!$actor || $actor->domain == null) {
+        if (! $actor || $actor->domain == null) {
             return;
         }
 
         $parent = Helpers::statusFetch($activity);
 
-        if(!$parent || empty($parent)) {
+        if (! $parent || empty($parent)) {
             return;
         }
 
-        if(AccountService::blocksDomain($parent->profile_id, $actor->domain) == true) {
+        if (AccountService::blocksDomain($parent->profile_id, $actor->domain) == true) {
             return;
         }
 
         $blocks = UserFilterService::blocks($parent->profile_id);
-        if($blocks && in_array($actor->id, $blocks)) {
+        if ($blocks && in_array($actor->id, $blocks)) {
             return;
         }
 
         $status = Status::firstOrCreate([
             'profile_id' => $actor->id,
             'reblog_of_id' => $parent->id,
-            'type' => 'share'
+            'type' => 'share',
         ]);
 
         Notification::firstOrCreate(
@@ -648,7 +649,6 @@ class Inbox
 
         ReblogService::addPostReblog($parent->profile_id, $status->id);
 
-        return;
     }
 
     public function handleAcceptActivity()
@@ -657,25 +657,25 @@ class Inbox
         $obj = $this->payload['object']['object'];
         $type = $this->payload['object']['type'];
 
-        if($type !== 'Follow') {
+        if ($type !== 'Follow') {
             return;
         }
 
         $actor = Helpers::validateLocalUrl($actor);
         $target = Helpers::validateUrl($obj);
 
-        if(!$actor || !$target) {
+        if (! $actor || ! $target) {
             return;
         }
 
         $actor = Helpers::profileFetch($actor);
         $target = Helpers::profileFetch($target);
 
-        if(!$actor || !$target) {
+        if (! $actor || ! $target) {
             return;
         }
 
-        if(AccountService::blocksDomain($target->id, $actor->domain) == true) {
+        if (AccountService::blocksDomain($target->id, $actor->domain) == true) {
             return;
         }
 
@@ -684,7 +684,7 @@ class Inbox
             ->whereIsRejected(false)
             ->first();
 
-        if(!$request) {
+        if (! $request) {
             return;
         }
 
@@ -696,12 +696,11 @@ class Inbox
 
         $request->delete();
 
-        return;
     }
 
     public function handleDeleteActivity()
     {
-        if(!isset(
+        if (! isset(
             $this->payload['actor'],
             $this->payload['object']
         )) {
@@ -709,15 +708,16 @@ class Inbox
         }
         $actor = $this->payload['actor'];
         $obj = $this->payload['object'];
-        if(is_string($obj) == true && $actor == $obj && Helpers::validateUrl($obj)) {
+        if (is_string($obj) == true && $actor == $obj && Helpers::validateUrl($obj)) {
             $profile = Profile::whereRemoteUrl($obj)->first();
-            if(!$profile || $profile->private_key != null) {
+            if (! $profile || $profile->private_key != null) {
                 return;
             }
             DeleteRemoteProfilePipeline::dispatch($profile)->onQueue('inbox');
+
             return;
         } else {
-            if(!isset(
+            if (! isset(
                 $obj['id'],
                 $this->payload['object'],
                 $this->payload['object']['id'],
@@ -727,54 +727,57 @@ class Inbox
             }
             $type = $this->payload['object']['type'];
             $typeCheck = in_array($type, ['Person', 'Tombstone', 'Story']);
-            if(!Helpers::validateUrl($actor) || !Helpers::validateUrl($obj['id']) || !$typeCheck) {
+            if (! Helpers::validateUrl($actor) || ! Helpers::validateUrl($obj['id']) || ! $typeCheck) {
                 return;
             }
-            if(parse_url($obj['id'], PHP_URL_HOST) !== parse_url($actor, PHP_URL_HOST)) {
+            if (parse_url($obj['id'], PHP_URL_HOST) !== parse_url($actor, PHP_URL_HOST)) {
                 return;
             }
             $id = $this->payload['object']['id'];
             switch ($type) {
                 case 'Person':
-                        $profile = Profile::whereRemoteUrl($actor)->first();
-                        if(!$profile || $profile->private_key != null) {
-                            return;
-                        }
-                        DeleteRemoteProfilePipeline::dispatch($profile)->onQueue('inbox');
+                    $profile = Profile::whereRemoteUrl($actor)->first();
+                    if (! $profile || $profile->private_key != null) {
                         return;
+                    }
+                    DeleteRemoteProfilePipeline::dispatch($profile)->onQueue('inbox');
+
+                    return;
                     break;
 
                 case 'Tombstone':
-                        $profile = Profile::whereRemoteUrl($actor)->first();
-                        if(!$profile || $profile->private_key != null) {
-                            return;
-                        }
-
-                        $status = Status::where('object_url', $id)->first();
-                        if(!$status) {
-                            $status = Status::where('url', $id)->first();
-                            if(!$status) {
-                                return;
-                            }
-                        }
-                        if($status->profile_id != $profile->id) {
-                            return;
-                        }
-                        if($status->scope && in_array($status->scope, ['public', 'unlisted', 'private'])) {
-                            if($status->type && !in_array($status->type, ['story:reaction', 'story:reply', 'reply'])) {
-                                FeedRemoveRemotePipeline::dispatch($status->id, $status->profile_id)->onQueue('feed');
-                            }
-                        }
-                        RemoteStatusDelete::dispatch($status)->onQueue('high');
+                    $profile = Profile::whereRemoteUrl($actor)->first();
+                    if (! $profile || $profile->private_key != null) {
                         return;
+                    }
+
+                    $status = Status::where('object_url', $id)->first();
+                    if (! $status) {
+                        $status = Status::where('url', $id)->first();
+                        if (! $status) {
+                            return;
+                        }
+                    }
+                    if ($status->profile_id != $profile->id) {
+                        return;
+                    }
+                    if ($status->scope && in_array($status->scope, ['public', 'unlisted', 'private'])) {
+                        if ($status->type && ! in_array($status->type, ['story:reaction', 'story:reply', 'reply'])) {
+                            FeedRemoveRemotePipeline::dispatch($status->id, $status->profile_id)->onQueue('feed');
+                        }
+                    }
+                    RemoteStatusDelete::dispatch($status)->onQueue('high');
+
+                    return;
                     break;
 
                 case 'Story':
                     $story = Story::whereObjectId($id)
                         ->first();
-                    if($story) {
+                    if ($story) {
                         StoryExpire::dispatch($story)->onQueue('story');
                     }
+
                     return;
                     break;
 
@@ -783,53 +786,50 @@ class Inbox
                     break;
             }
         }
-        return;
+
     }
 
     public function handleLikeActivity()
     {
         $actor = $this->payload['actor'];
 
-        if(!Helpers::validateUrl($actor)) {
+        if (! Helpers::validateUrl($actor)) {
             return;
         }
 
         $profile = self::actorFirstOrCreate($actor);
         $obj = $this->payload['object'];
-        if(!Helpers::validateUrl($obj)) {
+        if (! Helpers::validateUrl($obj)) {
             return;
         }
         $status = Helpers::statusFirstOrFetch($obj);
-        if(!$status || !$profile) {
+        if (! $status || ! $profile) {
             return;
         }
 
-        if(AccountService::blocksDomain($status->profile_id, $profile->domain) == true) {
+        if (AccountService::blocksDomain($status->profile_id, $profile->domain) == true) {
             return;
         }
 
         $blocks = UserFilterService::blocks($status->profile_id);
-        if($blocks && in_array($profile->id, $blocks)) {
+        if ($blocks && in_array($profile->id, $blocks)) {
             return;
         }
 
         $like = Like::firstOrCreate([
             'profile_id' => $profile->id,
-            'status_id' => $status->id
+            'status_id' => $status->id,
         ]);
 
-        if($like->wasRecentlyCreated == true) {
+        if ($like->wasRecentlyCreated == true) {
             $status->likes_count = $status->likes_count + 1;
             $status->save();
             LikePipeline::dispatch($like);
         }
 
-        return;
     }
 
-    public function handleRejectActivity()
-    {
-    }
+    public function handleRejectActivity() {}
 
     public function handleUndoActivity()
     {
@@ -837,11 +837,11 @@ class Inbox
         $profile = self::actorFirstOrCreate($actor);
         $obj = $this->payload['object'];
 
-        if(!$profile) {
+        if (! $profile) {
             return;
         }
         // TODO: Some implementations do not inline the object, skip for now
-        if(!$obj || !is_array($obj) || !isset($obj['type'])) {
+        if (! $obj || ! is_array($obj) || ! isset($obj['type'])) {
             return;
         }
 
@@ -850,22 +850,22 @@ class Inbox
                 break;
 
             case 'Announce':
-                if(is_array($obj) && isset($obj['object'])) {
+                if (is_array($obj) && isset($obj['object'])) {
                     $obj = $obj['object'];
                 }
-                if(!is_string($obj)) {
+                if (! is_string($obj)) {
                     return;
                 }
-                if(Helpers::validateLocalUrl($obj)) {
+                if (Helpers::validateLocalUrl($obj)) {
                     $parsedId = last(explode('/', $obj));
                     $status = Status::find($parsedId);
                 } else {
                     $status = Status::whereUri($obj)->first();
                 }
-                if(!$status) {
+                if (! $status) {
                     return;
                 }
-                if(AccountService::blocksDomain($status->profile_id, $profile->domain) == true) {
+                if (AccountService::blocksDomain($status->profile_id, $profile->domain) == true) {
                     return;
                 }
                 FeedRemoveRemotePipeline::dispatch($status->id, $status->profile_id)->onQueue('feed');
@@ -886,10 +886,10 @@ class Inbox
 
             case 'Follow':
                 $following = self::actorFirstOrCreate($obj['object']);
-                if(!$following) {
+                if (! $following) {
                     return;
                 }
-                if(AccountService::blocksDomain($following->id, $profile->domain) == true) {
+                if (AccountService::blocksDomain($following->id, $profile->domain) == true) {
                     return;
                 }
                 Follower::whereProfileId($profile->id)
@@ -906,18 +906,18 @@ class Inbox
 
             case 'Like':
                 $objectUri = $obj['object'];
-                if(!is_string($objectUri)) {
-                    if(is_array($objectUri) && isset($objectUri['id']) && is_string($objectUri['id'])) {
+                if (! is_string($objectUri)) {
+                    if (is_array($objectUri) && isset($objectUri['id']) && is_string($objectUri['id'])) {
                         $objectUri = $objectUri['id'];
                     } else {
                         return;
                     }
                 }
                 $status = Helpers::statusFirstOrFetch($objectUri);
-                if(!$status) {
+                if (! $status) {
                     return;
                 }
-                if(AccountService::blocksDomain($status->profile_id, $profile->domain) == true) {
+                if (AccountService::blocksDomain($status->profile_id, $profile->domain) == true) {
                     return;
                 }
                 Like::whereProfileId($profile->id)
@@ -931,12 +931,12 @@ class Inbox
                     ->forceDelete();
                 break;
         }
-        return;
+
     }
 
     public function handleViewActivity()
     {
-        if(!isset(
+        if (! isset(
             $this->payload['actor'],
             $this->payload['object']
         )) {
@@ -946,19 +946,19 @@ class Inbox
         $actor = $this->payload['actor'];
         $obj = $this->payload['object'];
 
-        if(!Helpers::validateUrl($actor)) {
+        if (! Helpers::validateUrl($actor)) {
             return;
         }
 
-        if(!$obj || !is_array($obj)) {
+        if (! $obj || ! is_array($obj)) {
             return;
         }
 
-        if(!isset($obj['type']) || !isset($obj['object']) || $obj['type'] != 'Story') {
+        if (! isset($obj['type']) || ! isset($obj['object']) || $obj['type'] != 'Story') {
             return;
         }
 
-        if(!Helpers::validateLocalUrl($obj['object'])) {
+        if (! Helpers::validateLocalUrl($obj['object'])) {
             return;
         }
 
@@ -969,34 +969,33 @@ class Inbox
             ->whereLocal(true)
             ->find($storyId);
 
-        if(!$story) {
+        if (! $story) {
             return;
         }
 
-        if(AccountService::blocksDomain($story->profile_id, $profile->domain) == true) {
+        if (AccountService::blocksDomain($story->profile_id, $profile->domain) == true) {
             return;
         }
 
-        if(!FollowerService::follows($profile->id, $story->profile_id)) {
+        if (! FollowerService::follows($profile->id, $story->profile_id)) {
             return;
         }
 
         $view = StoryView::firstOrCreate([
             'story_id' => $story->id,
-            'profile_id' => $profile->id
+            'profile_id' => $profile->id,
         ]);
 
-        if($view->wasRecentlyCreated == true) {
+        if ($view->wasRecentlyCreated == true) {
             $story->view_count++;
             $story->save();
         }
 
-        return;
     }
 
     public function handleStoryReactionActivity()
     {
-        if(!isset(
+        if (! isset(
             $this->payload['actor'],
             $this->payload['id'],
             $this->payload['inReplyTo'],
@@ -1011,23 +1010,23 @@ class Inbox
         $to = $this->payload['to'];
         $text = Purify::clean($this->payload['content']);
 
-        if(parse_url($id, PHP_URL_HOST) !== parse_url($actor, PHP_URL_HOST)) {
+        if (parse_url($id, PHP_URL_HOST) !== parse_url($actor, PHP_URL_HOST)) {
             return;
         }
 
-        if(!Helpers::validateUrl($id) || !Helpers::validateUrl($actor)) {
+        if (! Helpers::validateUrl($id) || ! Helpers::validateUrl($actor)) {
             return;
         }
 
-        if(!Helpers::validateLocalUrl($storyUrl)) {
+        if (! Helpers::validateLocalUrl($storyUrl)) {
             return;
         }
 
-        if(!Helpers::validateLocalUrl($to)) {
+        if (! Helpers::validateLocalUrl($to)) {
             return;
         }
 
-        if(Status::whereObjectUrl($id)->exists()) {
+        if (Status::whereObjectUrl($id)->exists()) {
             return;
         }
 
@@ -1037,27 +1036,27 @@ class Inbox
         $story = Story::whereProfileId($targetProfile->id)
             ->find($storyId);
 
-        if(!$story) {
+        if (! $story) {
             return;
         }
 
-        if($story->can_react == false) {
+        if ($story->can_react == false) {
             return;
         }
 
         $actorProfile = Helpers::profileFetch($actor);
 
-        if(AccountService::blocksDomain($targetProfile->id, $actorProfile->domain) == true) {
+        if (AccountService::blocksDomain($targetProfile->id, $actorProfile->domain) == true) {
             return;
         }
 
-        if(!FollowerService::follows($actorProfile->id, $targetProfile->id)) {
+        if (! FollowerService::follows($actorProfile->id, $targetProfile->id)) {
             return;
         }
 
         $url = $id;
 
-        if(str_ends_with($url, '/activity')) {
+        if (str_ends_with($url, '/activity')) {
             $url = substr($url, 0, -9);
         }
 
@@ -1074,7 +1073,7 @@ class Inbox
         $status->in_reply_to_profile_id = $story->profile_id;
         $status->entities = json_encode([
             'story_id' => $story->id,
-            'reaction' => $text
+            'reaction' => $text,
         ]);
         $status->save();
 
@@ -1088,20 +1087,20 @@ class Inbox
             'story_actor_username' => $actorProfile->username,
             'story_id' => $story->id,
             'story_media_url' => url(Storage::url($story->path)),
-            'reaction' => $text
+            'reaction' => $text,
         ]);
         $dm->save();
 
         Conversation::updateOrInsert(
             [
                 'to_id' => $story->profile_id,
-                'from_id' => $actorProfile->id
+                'from_id' => $actorProfile->id,
             ],
             [
                 'type' => 'story:react',
                 'status_id' => $status->id,
                 'dm_id' => $dm->id,
-                'is_hidden' => false
+                'is_hidden' => false,
             ]
         );
 
@@ -1113,12 +1112,11 @@ class Inbox
         $n->action = 'story:react';
         $n->save();
 
-        return;
     }
 
     public function handleStoryReplyActivity()
     {
-        if(!isset(
+        if (! isset(
             $this->payload['actor'],
             $this->payload['id'],
             $this->payload['inReplyTo'],
@@ -1133,23 +1131,23 @@ class Inbox
         $to = $this->payload['to'];
         $text = Purify::clean($this->payload['content']);
 
-        if(parse_url($id, PHP_URL_HOST) !== parse_url($actor, PHP_URL_HOST)) {
+        if (parse_url($id, PHP_URL_HOST) !== parse_url($actor, PHP_URL_HOST)) {
             return;
         }
 
-        if(!Helpers::validateUrl($id) || !Helpers::validateUrl($actor)) {
+        if (! Helpers::validateUrl($id) || ! Helpers::validateUrl($actor)) {
             return;
         }
 
-        if(!Helpers::validateLocalUrl($storyUrl)) {
+        if (! Helpers::validateLocalUrl($storyUrl)) {
             return;
         }
 
-        if(!Helpers::validateLocalUrl($to)) {
+        if (! Helpers::validateLocalUrl($to)) {
             return;
         }
 
-        if(Status::whereObjectUrl($id)->exists()) {
+        if (Status::whereObjectUrl($id)->exists()) {
             return;
         }
 
@@ -1159,28 +1157,27 @@ class Inbox
         $story = Story::whereProfileId($targetProfile->id)
             ->find($storyId);
 
-        if(!$story) {
+        if (! $story) {
             return;
         }
 
-        if($story->can_react == false) {
+        if ($story->can_react == false) {
             return;
         }
 
         $actorProfile = Helpers::profileFetch($actor);
 
-
-        if(AccountService::blocksDomain($targetProfile->id, $actorProfile->domain) == true) {
+        if (AccountService::blocksDomain($targetProfile->id, $actorProfile->domain) == true) {
             return;
         }
 
-        if(!FollowerService::follows($actorProfile->id, $targetProfile->id)) {
+        if (! FollowerService::follows($actorProfile->id, $targetProfile->id)) {
             return;
         }
 
         $url = $id;
 
-        if(str_ends_with($url, '/activity')) {
+        if (str_ends_with($url, '/activity')) {
             $url = substr($url, 0, -9);
         }
 
@@ -1197,7 +1194,7 @@ class Inbox
         $status->in_reply_to_profile_id = $story->profile_id;
         $status->entities = json_encode([
             'story_id' => $story->id,
-            'caption' => $text
+            'caption' => $text,
         ]);
         $status->save();
 
@@ -1211,20 +1208,20 @@ class Inbox
             'story_actor_username' => $actorProfile->username,
             'story_id' => $story->id,
             'story_media_url' => url(Storage::url($story->path)),
-            'caption' => $text
+            'caption' => $text,
         ]);
         $dm->save();
 
         Conversation::updateOrInsert(
             [
                 'to_id' => $story->profile_id,
-                'from_id' => $actorProfile->id
+                'from_id' => $actorProfile->id,
             ],
             [
                 'type' => 'story:comment',
                 'status_id' => $status->id,
                 'dm_id' => $dm->id,
-                'is_hidden' => false
+                'is_hidden' => false,
             ]
         );
 
@@ -1236,12 +1233,11 @@ class Inbox
         $n->action = 'story:comment';
         $n->save();
 
-        return;
     }
 
     public function handleFlagActivity()
     {
-        if(!isset(
+        if (! isset(
             $this->payload['id'],
             $this->payload['type'],
             $this->payload['actor'],
@@ -1253,43 +1249,43 @@ class Inbox
         $id = $this->payload['id'];
         $actor = $this->payload['actor'];
 
-        if(Helpers::validateLocalUrl($id) || parse_url($id, PHP_URL_HOST) !== parse_url($actor, PHP_URL_HOST)) {
+        if (Helpers::validateLocalUrl($id) || parse_url($id, PHP_URL_HOST) !== parse_url($actor, PHP_URL_HOST)) {
             return;
         }
 
         $content = null;
-        if(isset($this->payload['content'])) {
-            if(strlen($this->payload['content']) > 5000) {
-                $content = Purify::clean(substr($this->payload['content'], 0, 5000) . ' ... (truncated message due to exceeding max length)');
+        if (isset($this->payload['content'])) {
+            if (strlen($this->payload['content']) > 5000) {
+                $content = Purify::clean(substr($this->payload['content'], 0, 5000).' ... (truncated message due to exceeding max length)');
             } else {
                 $content = Purify::clean($this->payload['content']);
             }
         }
         $object = $this->payload['object'];
 
-        if(empty($object) || (!is_array($object) && !is_string($object))) {
+        if (empty($object) || (! is_array($object) && ! is_string($object))) {
             return;
         }
 
-        if(is_array($object) && count($object) > 100) {
+        if (is_array($object) && count($object) > 100) {
             return;
         }
 
         $objects = collect([]);
         $accountId = null;
 
-        foreach($object as $objectUrl) {
-            if(!Helpers::validateLocalUrl($objectUrl)) {
+        foreach ($object as $objectUrl) {
+            if (! Helpers::validateLocalUrl($objectUrl)) {
                 return;
             }
 
-            if(str_contains($objectUrl, '/users/')) {
+            if (str_contains($objectUrl, '/users/')) {
                 $username = last(explode('/', $objectUrl));
                 $profileId = Profile::whereUsername($username)->first();
-                if($profileId) {
+                if ($profileId) {
                     $accountId = $profileId->id;
                 }
-            } else if(str_contains($objectUrl, '/p/')) {
+            } elseif (str_contains($objectUrl, '/p/')) {
                 $postId = last(explode('/', $objectUrl));
                 $objects->push($postId);
             } else {
@@ -1297,14 +1293,14 @@ class Inbox
             }
         }
 
-        if(!$accountId && !$objects->count()) {
+        if (! $accountId && ! $objects->count()) {
             return;
         }
 
-        if($objects->count()) {
+        if ($objects->count()) {
             $obc = $objects->count();
-            if($obc > 25) {
-                if($obc > 30) {
+            if ($obc > 25) {
+                if ($obc > 30) {
                     return;
                 } else {
                     $objLimit = $objects->take(20);
@@ -1313,7 +1309,7 @@ class Inbox
                 }
             }
             $count = Status::whereProfileId($accountId)->find($objects)->count();
-            if($obc !== $count) {
+            if ($obc !== $count) {
                 return;
             }
         }
@@ -1321,7 +1317,7 @@ class Inbox
         $instanceHost = parse_url($id, PHP_URL_HOST);
 
         $instance = Instance::updateOrCreate([
-            'domain' => $instanceHost
+            'domain' => $instanceHost,
         ]);
 
         $report = new RemoteReport;
@@ -1332,31 +1328,30 @@ class Inbox
         $report->instance_id = $instance->id;
         $report->report_meta = [
             'actor' => $actor,
-            'object' => $object
+            'object' => $object,
         ];
         $report->save();
 
-        return;
     }
 
     public function handleUpdateActivity()
     {
         $activity = $this->payload['object'];
 
-        if(!isset($activity['type'], $activity['id'])) {
+        if (! isset($activity['type'], $activity['id'])) {
             return;
         }
 
-        if(!Helpers::validateUrl($activity['id'])) {
+        if (! Helpers::validateUrl($activity['id'])) {
             return;
         }
 
-        if($activity['type'] === 'Note') {
-            if(Status::whereObjectUrl($activity['id'])->exists()) {
+        if ($activity['type'] === 'Note') {
+            if (Status::whereObjectUrl($activity['id'])->exists()) {
                 StatusRemoteUpdatePipeline::dispatch($activity);
             }
-        } else if ($activity['type'] === 'Person') {
-            if(UpdatePersonValidator::validate($this->payload)) {
+        } elseif ($activity['type'] === 'Person') {
+            if (UpdatePersonValidator::validate($this->payload)) {
                 HandleUpdateActivity::dispatch($this->payload)->onQueue('low');
             }
         }
@@ -1367,21 +1362,21 @@ class Inbox
         $actor = $this->payload['actor'];
         $activity = $this->payload['object'];
         $target = $this->payload['target'];
-        if(
-            !Helpers::validateUrl($actor) ||
-            !Helpers::validateUrl($activity) ||
-            !Helpers::validateUrl($target)
+        if (
+            ! Helpers::validateUrl($actor) ||
+            ! Helpers::validateUrl($activity) ||
+            ! Helpers::validateUrl($target)
         ) {
             return;
         }
 
         Bus::chain([
-            new ProcessMoveActivity,
+            new ProcessMovePipeline,
             new MoveMigrateFollowersPipeline,
             new UnfollowLegacyAccountMovePipeline,
-            new CleanupLegacyAccountMovePipeline
+            new CleanupLegacyAccountMovePipeline,
         ])
-        ->onQueue('move')
-        ->dispatch($target, $activity);
+            ->onQueue('move')
+            ->dispatch($target, $activity);
     }
 }

--- a/app/Util/ActivityPub/Inbox.php
+++ b/app/Util/ActivityPub/Inbox.php
@@ -1369,8 +1369,6 @@ class Inbox
             ! Helpers::validateUrl($activity) ||
             ! Helpers::validateUrl($target)
         ) {
-            Log::info('[AP][INBOX][MOVE] validateUrl fail');
-
             return;
         }
 

--- a/app/Util/ActivityPub/Inbox.php
+++ b/app/Util/ActivityPub/Inbox.php
@@ -145,7 +145,6 @@ class Inbox
             case 'Move':
                 if (MoveValidator::validate($this->payload) == false) {
                     \Log::info('[AP][INBOX][MOVE] VALIDATE_FAILURE '.json_encode($this->payload));
-
                     return;
                 }
                 $this->handleMoveActivity();
@@ -1367,6 +1366,7 @@ class Inbox
             ! Helpers::validateUrl($activity) ||
             ! Helpers::validateUrl($target)
         ) {
+            \Log::info('[AP][INBOX][MOVE] validateUrl fail');
             return;
         }
 
@@ -1375,6 +1375,6 @@ class Inbox
             new MoveMigrateFollowersPipeline($target, $activity),
             new UnfollowLegacyAccountMovePipeline($target, $activity),
             new CleanupLegacyAccountMovePipeline($target, $activity),
-        ])->onQueue('move')->dispatch();
+        ])->onQueue('move')->dispatchSync();
     }
 }

--- a/app/Util/ActivityPub/Inbox.php
+++ b/app/Util/ActivityPub/Inbox.php
@@ -1375,6 +1375,6 @@ class Inbox
             new MoveMigrateFollowersPipeline($target, $activity),
             new UnfollowLegacyAccountMovePipeline($target, $activity),
             new CleanupLegacyAccountMovePipeline($target, $activity),
-        ])->onQueue('move')->dispatchSync();
+        ])->onQueue('move')->dispatch();
     }
 }

--- a/app/Util/ActivityPub/Inbox.php
+++ b/app/Util/ActivityPub/Inbox.php
@@ -1382,7 +1382,7 @@ class Inbox
                 Log::error($e);
             })
             ->onQueue('move')
-            ->delay(now()->addMinutes(random_int(2, 5)))
+            ->delay(now()->addMinutes(random_int(1, 3)))
             ->dispatch();
     }
 }

--- a/app/Util/ActivityPub/Inbox.php
+++ b/app/Util/ActivityPub/Inbox.php
@@ -1384,7 +1384,7 @@ class Inbox
                 Log::error($e);
             })
             ->onQueue('move')
-            ->dispatch()
-            ->delay(now()->addMinutes(random_int(5, 9)));
+            ->delay(now()->addMinutes(random_int(5, 9)))
+            ->dispatch();
     }
 }

--- a/app/Util/ActivityPub/Validator/MoveValidator.php
+++ b/app/Util/ActivityPub/Validator/MoveValidator.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Util\ActivityPub\Validator;
+
+use Illuminate\Validation\Rule;
+use Validator;
+
+class MoveValidator
+{
+    public static function validate($payload)
+    {
+        return Validator::make($payload, [
+            '@context' => 'required',
+            'type' => [
+                'required',
+                Rule::in(['Move']),
+            ],
+            'actor' => 'required|url',
+            'object' => 'required|url',
+            'target' => 'required|url',
+        ])->passes();
+    }
+}

--- a/config/horizon.php
+++ b/config/horizon.php
@@ -92,6 +92,7 @@ return [
         'redis:intbg' => 30,
         'redis:adelete' => 30,
         'redis:groups' => 30,
+        'redis:move' => 30,
     ],
 
     /*
@@ -175,7 +176,7 @@ return [
         'production' => [
             'supervisor-1' => [
                 'connection'    => 'redis',
-                'queue'         => ['high', 'default', 'follow', 'shared', 'inbox', 'feed', 'low', 'story', 'delete', 'mmo', 'intbg', 'groups', 'adelete'],
+                'queue'         => ['high', 'default', 'follow', 'shared', 'inbox', 'feed', 'low', 'story', 'delete', 'mmo', 'intbg', 'groups', 'adelete', 'move'],
                 'balance'       => env('HORIZON_BALANCE_STRATEGY', 'auto'),
                 'minProcesses'  => env('HORIZON_MIN_PROCESSES', 1),
                 'maxProcesses'  => env('HORIZON_MAX_PROCESSES', 20),
@@ -189,7 +190,7 @@ return [
         'local' => [
             'supervisor-1' => [
                 'connection'    => 'redis',
-                'queue'         => ['high', 'default', 'follow', 'shared', 'inbox', 'feed', 'low', 'story', 'delete', 'mmo', 'intbg', 'groups', 'adelete'],
+                'queue'         => ['high', 'default', 'follow', 'shared', 'inbox', 'feed', 'low', 'story', 'delete', 'mmo', 'intbg', 'groups', 'adelete', 'move'],
                 'balance'       => 'auto',
                 'minProcesses' => 1,
                 'maxProcesses'  => 20,


### PR DESCRIPTION
Fix Federation logic to process federated `Move` activities.

Will be compatible with Mastodon and other implementations that support the `Move` activity with `alsoKnownAs` and `movedTo` attributes.

[Spec](https://swicg.github.io/activitypub-data-portability/#process-0)