### PR TITLE
Fix self followers & following hidden

### DIFF
--- a/app/Profile.php
+++ b/app/Profile.php
@@ -65,10 +65,10 @@ class Profile extends Model
 		return $this->hasMany(Status::class);
 	}
 
-	public function followingCount($short = false)
+	public function followingCount($short = false, $isSelf = false)
 	{
 		$count = Cache::remember('profile:following_count:'.$this->id, now()->addMonths(1), function() {
-			if($this->domain == null && $this->user->settings->show_profile_following_count == false) {
+			if(!$isSelf && $this->domain == null && $this->user->settings->show_profile_following_count == false) {
 				return 0;
 			}
 			$count = DB::table('followers')->where('profile_id', $this->id)->count();
@@ -82,10 +82,10 @@ class Profile extends Model
 		return $short ? PrettyNumber::convert($count) : $count;
 	}
 
-	public function followerCount($short = false)
+	public function followerCount($short = false, $isSelf = false)
 	{
 		$count = Cache::remember('profile:follower_count:'.$this->id, now()->addMonths(1), function() {
-			if($this->domain == null && $this->user->settings->show_profile_follower_count == false) {
+			if(!$isSelf && $this->domain == null && $this->user->settings->show_profile_follower_count == false) {
 				return 0;
 			}
 			$count = DB::table('followers')->where('following_id', $this->id)->count();

--- a/app/Transformer/Api/AccountWithStatusesTransformer.php
+++ b/app/Transformer/Api/AccountWithStatusesTransformer.php
@@ -15,6 +15,9 @@ class AccountWithStatusesTransformer extends Fractal\TransformerAbstract
 
 	public function transform(Profile $profile)
 	{
+		$auth = Auth::check();
+		$isSelf = $auth && $profile->id == Auth::user()->profile->id;
+
 		$local = $profile->domain == null;
 		$is_admin = !$local ? false : $profile->user->is_admin;
 		$acct = $local ? $profile->username : substr($profile->username, 1);
@@ -26,8 +29,8 @@ class AccountWithStatusesTransformer extends Fractal\TransformerAbstract
 			'display_name' => $profile->name,
 			'locked' => (bool) $profile->is_private,
 			'followers_count' => $profile->followerCount(),
-			'following_count' => $profile->followingCount(),
-			'statuses_count' => (int) $profile->statusCount(),
+			'following_count' => $profile->followingCount($isSelf),
+			'statuses_count' => (int) $profile->statusCount($isSelf),
 			'note' => $profile->bio ?? '',
 			'url' => $profile->url(),
 			'avatar' => $profile->avatarUrl(),

--- a/app/Transformer/Api/Mastodon/v1/AccountTransformer.php
+++ b/app/Transformer/Api/Mastodon/v1/AccountTransformer.php
@@ -10,6 +10,9 @@ class AccountTransformer extends Fractal\TransformerAbstract
 {
 	public function transform(Profile $profile)
 	{
+		$auth = Auth::check();
+		$isSelf = $auth && $profile->id == Auth::user()->profile->id;
+
 		$local = $profile->domain == null;
 		$username = $local ? $profile->username : explode('@', substr($profile->username, 1))[0];
 		return [
@@ -26,8 +29,8 @@ class AccountTransformer extends Fractal\TransformerAbstract
 			'avatar_static' => $profile->avatarUrl(),
 			'header' =>  url('/storage/headers/missing.png'),
 			'header_static' =>  url('/storage/headers/missing.png'),
-			'followers_count' => (int) $profile->followerCount(),
-			'following_count' => (int) $profile->followingCount(),
+			'followers_count' => (int) $profile->followerCount($isSelf),
+			'following_count' => (int) $profile->followingCount($isSelf),
 			'statuses_count' => (int) $profile->statusCount(),
 			'last_status_at' => optional($profile->last_status_at)->toJSON(),
 			'emojis' => [],


### PR DESCRIPTION
This addresses the following issue documented on the react-native app repo https://github.com/pixelfed/pixelfed-rn/issues/158

### Issue

When the currently logged in user hides their follower count, they will see their own follower count as 0 when they navigate to their own profile.

### How to reproduce

Go to settings -> privacy -> click Hide Followers -> clear cache -> login -> go to profile -> follower count is at 0

### This change

This change cross checks the currently authenticated user with the profile thats being fetched, and passes in a `isSelf` parameter to the profile methods. The methods will have `!$isSelf` as a prerequisite to hide the follower count. `isSelf` is false by default, for when this shall not matter.