### PR TITLE
check for existing case insensitive email match before signing up

### DIFF
--- a/app/Console/Commands/UserCreate.php
+++ b/app/Console/Commands/UserCreate.php
@@ -71,7 +71,7 @@ class UserCreate extends Command
 
         $email = $this->ask('Email');
 
-        if(User::whereEmail($email)->exists()) {
+        if(User::whereRaw('lower(email) = ?', [strtolower($email)])->exists()) {
             $this->error('Email already in use, please try again...');
             exit;
         }


### PR DESCRIPTION
Identified by this bug report: https://github.com/pixelfed/pixelfed/issues/5474#issue-2789453855

This change converts the email address to lowercase before checking its existence in the database, ensuring uniqueness of email addresses