### PR TITLE
Fix the local column for statuses to not include remote shares

### DIFF
--- a/app/Util/ActivityPub/Inbox.php
+++ b/app/Util/ActivityPub/Inbox.php
@@ -645,6 +645,7 @@ class Inbox
             'profile_id' => $actor->id,
             'reblog_of_id' => $parent->id,
             'type' => 'share',
+            'local' => false,
         ]);
 
         Notification::firstOrCreate(

--- a/database/migrations/2025_01_18_061532_fix_local_statuses.php
+++ b/database/migrations/2025_01_18_061532_fix_local_statuses.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        DB::table('statuses')
+            ->leftJoin('profiles', 'statuses.profile_id', '=', 'profiles.id')
+            ->leftJoin('users', 'users.profile_id', '=', 'profiles.id')
+            ->whereNull('users.id')
+            ->update(['local' => false]);
+    }
+
+    public function down(): void
+    {
+        // No down migration needed since this is a data fix
+    }
+};

--- a/database/migrations/2025_01_18_061532_fix_local_statuses.php
+++ b/database/migrations/2025_01_18_061532_fix_local_statuses.php
@@ -4,16 +4,24 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Facades\DB;
+use App\Models\Status;
 
 return new class extends Migration
 {
     public function up(): void
     {
-        DB::table('statuses')
-            ->leftJoin('profiles', 'statuses.profile_id', '=', 'profiles.id')
-            ->leftJoin('users', 'users.profile_id', '=', 'profiles.id')
-            ->whereNull('users.id')
-            ->update(['local' => false]);
+        Status::query()
+            ->where('local', true)
+            ->where('type', 'share')
+            ->whereHas('profile', function($query) {
+                $query->whereDoesntHave('user');
+            })
+            ->chunkById(100, function($statuses) {
+                foreach($statuses as $status) {
+                    $status->local = false;
+                    $status->save();
+                }
+            });
     }
 
     public function down(): void


### PR DESCRIPTION
My server has O(100) posts, but the local stats are quite off. From doing a quick investigation, this is because shares are marked as local:
```
 SELECT COUNT(*), statuses.type from statuses WHERE local is true group by type;
 count  |    type     
--------+-------------
    133 | photo
     28 | photo:album
 138459 | share
     42 | text
```

This fixes the Inbox controller to mark shares as false. It also includes a data migration to fix-up the old rows. From looking through the code, I think that `profile_id` is set everywhere else local = True (all valid cases), but it would be great to double check

# Test plan
Dry run to see what rows would be updated:
```
$count = 0;
Status::query()
            ->where('local', true)
            ->where('type', 'share)
            ->whereHas('profile', function($query) {
                $query->whereDoesntHave('user');
            })
            ->chunkById(100, function($statuses) use (&$count) {
                foreach($statuses as $status) {
                    $count++;
                }
            });

echo "Total statuses that would be updated: {$count}\n";
Total statuses that would be updated: 136949
```

Which matches what I would expect from the raw sql:
```
SELECT COUNT(DISTINCT(statuses.id)) FROM statuses LEFT JOIN profiles on statuses.profile_id = profiles.id LEFT JOIN users on users.profile_id = profiles.id WHERE users.id IS NULL AND statuses.local is TRUE AND statuses.deleted_at IS NULL;
 count  
--------
 136949
(1 row)

```

# Performance analysis

TL;DR: With 10 million statuses, the first batch took 9 seconds, and every subsequent batch took milliseconds

We want to make sure this doesn't blow up the CPU or RAM for pg/mysql databases with millions of statuses. Here's the work I did to investigate this.

First, I used `\DB::enableQueryLog();` and `dd(\DB::getQueryLog());` to see what query is generated via the chunkById call.

Here's an example:
```sql
"select * from "statuses" where  exists (select * from "profiles" where "statuses"."profile_id" = "profiles"."id" and not exists (select * from "users" where "profiles"."user_id" = "users"."id" and "users"."deleted_at" is null) and "profiles"."deleted_at" is null) and "statuses"."deleted_at" is null order by "id" asc limit 100"
```

Next, I used this script to generate a sample database with 1,000,000 users and 10,000,000 statuses:
```sh
PGPASSWORD=postgres psql -h localhost -U postgres -c "CREATE DATABASE testdb;"

# Create tables
PGPASSWORD=postgres psql -h localhost -U postgres -d testdb -c "
CREATE TABLE users (
    id BIGSERIAL PRIMARY KEY,
    profile_id BIGINT
);

CREATE TABLE profiles (
    id BIGSERIAL PRIMARY KEY,
    user_id INTEGER,
    domain VARCHAR,
    username VARCHAR,
    name VARCHAR,
    created_at TIMESTAMP,
    updated_at TIMESTAMP,
    UNIQUE(domain, username)
);

CREATE TABLE statuses (
    id BIGSERIAL PRIMARY KEY,
    local BOOLEAN DEFAULT true,
    profile_id BIGINT
);

CREATE INDEX users_profile_id_idx ON users(profile_id);
CREATE INDEX statuses_profile_id_idx ON statuses(profile_id);
"

# Create pgbench script for initial data
cat > init_data.sql << EOF
WITH txid AS (SELECT txid_current() as id)
INSERT INTO profiles (domain, username, name, created_at, updated_at)
SELECT 'localhost_' || id, 'test_user_' || id, 'Test User ' || id, NOW(), NOW()
FROM txid
RETURNING id \gset profile_
INSERT INTO users (profile_id)
VALUES (:profile_id)
RETURNING id \gset user_
UPDATE profiles SET user_id = :user_id WHERE id = :profile_id;
-- Create some test statuses for this user
INSERT INTO statuses (profile_id, local) 
VALUES 
    (:profile_id, true),
    (:profile_id, true),
    (:profile_id, true),
    (:profile_id, false),
    (:profile_id, false),
    (:profile_id, false),
    (:profile_id, true),
    (:profile_id, true),
    (:profile_id, true),
    (:profile_id, true);
EOF

# Initialize pgbench
PGPASSWORD=postgres pgbench -h localhost -U postgres -d testdb -i

# Run pgbench to create users
PGPASSWORD=postgres pgbench -h localhost -U postgres -d testdb \
  -f init_data.sql \
  -c 10 -j 10 -t 100000
# Drop 20% of users randomly and set their profiles' user_id to null
# This is needed to simullate the bug condition where there are remote statuses
PGPASSWORD=postgres psql -h localhost -U postgres -d testdb -c "
BEGIN;
CREATE TEMP TABLE users_to_drop AS 
SELECT id FROM users TABLESAMPLE SYSTEM (20);

UPDATE profiles SET user_id = NULL 
WHERE user_id IN (SELECT id FROM users_to_drop);

DELETE FROM users 
WHERE id IN (SELECT id FROM users_to_drop);

DROP TABLE users_to_drop;
COMMIT;
"

echo "Setup complete! Database is ready for testing."
```

If we modify the sql query a bit for our new test db, that gets the following:
```
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=1001.31..30196.24 rows=100 width=17) (actual time=9344.356..9348.339 rows=0 loops=1)
   ->  Gather Merge  (cost=1001.31..4129456.15 rows=14141 width=17) (actual time=9344.353..9348.334 rows=0 loops=1)
         Workers Planned: 2
         Workers Launched: 2
         ->  Nested Loop Semi Join  (cost=1.28..4126823.91 rows=5892 width=17) (actual time=9337.623..9337.624 rows=0 loops=3)
               ->  Parallel Index Scan using statuses_pkey on statuses  (cost=0.43..265130.70 rows=4167159 width=17) (actual time=0.052..731.963 rows=3333333 loops=3)
               ->  Nested Loop Anti Join  (cost=0.85..0.92 rows=1 width=8) (actual time=0.002..0.002 rows=0 loops=10000000)
                     ->  Index Scan using profiles_pkey on profiles  (cost=0.42..0.45 rows=1 width=12) (actual time=0.001..0.001 rows=1 loops=10000000)
                           Index Cond: (id = statuses.profile_id)
                     ->  Index Only Scan using users_pkey on users  (cost=0.42..0.46 rows=1 width=8) (actual time=0.001..0.001 rows=1 loops=10000000)
                           Index Cond: (id = profiles.user_id)
                           Heap Fetches: 1713850
 Planning Time: 1.015 ms
 Execution Time: 9348.418 ms
(14 rows)
```

and then subsequent calls with different id conditions are extremely fast, because the join is cached by postgres:
```
                                                                     QUERY PLAN                                                                      
-----------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=1.28..469.80 rows=100 width=17) (actual time=8.630..10.766 rows=100 loops=1)
   ->  Nested Loop Semi Join  (cost=1.28..9610030.67 rows=2051172 width=17) (actual time=8.628..10.758 rows=100 loops=1)
         ->  Index Scan using statuses_pkey on statuses  (cost=0.43..323470.92 rows=10001181 width=17) (actual time=0.016..3.897 rows=10970 loops=1)
         ->  Nested Loop Anti Join  (cost=0.85..0.92 rows=1 width=8) (actual time=0.000..0.000 rows=0 loops=10970)
               ->  Index Scan using profiles_pkey on profiles  (cost=0.42..0.46 rows=1 width=12) (actual time=0.000..0.000 rows=0 loops=10970)
                     Index Cond: ((id = statuses.profile_id) AND (id > 1000))
               ->  Index Only Scan using users_pkey on users  (cost=0.42..0.45 rows=1 width=8) (actual time=0.001..0.001 rows=1 loops=970)
                     Index Cond: (id = profiles.user_id)
                     Heap Fetches: 0
 Planning Time: 0.610 ms
 Execution Time: 10.813 ms
(11 rows)
```

Because of this I feel comfortable checking this in directly as a db migration (as opposed to e.g. a artisan:cleanup command

