### PR TITLE
Fix sqlite database migration

### DIFF
--- a/database/migrations/2024_05_20_062706_update_group_posts_table.php
+++ b/database/migrations/2024_05_20_062706_update_group_posts_table.php
@@ -12,6 +12,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('group_posts', function (Blueprint $table) {
+            $table->dropUnique(['status_id']);
             $table->dropColumn('status_id');
             $table->dropColumn('reply_child_id');
             $table->dropColumn('in_reply_to_id');


### PR DESCRIPTION
The database migration currently didn't work for SQLite because it tries to remove column that has a UNIQUE constraint. Which is not allowed according to [SQLite documentation](https://www.sqlite.org/lang_altertable.html#alter_table_drop_column)

This pr fix that by removing the unique index first before dropping the column.