### PR TITLE
Fix notifications not being delivered by directly checking the database

### DIFF
--- a/app/Console/Commands/PushGatewayRefresh.php
+++ b/app/Console/Commands/PushGatewayRefresh.php
@@ -51,8 +51,6 @@ class PushGatewayRefresh extends Command
                 $recheck = NotificationAppGatewayService::forceSupportRecheck();
                 if ($recheck) {
                     $this->info('Success! Push Notifications are now active!');
-                    PushNotificationService::warmList('like');
-
                     return;
                 } else {
                     $this->error('Error, please ensure you have a valid API key.');

--- a/app/Http/Controllers/Api/ApiV1Dot1Controller.php
+++ b/app/Http/Controllers/Api/ApiV1Dot1Controller.php
@@ -1058,8 +1058,6 @@ class ApiV1Dot1Controller extends Controller
             'notify_comment' => false,
         ]);
 
-        PushNotificationService::removeMemberFromAll($request->user()->profile_id);
-
         $user = $request->user();
 
         return $this->json([
@@ -1145,31 +1143,15 @@ class ApiV1Dot1Controller extends Controller
 
         if ($request->filled('notify_like')) {
             $request->user()->update(['notify_like' => (bool) $request->boolean('notify_like')]);
-            $request->boolean('notify_like') == true ?
-                PushNotificationService::set('like', $pid) :
-                PushNotificationService::removeMember('like', $pid);
         }
         if ($request->filled('notify_follow')) {
             $request->user()->update(['notify_follow' => (bool) $request->boolean('notify_follow')]);
-            $request->boolean('notify_follow') == true ?
-                PushNotificationService::set('follow', $pid) :
-                PushNotificationService::removeMember('follow', $pid);
         }
         if ($request->filled('notify_mention')) {
             $request->user()->update(['notify_mention' => (bool) $request->boolean('notify_mention')]);
-            $request->boolean('notify_mention') == true ?
-                PushNotificationService::set('mention', $pid) :
-                PushNotificationService::removeMember('mention', $pid);
         }
         if ($request->filled('notify_comment')) {
             $request->user()->update(['notify_comment' => (bool) $request->boolean('notify_comment')]);
-            $request->boolean('notify_comment') == true ?
-                PushNotificationService::set('comment', $pid) :
-                PushNotificationService::removeMember('comment', $pid);
-        }
-
-        if ($request->boolean('notify_enabled') == false) {
-            PushNotificationService::removeMemberFromAll($request->user()->profile_id);
         }
 
         $user = $request->user();

--- a/app/Services/PushNotificationService.php
+++ b/app/Services/PushNotificationService.php
@@ -3,121 +3,15 @@
 namespace App\Services;
 
 use App\User;
-use Exception;
-use Illuminate\Support\Facades\Cache;
-use Illuminate\Support\Facades\Redis;
-use Log;
 
-class PushNotificationService
-{
-    public const ACTIVE_LIST_KEY = 'pf:services:push-notify:active_deliver:';
+class PushNotificationService {
 
     public const NOTIFY_TYPES = ['follow', 'like', 'mention', 'comment'];
 
-    public const DEEP_CHECK_KEY = 'pf:services:push-notify:deep-check:';
-
     public const PUSH_GATEWAY_VERSION = '1.0';
 
-    public const LOTTERY_ODDS = 20;
-
-    public const CACHE_LOCK_SECONDS = 10;
-
-    public static function get($list)
-    {
-        return Redis::smembers(self::ACTIVE_LIST_KEY.$list);
-    }
-
-    public static function set($listId, $memberId)
-    {
-        if (! in_array($listId, self::NOTIFY_TYPES)) {
-            return false;
-        }
-        $user = User::whereProfileId($memberId)->first();
-        if (! $user || $user->status || $user->deleted_at) {
-            return false;
-        }
-
-        return Redis::sadd(self::ACTIVE_LIST_KEY.$listId, $memberId);
-    }
-
-    public static function check($listId, $memberId)
-    {
-        return random_int(1, self::LOTTERY_ODDS) === 1
-            ? self::isMemberDeepCheck($listId, $memberId)
-            : self::isMember($listId, $memberId);
-    }
-
-    public static function isMember($listId, $memberId)
-    {
-        try {
-            return Redis::sismember(self::ACTIVE_LIST_KEY.$listId, $memberId);
-        } catch (Exception $e) {
-            return false;
-        }
-    }
-
-    public static function isMemberDeepCheck($listId, $memberId)
-    {
-        $lock = Cache::lock(self::DEEP_CHECK_KEY.$listId, self::CACHE_LOCK_SECONDS);
-
-        try {
-            $lock->block(5);
-            $actualCount = User::whereNull('status')->where('notify_enabled', true)->where('notify_'.$listId, true)->count();
-            $cachedCount = self::count($listId);
-            if ($actualCount != $cachedCount) {
-                self::warmList($listId);
-                $user = User::where('notify_enabled', true)->where('profile_id', $memberId)->first();
-
-                return $user ? (bool) $user->{"notify_{$listId}"} : false;
-            } else {
-                return self::isMember($listId, $memberId);
-            }
-        } catch (Exception $e) {
-            Log::error('Failed during deep membership check: '.$e->getMessage());
-
-            return false;
-        } finally {
-            optional($lock)->release();
-        }
-    }
-
-    public static function removeMember($listId, $memberId)
-    {
-        return Redis::srem(self::ACTIVE_LIST_KEY.$listId, $memberId);
-    }
-
-    public static function removeMemberFromAll($memberId)
-    {
-        foreach (self::NOTIFY_TYPES as $type) {
-            self::removeMember($type, $memberId);
-        }
-
-        return 1;
-    }
-
-    public static function count($listId)
-    {
-        if (! in_array($listId, self::NOTIFY_TYPES)) {
-            return false;
-        }
-
-        return Redis::scard(self::ACTIVE_LIST_KEY.$listId);
-    }
-
-    public static function warmList($listId)
-    {
-        if (! in_array($listId, self::NOTIFY_TYPES)) {
-            return false;
-        }
-        $key = self::ACTIVE_LIST_KEY.$listId;
-        Redis::del($key);
-        foreach (User::where('notify_'.$listId, true)->cursor() as $acct) {
-            if ($acct->status || $acct->deleted_at || ! $acct->profile_id || ! $acct->notify_enabled) {
-                continue;
-            }
-            Redis::sadd($key, $acct->profile_id);
-        }
-
-        return self::count($listId);
+    public static function check($listId, $memberId) {
+        $user = User::where('notify_enabled', true)->where('profile_id', $memberId)->first();
+        return $user ? (bool) $user->{"notify_{$listId}"} : false;
     }
 }


### PR DESCRIPTION
The Redis cache for push notifications is out of sync and causing push notifications not to be sent. This PR removes the redis cache and just directly reads from the database instead

# Test plan
Built and deployed an image with the fix: https://github.com/intentionally-left-nil/pixelfed/pkgs/container/pixelfed-fpm

Liked a post, made sure that a push notification was sent to the android app.
Disabled push notifications for likes, liked a new post. Made sure no pushes were sent


Ensure that an equivalent SQL command is properly indexed (Not sure how to generate exactly what laravel outputs)

```
EXPLAIN ANALYZE SELECT * FROM users join profiles ON users.id = profiles.user_id WHERE profiles.id = '546725230825791491';
                                                           QUERY PLAN                                                            
---------------------------------------------------------------------------------------------------------------------------------
 Nested Loop  (cost=0.29..9.44 rows=1 width=9599) (actual time=0.059..0.060 rows=1 loops=1)
   Join Filter: (users.id = profiles.user_id)
   Rows Removed by Join Filter: 6
   ->  Index Scan using profiles_pkey on profiles  (cost=0.29..8.31 rows=1 width=4046) (actual time=0.034..0.035 rows=1 loops=1)
         Index Cond: (id = '546725230825791491'::bigint)
   ->  Seq Scan on users  (cost=0.00..1.06 rows=6 width=5553) (actual time=0.013..0.018 rows=7 loops=1)
 Planning Time: 0.346 ms
 Execution Time: 0.195 ms
```

