### PR TITLE
Update Dockerfile - Issue #5535

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,11 +28,11 @@ ARG DOTTIE_VERSION="v0.9.5"
 ###
 
 # See: https://hub.docker.com/_/php/tags
-ARG PHP_VERSION="8.1"
+ARG PHP_VERSION="8.3"
 
 # See: https://github.com/docker-library/docs/blob/master/php/README.md#image-variants
 ARG PHP_BASE_TYPE="apache"
-ARG PHP_DEBIAN_RELEASE="bullseye"
+ARG PHP_DEBIAN_RELEASE="bookworm"
 
 ARG RUNTIME_UID=33 # often called 'www-data'
 ARG RUNTIME_GID=33 # often called 'www-data'


### PR DESCRIPTION
Change PHP Version to 8.3 to fix https://github.com/pixelfed/pixelfed/issues/5535.

Update the Debian release to Bookworm, as it's been a stable release for nearly 2 years.