### PR TITLE
FILTER_SANITIZE_STRING filter was deprecated in PHP 8.1.0. Use htmlspecialchars()

### DIFF
--- a/app/Console/Commands/FixUsernames.php
+++ b/app/Console/Commands/FixUsernames.php
@@ -90,7 +90,7 @@ class FixUsernames extends Command
                         break;
 
                     case $opts[1]:
-                        $new = filter_var($old, FILTER_SANITIZE_STRING|FILTER_FLAG_STRIP_LOW);
+                        $new = htmlspecialchars($old, ENT_QUOTES, 'UTF-8');
                         if(strlen($new) < 6) {
                             $new = $new . '_' . str_random(4);
                         }


### PR DESCRIPTION
https://www.php.net/manual/it/function.htmlspecialchars.php
https://www.w3schools.com/php/filter_sanitize_string.asp


`The FILTER_SANITIZE_STRING filter was deprecated in PHP 8.1.0. Use [htmlspecialchars()](https://www.w3schools.com/php/func_string_htmlspecialchars.asp) to encode special characters, or [strip_tags()](https://www.w3schools.com/php/func_string_strip_tags.asp) to remove HTML tags.`