### PR TITLE
Fix photo_reblogs_only not working

### DIFF
--- a/resources/assets/components/sections/Timeline.vue
+++ b/resources/assets/components/sections/Timeline.vue
@@ -325,29 +325,24 @@
 
                 this.isFetchingMore = true;
 
-                let url, params;
-                if(this.getScope() === 'home' && this.settings && this.settings.hasOwnProperty('enable_reblogs') && this.settings.enable_reblogs) {
-                    url = this.baseApi + `home`;
+                let url = this.baseApi + this.getScope();
+                let params = {
+                    max_id: this.max_id,
+                    limit: 6,
+                    '_pe': 1,
+                };
 
-                    params = {
-                        '_pe': 1,
-                        max_id: this.max_id,
-                        limit: 6,
-                        include_reblogs: true,
-                    }
-                } else {
-                    url = this.baseApi + this.getScope();
-                    params = {
-                        max_id: this.max_id,
-                        limit: 6,
-                        '_pe': 1,
-                    }
+                switch(this.getScope()) {
+                    case 'home':
+                        params.include_reblogs = this?.settings?.enable_reblogs ?? false;
+                        params.photos_reblogs_only = this?.settings?.photo_reblogs_only ?? true;
+                        break;
+                    case 'network':
+                        params.remote = true;
+                        url = this.baseApi + `public`;
+                        break;
                 }
-                if(this.getScope() === 'network') {
-                    params.remote = true;
-                    url = this.baseApi + `public`;
 
-                }
                 axios.get(url, {
                     params: params
                 }).then(res => {


### PR DESCRIPTION
This makes sure timeline fetches knows if a reblog is of a valid type, and shows it according to `photos_reblogs_only` setting.

You will need to rebuild UI assets for it to work.