### PR TITLE
fix failed import when caption is null

### DIFF
--- a/app/Console/Commands/TransformImports.php
+++ b/app/Console/Commands/TransformImports.php
@@ -103,7 +103,7 @@ class TransformImports extends Command
                 continue;
             }
 
-            $caption = $ip->caption != null ? $ip->caption : "";
+            $caption = !is_null($ip->caption) ? $ip->caption : "";
             $status = new Status;
             $status->profile_id = $pid;
             $status->caption = $caption;

--- a/app/Console/Commands/TransformImports.php
+++ b/app/Console/Commands/TransformImports.php
@@ -103,7 +103,7 @@ class TransformImports extends Command
                 continue;
             }
 
-            $caption = $ip->caption;
+            $caption = $ip->caption != null ? $ip->caption : "";
             $status = new Status;
             $status->profile_id = $pid;
             $status->caption = $caption;


### PR DESCRIPTION
I'm trying to import my instagram posts but running

```
php artisan app:transform-imports
```
will fail because caption cannot be null

this should do the trick

this bug was happening on current stable pixelfed, not sure it is happening in dev