### PR TITLE
Fix text no posts archived

### DIFF
--- a/resources/assets/components/partials/profile/ProfileFeed.vue
+++ b/resources/assets/components/partials/profile/ProfileFeed.vue
@@ -438,7 +438,7 @@
 			<div v-if="!archives || !archives.length" class="row justify-content-center">
 				<div class="col-12 col-md-8 text-center">
 					<img src="/img/illustrations/dk-nature-man-monochrome.svg" class="img-fluid" style="opacity: 0.6;">
-					<p class="lead text-muted font-weight-bold">We can't seem to find any posts you have bookmarked</p>
+					<p class="lead text-muted font-weight-bold">We can't seem to find any posts you have archived</p>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
On your own profile page in the “Archives” tab it currently displays “We can't seem to find any posts you have bookmarked”. This is the same text as in the “Bookmarks” tab. I have therefore fixed the text accordingly.