### PR TITLE
fix(compose-modal): avoid WebGL if it's not needed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
 				"vue-loading-overlay": "^3.3.3",
 				"vue-timeago": "^5.1.2",
 				"vue-tribute": "^1.0.7",
-				"webgl-media-editor": "^0.0.1",
+				"webgl-media-editor": "^0.0.6",
 				"zuck.js": "^1.6.0"
 			},
 			"devDependencies": {
@@ -2322,6 +2322,12 @@
 				"events": "^3.3.0",
 				"m3u8-parser": "~4.7.1"
 			}
+		},
+		"node_modules/@reactively/core": {
+			"version": "0.0.8",
+			"resolved": "https://registry.npmjs.org/@reactively/core/-/core-0.0.8.tgz",
+			"integrity": "sha512-5uAnNf2gQSm3gM7z6Lx079H1/MuDQQI+5aYfwyDFGR9nHZj8yblLY/6aOJVWp+NcBwXVBKuWQ28qWHD9F1qN1w==",
+			"license": "ISC"
 		},
 		"node_modules/@thaunknown/simple-peer": {
 			"version": "10.0.11",
@@ -5643,6 +5649,15 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/fine-jsx": {
+			"version": "0.0.5",
+			"resolved": "https://registry.npmjs.org/fine-jsx/-/fine-jsx-0.0.5.tgz",
+			"integrity": "sha512-UKQ0ymyZnA605yf7np/wAv3iTs6i9oRKgyYmz+dX+F3VanYEBr60zRQ+WPcYzXMtl9NghNxT736qHfDBjoXVDg==",
+			"license": "AGPL-3.0-only",
+			"dependencies": {
+				"@reactively/core": "^0.0.8"
 			}
 		},
 		"node_modules/fizzy-ui-utils": {
@@ -10749,16 +10764,28 @@
 				"node": ">= 8"
 			}
 		},
+		"node_modules/webgl-effects": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/webgl-effects/-/webgl-effects-0.0.3.tgz",
+			"integrity": "sha512-P+qxcO0QyydUnHHwnsge2ckou85Pnsdgn0BKAjrhD9LiPFz5i2hq8rT8AdS7wNdXrXyqlM1Y0id+AB0gKTDtpQ==",
+			"license": "AGPL-3.0-only",
+			"dependencies": {
+				"gl-matrix": "^3.4.3",
+				"twgl.js": "^5.5.4"
+			}
+		},
 		"node_modules/webgl-media-editor": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/webgl-media-editor/-/webgl-media-editor-0.0.1.tgz",
-			"integrity": "sha512-TxnuRl3rpWa1Cia/pn+vh+0iz3yDNwzsrnRGJ61YkdZAYuimu2afBivSHv0RK73hKza6Y/YoRCkuEcsFmtxPNw==",
+			"version": "0.0.6",
+			"resolved": "https://registry.npmjs.org/webgl-media-editor/-/webgl-media-editor-0.0.6.tgz",
+			"integrity": "sha512-hqpIY+a+ay3QzXKECC4pFSHS0dVogV3GlBWzuSwBzEeGZcs7MeEYxLhFdqUa1D2xFtNnXb0pAo+1lCndYDKP2A==",
 			"license": "AGPL-3.0-only",
 			"dependencies": {
 				"cropperjs": "^1.6.2",
+				"fine-jsx": "^0.0.5",
 				"gl-matrix": "^3.4.3",
 				"throttle-debounce": "^5.0.2",
-				"twgl.js": "^5.5.4"
+				"twgl.js": "^5.5.4",
+				"webgl-effects": "^0.0.3"
 			}
 		},
 		"node_modules/webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
 		"vue-loading-overlay": "^3.3.3",
 		"vue-timeago": "^5.1.2",
 		"vue-tribute": "^1.0.7",
-		"webgl-media-editor": "^0.0.1",
+		"webgl-media-editor": "^0.0.6",
 		"zuck.js": "^1.6.0"
 	},
 	"collective": {


### PR DESCRIPTION
This PR does a few things to handle missing/broken WebGL better:

- wraps the instantiation of the WebGL image editor in a try-catch
- uses cropper.js to get the cropped image Blob if there's no WebGL editor instance
- avoids using the WebGL editor preview or result blob if there are no edits applied

Re: #5443 #5539