### PR TITLE
Fix #5272 Instagram import fails silently if there's one post only in posts_1.json

### DIFF
--- a/resources/assets/components/AccountImport.vue
+++ b/resources/assets/components/AccountImport.vue
@@ -369,6 +369,10 @@
             async filterPostMeta(media) {
             	let fbfix = await this.fixFacebookEncoding(media);
                 let json = JSON.parse(fbfix);
+                /* Sometimes the JSON isn't an array, when there's only one post */
+                if (!Array.isArray(json)) {
+                    json = new Array(json);
+                }
                 let res = json.filter(j => {
                     let ids = j.media.map(m => m.uri).filter(m => {
                         if(this.config.allow_video_posts == true) {


### PR DESCRIPTION
Manage the case when there's only one post in  posts_1.json and the JSON is not an array

Fixes #5272