### PR TITLE
Fix missing video thumbnails on hashtag page (#5394).

### DIFF
--- a/resources/assets/components/Hashtag.vue
+++ b/resources/assets/components/Hashtag.vue
@@ -74,7 +74,7 @@
 												width="32"
 												height="32"
 												:hash="status.media_attachments[0].blurhash"
-												:src="status.media_attachments[0].url"
+												:src="status.media_attachments[0].preview_url"
 												/>
 										</div>
 										<span v-if="status.pf_type == 'photo:album'" class="float-right mr-3 post-icon"><i class="fas fa-images fa-2x"></i></span>


### PR DESCRIPTION
**Changes**

This implements #5394. As described in that ticket, video thumbnails were missing from the hashtag page, and it appeared that the wrong URL was being requested. Upon closer inspection (looking at the DOM elements of the page), that did appear to be the case.. The `<img src="...">` for any video thumbnail ended in `.mp4` rather than the expected `.png` or `.jpg`. So switching the page from using just `.url` to `.preview_url` for each status' media attachments appeared to fix the problem—and now the correct video thumbnail shows up. Also, thumbnails for non-video media attachments continue showing up properly.

**Testing done**

I don't have a pipeline set up for Pixelfed source :arrow_right: container currently, so I hand-hacked the JavaScript of the bundle corresponding to the modified Vue file. :grimacing: Then I reloaded a hashtag page on my site and observed that video thumbnails loaded alongside the existing image thumbnails.

Let me know if there are any automated tests I should add here.. I didn't see existing tests for any Vue components.

**Future work**

It's beyond my abilities right now (I'm a backend dev), but now that there are working thumbnails, it would probably be a good idea to bring over the `video-overlay-badge` (and `timestamp-overlay-badge`?) from the profile page (`ProfileFeed.vue` ). That way, it'd be clear which thumbnail here corresponds to a video and which is just an image.