### PR TITLE
[Improvement] Add note about import format limitations

### DIFF
--- a/resources/views/site/help/import.blade.php
+++ b/resources/views/site/help/import.blade.php
@@ -25,7 +25,7 @@
             <span>Navigate to the <a href="/settings/import" class="font-weight-bold">Import</a> settings page</span>
         </li>
         <li class="">
-            <span>Follow the instructions and import your posts 🥳</span>
+            <span>Follow the instructions and import your posts 🥳 NB: The export may contain files in the webp or heic file formats, this media is not supported by the import</span>
         </li>
     </ol>
     <hr class="mb-4" />


### PR DESCRIPTION
In trying to import photos from Instagram, I came across this issue #5236. This adds a note to the help centre to reflect this limitation.