### PR TITLE
Docker Registry

### DIFF
--- a/.env.docker
+++ b/.env.docker
@@ -964,7 +964,7 @@ TZ="${APP_TIMEZONE}"
 # Combined with [DOCKER_APP_RUNTIME] and [PHP_VERSION] configured
 # elsewhere in this file, the final Docker tag is computed.
 # @dottie/validate required
-DOCKER_APP_RELEASE="v0.12.4"
+DOCKER_APP_RELEASE="v0.12"
 
 # The PHP version to use for [web] and [worker] container
 #
@@ -1016,7 +1016,7 @@ DOCKER_APP_IMAGE="ghcr.io/jippi/docker-pixelfed"
 #
 # @see https://github.com/pixelfed/pixelfed/pkgs/container/pixelfed
 # @dottie/validate required
-DOCKER_APP_TAG="${DOCKER_APP_RELEASE:?error}-${DOCKER_APP_RUNTIME:?error}-${DOCKER_APP_PHP_VERSION:?error}-${DOCKER_APP_DEBIAN_RELEASE:?error}"
+DOCKER_APP_TAG="${DOCKER_APP_RELEASE:?error}-${DOCKER_APP_RUNTIME:?error}-${DOCKER_APP_PHP_VERSION:?error}"
 
 # Path (on host system) where the [app] + [worker] container will write
 # its [storage] data (e.g uploads/images/profile pictures etc.).

--- a/.env.docker
+++ b/.env.docker
@@ -964,7 +964,7 @@ TZ="${APP_TIMEZONE}"
 # Combined with [DOCKER_APP_RUNTIME] and [PHP_VERSION] configured
 # elsewhere in this file, the final Docker tag is computed.
 # @dottie/validate required
-DOCKER_APP_RELEASE="branch-jippi-fork"
+DOCKER_APP_RELEASE="v0.12.4"
 
 # The PHP version to use for [web] and [worker] container
 #
@@ -981,7 +981,7 @@ DOCKER_APP_RELEASE="branch-jippi-fork"
 # *only* the version part. The rest of the full tag is derived from
 # the [DOCKER_APP_RUNTIME] and [PHP_DEBIAN_RELEASE] settings
 # @dottie/validate required
-DOCKER_APP_PHP_VERSION="8.2"
+DOCKER_APP_PHP_VERSION="8.3"
 
 # The container runtime to use.
 #
@@ -993,7 +993,7 @@ DOCKER_APP_RUNTIME="apache"
 #
 # Examlpe: [bookworm] or [bullseye]
 # @dottie/validate required,oneof=bookworm bullseye
-DOCKER_APP_DEBIAN_RELEASE="bullseye"
+DOCKER_APP_DEBIAN_RELEASE="bookworm"
 
 # The [php] Docker image base type
 #
@@ -1010,13 +1010,13 @@ DOCKER_APP_BASE_TYPE="apache"
 #   * "your/fork"                 to pull from a custom fork
 #
 # @dottie/validate required
-DOCKER_APP_IMAGE="ghcr.io/jippi/pixelfed"
+DOCKER_APP_IMAGE="ghcr.io/jippi/docker-pixelfed"
 
 # Pixelfed version (image tag) to pull from the registry.
 #
 # @see https://github.com/pixelfed/pixelfed/pkgs/container/pixelfed
 # @dottie/validate required
-DOCKER_APP_TAG="${DOCKER_APP_RELEASE:?error}-${DOCKER_APP_RUNTIME:?error}-${DOCKER_APP_PHP_VERSION:?error}"
+DOCKER_APP_TAG="${DOCKER_APP_RELEASE:?error}-${DOCKER_APP_RUNTIME:?error}-${DOCKER_APP_PHP_VERSION:?error}-${DOCKER_APP_DEBIAN_RELEASE:?error}"
 
 # Path (on host system) where the [app] + [worker] container will write
 # its [storage] data (e.g uploads/images/profile pictures etc.).


### PR DESCRIPTION
Registry has changed. Old registry has been discontinued in August 2024. New Registry added, format of Docker tag has been adjusted as it now contains the Debian Release as well.

Sample Version is set to current stable but can be adjusted to any of the available branches.