### PR TITLE
Fix `artisan route:list` via middleware

### DIFF
--- a/app/Http/Controllers/CuratedRegisterController.php
+++ b/app/Http/Controllers/CuratedRegisterController.php
@@ -17,17 +17,6 @@ use App\Jobs\CuratedOnboarding\CuratedOnboardingNotifyAdminNewApplicationPipelin
 
 class CuratedRegisterController extends Controller
 {
-    public function __construct()
-    {
-        abort_unless((bool) config_cache('instance.curated_registration.enabled'), 404);
-
-        if((bool) config_cache('pixelfed.open_registration')) {
-            abort_if(config('instance.curated_registration.state.only_enabled_on_closed_reg'), 404);
-        } else {
-            abort_unless(config('instance.curated_registration.state.fallback_on_closed_reg'), 404);
-        }
-    }
-
     public function index(Request $request)
     {
         abort_if($request->user(), 404);

--- a/app/Http/Controllers/GroupController.php
+++ b/app/Http/Controllers/GroupController.php
@@ -27,7 +27,7 @@ class GroupController extends GroupFederationController
     public function __construct()
     {
         $this->middleware('auth');
-        abort_unless(config('groups.enabled'), 404);
+        $this->middleware('hasConfig:groups.enabled');
     }
 
     public function index(Request $request)

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -71,6 +71,7 @@ class Kernel extends HttpKernel
         'interstitial'  => \App\Http\Middleware\AccountInterstitial::class,
         'scopes'        => \Laravel\Passport\Http\Middleware\CheckScopes::class,
         'scope'         => \Laravel\Passport\Http\Middleware\CheckForAnyScope::class,
+        'hasConfig'     => \App\Http\Middleware\HasConfig::class,
         // 'restricted'    => \App\Http\Middleware\RestrictedAccess::class,
     ];
 }

--- a/app/Http/Middleware/EnsureCuratedRegistration.php
+++ b/app/Http/Middleware/EnsureCuratedRegistration.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class EnsureCuratedRegistration
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        abort_unless((bool) config_cache('instance.curated_registration.enabled'), 404);
+
+        if ((bool) config_cache('pixelfed.open_registration')) {
+            abort_if(config('instance.curated_registration.state.only_enabled_on_closed_reg'), 404);
+        } else {
+            abort_unless(config('instance.curated_registration.state.fallback_on_closed_reg'), 404);
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Http/Middleware/HasConfig.php
+++ b/app/Http/Middleware/HasConfig.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class HasConfig
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next, string $config): Response
+    {
+        abort_unless(config($config), 404);
+
+        return $next($request);
+    }
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,5 +1,8 @@
 <?php
 
+use App\Http\Controllers\CuratedRegisterController;
+use App\Http\Middleware\EnsureCuratedRegistration;
+
 Route::domain(config('pixelfed.domain.app'))->middleware(['validemail', 'twofactor', 'localization'])->group(function () {
     Route::get('/', 'SiteController@home')->name('timeline.personal');
     Route::redirect('/home', '/')->name('home');
@@ -31,17 +34,21 @@ Route::domain(config('pixelfed.domain.app'))->middleware(['validemail', 'twofact
     Route::post('auth/pci/{id}/{code}', 'ParentalControlsController@inviteRegisterStore');
 
     Route::get('auth/sign_up', 'SiteController@curatedOnboarding')->name('auth.curated-onboarding');
-    Route::post('auth/sign_up', 'CuratedRegisterController@proceed');
-    Route::get('auth/sign_up/concierge/response-sent', 'CuratedRegisterController@conciergeResponseSent');
-    Route::get('auth/sign_up/concierge', 'CuratedRegisterController@concierge');
-    Route::post('auth/sign_up/concierge', 'CuratedRegisterController@conciergeStore');
-    Route::get('auth/sign_up/concierge/form', 'CuratedRegisterController@conciergeFormShow');
-    Route::post('auth/sign_up/concierge/form', 'CuratedRegisterController@conciergeFormStore');
-    Route::get('auth/sign_up/confirm', 'CuratedRegisterController@confirmEmail');
-    Route::post('auth/sign_up/confirm', 'CuratedRegisterController@confirmEmailHandle');
-    Route::get('auth/sign_up/confirmed', 'CuratedRegisterController@emailConfirmed');
-    Route::get('auth/sign_up/resend-confirmation', 'CuratedRegisterController@resendConfirmation');
-    Route::post('auth/sign_up/resend-confirmation', 'CuratedRegisterController@resendConfirmationProcess');
+
+    Route::controller(CuratedRegisterController::class)->group(function () {
+        Route::post('auth/sign_up', 'proceed');
+        Route::get('auth/sign_up/concierge/response-sent', 'conciergeResponseSent');
+        Route::get('auth/sign_up/concierge', 'concierge');
+        Route::post('auth/sign_up/concierge', 'conciergeStore');
+        Route::get('auth/sign_up/concierge/form', 'conciergeFormShow');
+        Route::post('auth/sign_up/concierge/form', 'conciergeFormStore');
+        Route::get('auth/sign_up/confirm', 'confirmEmail');
+        Route::post('auth/sign_up/confirm', 'confirmEmailHandle');
+        Route::get('auth/sign_up/confirmed', 'emailConfirmed');
+        Route::get('auth/sign_up/resend-confirmation', 'resendConfirmation');
+        Route::post('auth/sign_up/resend-confirmation', 'resendConfirmationProcess');
+    })->middleware(EnsureCuratedRegistration::class);
+
     Route::get('auth/forgot/email', 'UserEmailForgotController@index')->name('email.forgot');
     Route::post('auth/forgot/email', 'UserEmailForgotController@store')->middleware('throttle:10,900,forgotEmail');
 


### PR DESCRIPTION
Problem: I noticed that `artisan route:list` is erroring due to a couple controllers' constructors

### I'm still in process of getting my dev environment set up so this is untested.

Since I'm still getting familiar, I wanted to make sure these kind of changes weren't disallowed. I did check the outputs of `route:list` with my changes and staging's (with the offenders commented out) to give some assurances that the routes weren't changed by the grouping.

This extracts 2 middleware to keep the `abort*` functions from causing issues. The `HasConfig` middleware accepts a string parameter that is passed to `config()` to make it flexible to apply to routes.

It feels like this pattern in general would be better as a service but I'm staying focused on minimal fix.