### PR TITLE
fix: don't restore memory limit after cities import

### DIFF
--- a/app/Console/Commands/ImportCities.php
+++ b/app/Console/Commands/ImportCities.php
@@ -74,7 +74,6 @@ class ImportCities extends Command
      */
     public function handle()
     {
-        $old_memory_limit = ini_get('memory_limit');
         ini_set('memory_limit', '256M');
         $path = storage_path('app/cities.json');
 
@@ -137,7 +136,6 @@ class ImportCities extends Command
         $this->line('');
         $this->info('Successfully imported ' . $cityCount . ' entries!');
         $this->line('');
-        ini_set('memory_limit', $old_memory_limit);
         return;
     }
 


### PR DESCRIPTION
Since this command can only be invoked by CLI, the process will exit after a successful import, so restoring the transient PHP memory limit doesn't really have any affect.

In PHP 8.4, this throws the following error (which doesn't happen in 8.3 and below)

> [entrypoint / 11-first-time-setup.sh] - (stderr) 128769/128769 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%[2025-01-20 11:29:23] production.ERROR: Failed to set memory limit to 134217728 bytes (Current memory usage is 134746112 bytes) {"exception":"[object] (ErrorException(code: 0): Failed to set memory limit to 134217728 bytes (Current memory usage is 134746112 bytes) at /var/www/app/Console/Commands/ImportCities.php:140)

It seems to be a 8.4 behavior change, so removing the logic would make it go away.

As seen here: https://github.com/jippi/docker-pixelfed/actions/runs/12866993507?pr=106 where only PHP 8.4 is affected by this issue