### PR TITLE
App Register API

### DIFF
--- a/app/Http/Controllers/Api/ApiV1Controller.php
+++ b/app/Http/Controllers/Api/ApiV1Controller.php
@@ -1709,7 +1709,7 @@ class ApiV1Controller extends Controller
                 'short_description' => config_cache('app.short_description'),
                 'description' => config_cache('app.description'),
                 'email' => config('instance.email'),
-                'version' => '3.5.3 (compatible; Pixelfed '.config('pixelfed.version').')',
+                'version' => config('pixelfed.version'),
                 'urls' => [
                     'streaming_api' => null,
                 ],
@@ -1720,6 +1720,7 @@ class ApiV1Controller extends Controller
                 'approval_required' => (bool) config_cache('instance.curated_registration.enabled'),
                 'contact_account' => $contact,
                 'rules' => $rules,
+                'mobile_registration' => config('auth.in_app_registration'),
                 'configuration' => [
                     'media_attachments' => [
                         'image_matrix_limit' => 16777216,

--- a/app/Http/Controllers/Api/ApiV1Controller.php
+++ b/app/Http/Controllers/Api/ApiV1Controller.php
@@ -1709,7 +1709,7 @@ class ApiV1Controller extends Controller
                 'short_description' => config_cache('app.short_description'),
                 'description' => config_cache('app.description'),
                 'email' => config('instance.email'),
-                'version' => config('pixelfed.version'),
+                'version' => '3.5.3 (compatible; Pixelfed '.config('pixelfed.version').')',
                 'urls' => [
                     'streaming_api' => null,
                 ],

--- a/app/Http/Controllers/AppRegisterController.php
+++ b/app/Http/Controllers/AppRegisterController.php
@@ -75,6 +75,6 @@ class AppRegisterController extends Controller
             'status' => 'success'
         ]);
 
-        return redirect("pixelfed://verifyEmail?{$errorParams}");
+        return redirect("pixelfed://verifyEmail?{$queryParams}");
     }
 }

--- a/app/Http/Controllers/AppRegisterController.php
+++ b/app/Http/Controllers/AppRegisterController.php
@@ -164,6 +164,8 @@ class AppRegisterController extends Controller
 
         $token = $user->createToken('Pixelfed App', ['read', 'write', 'follow', 'push']);
         $tokenModel = $token->token;
+        $clientId = $tokenModel->client_id;
+        $clientSecret = DB::table('oauth_clients')->where('id', $clientId)->value('secret');
         $refreshTokenRepo = app(RefreshTokenRepository::class);
         $refreshToken = $refreshTokenRepo->create([
             'id' => Str::random(80),
@@ -182,6 +184,8 @@ class AppRegisterController extends Controller
             'expires_in' => $expiresIn,
             'access_token' => $token->accessToken,
             'refresh_token' => $refreshToken->id,
+            'client_id' => $clientId,
+            'client_secret' => $clientSecret,
             'scope' => ['read', 'write', 'follow', 'push'],
             'user' => [
                 'pid' => (string) $user->profile_id,

--- a/app/Http/Controllers/AppRegisterController.php
+++ b/app/Http/Controllers/AppRegisterController.php
@@ -160,8 +160,8 @@ class AppRegisterController extends Controller
             'register_source' => 'app',
         ]);
 
-        sleep(10);
-
+        sleep(random_int(5,10));
+        $user = User::findOrFail($user->id);
         $token = $user->createToken('Pixelfed App', ['read', 'write', 'follow', 'push']);
         $tokenModel = $token->token;
         $clientId = $tokenModel->client_id;

--- a/app/Http/Controllers/AppRegisterController.php
+++ b/app/Http/Controllers/AppRegisterController.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Models\AppRegister;
+use App\Mail\InAppRegisterEmailVerify;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Mail;
+
+class AppRegisterController extends Controller
+{
+    public function index(Request $request)
+    {
+        abort_unless(config('auth.iar') == true, 404);
+        // $open = (bool) config_cache('pixelfed.open_registration');
+        // if(!$open || $request->user()) {
+        if($request->user()) {
+            return redirect('/');
+        }
+        return view('auth.iar');
+    }
+
+    public function store(Request $request)
+    {
+        abort_unless(config('auth.iar') == true, 404);
+
+        $rules = [
+            'email' => 'required|email:rfc,dns,spoof,strict|unique:users,email|unique:app_registers,email',
+        ];
+
+        if ((bool) config_cache('captcha.enabled') && (bool) config_cache('captcha.active.register')) {
+            $rules['h-captcha-response'] = 'required|captcha';
+        }
+
+        $this->validate($request, $rules);
+
+        $email = $request->input('email');
+        $code = str_pad(random_int(0, 999999), 6, '0', STR_PAD_LEFT);
+
+        $exists = AppRegister::whereEmail($email)->where('created_at', '>', now()->subHours(24))->count();
+
+        if($exists && $exists > 3) {
+            $errorParams = http_build_query([
+                'status' => 'error',
+                'message' => 'Too many attempts, please try again later.'
+            ]);
+            return redirect("pixelfed://verifyEmail?{$errorParams}");
+        }
+
+        DB::beginTransaction();
+
+        $registration = AppRegister::create([
+            'email' => $email,
+            'verify_code' => $code,
+            'email_delivered_at' => now()
+        ]);
+
+        try {
+            Mail::to($email)->send(new InAppRegisterEmailVerify($code));
+        } catch (\Exception $e) {
+            DB::rollBack();
+            $errorParams = http_build_query([
+                'status' => 'error',
+                'message' => 'Failed to send verification code'
+            ]);
+            return redirect("pixelfed://verifyEmail?{$errorParams}");
+        }
+
+        DB::commit();
+
+        $queryParams = http_build_query([
+            'email' => $request->email,
+            'expires_in' => 3600,
+            'status' => 'success'
+        ]);
+
+        return redirect("pixelfed://verifyEmail?{$errorParams}");
+    }
+}

--- a/app/Http/Controllers/AppRegisterController.php
+++ b/app/Http/Controllers/AppRegisterController.php
@@ -158,6 +158,7 @@ class AppRegisterController extends Controller
             'password' => Hash::make($password),
             'app_register_ip' => request()->ip(),
             'register_source' => 'app',
+            'email_verified_at' => now(),
         ]);
 
         sleep(random_int(5,10));

--- a/app/Http/Controllers/AppRegisterController.php
+++ b/app/Http/Controllers/AppRegisterController.php
@@ -19,7 +19,7 @@ class AppRegisterController extends Controller
 {
     public function index(Request $request)
     {
-        abort_unless(config('auth.iar') == true, 404);
+        abort_unless(config('auth.in_app_registration'), 404);
         $open = (bool) config_cache('pixelfed.open_registration');
         if (! $open || $request->user()) {
             return redirect('/');
@@ -30,7 +30,7 @@ class AppRegisterController extends Controller
 
     public function store(Request $request)
     {
-        abort_unless(config('auth.iar') == true, 404);
+        abort_unless(config('auth.in_app_registration'), 404);
         $open = (bool) config_cache('pixelfed.open_registration');
         if (! $open || $request->user()) {
             return redirect('/');
@@ -46,8 +46,10 @@ class AppRegisterController extends Controller
 
         $this->validate($request, $rules);
 
-        $email = $request->input('email');
+        $email = strtolower($request->input('email'));
         $code = str_pad(random_int(0, 999999), 6, '0', STR_PAD_LEFT);
+
+        DB::beginTransaction();
 
         $exists = AppRegister::whereEmail($email)->where('created_at', '>', now()->subHours(24))->count();
 
@@ -56,11 +58,9 @@ class AppRegisterController extends Controller
                 'status' => 'error',
                 'message' => 'Too many attempts, please try again later.',
             ]);
-
+            DB::rollBack();
             return redirect()->away("pixelfed://verifyEmail?{$errorParams}");
         }
-
-        DB::beginTransaction();
 
         $registration = AppRegister::create([
             'email' => $email,
@@ -93,7 +93,7 @@ class AppRegisterController extends Controller
 
     public function verifyCode(Request $request)
     {
-        abort_unless(config('auth.iar') == true, 404);
+        abort_unless(config('auth.in_app_registration'), 404);
         $open = (bool) config_cache('pixelfed.open_registration');
         if (! $open || $request->user()) {
             return redirect('/');
@@ -104,7 +104,7 @@ class AppRegisterController extends Controller
             'verify_code' => ['required', 'digits:6', 'numeric'],
         ]);
 
-        $email = $request->input('email');
+        $email = strtolower($request->input('email'));
         $code = $request->input('verify_code');
 
         $exists = AppRegister::whereEmail($email)
@@ -119,7 +119,7 @@ class AppRegisterController extends Controller
 
     public function onboarding(Request $request)
     {
-        abort_unless(config('auth.iar') == true, 404);
+        abort_unless(config('auth.in_app_registration'), 404);
         $open = (bool) config_cache('pixelfed.open_registration');
         if (! $open || $request->user()) {
             return redirect('/');
@@ -133,7 +133,7 @@ class AppRegisterController extends Controller
             'password' => 'required|string|min:'.config('pixelfed.min_password_length'),
         ]);
 
-        $email = $request->input('email');
+        $email = strtolower($request->input('email'));
         $code = $request->input('verify_code');
         $username = $request->input('username');
         $name = $request->input('name');

--- a/app/Http/Controllers/AppRegisterController.php
+++ b/app/Http/Controllers/AppRegisterController.php
@@ -150,7 +150,7 @@ class AppRegisterController extends Controller
 
         return response()->json([
             'status' => 'success',
-            'auth_token' => $user->createToken('Pixelfed App')->plainTextToken,
+            'auth_token' => $user->createToken('Pixelfed App')->accessToken,
         ]);
     }
 

--- a/app/Http/Controllers/AppRegisterController.php
+++ b/app/Http/Controllers/AppRegisterController.php
@@ -17,9 +17,8 @@ class AppRegisterController extends Controller
     public function index(Request $request)
     {
         abort_unless(config('auth.iar') == true, 404);
-        // $open = (bool) config_cache('pixelfed.open_registration');
-        // if(!$open || $request->user()) {
-        if ($request->user()) {
+        $open = (bool) config_cache('pixelfed.open_registration');
+        if (! $open || $request->user()) {
             return redirect('/');
         }
 
@@ -29,6 +28,10 @@ class AppRegisterController extends Controller
     public function store(Request $request)
     {
         abort_unless(config('auth.iar') == true, 404);
+        $open = (bool) config_cache('pixelfed.open_registration');
+        if (! $open || $request->user()) {
+            return redirect('/');
+        }
 
         $rules = [
             'email' => 'required|email:rfc,dns,spoof,strict|unique:users,email|unique:app_registers,email',
@@ -88,6 +91,10 @@ class AppRegisterController extends Controller
     public function verifyCode(Request $request)
     {
         abort_unless(config('auth.iar') == true, 404);
+        $open = (bool) config_cache('pixelfed.open_registration');
+        if (! $open || $request->user()) {
+            return redirect('/');
+        }
 
         $this->validate($request, [
             'email' => 'required|email:rfc,dns,spoof,strict|unique:users,email',
@@ -110,6 +117,10 @@ class AppRegisterController extends Controller
     public function onboarding(Request $request)
     {
         abort_unless(config('auth.iar') == true, 404);
+        $open = (bool) config_cache('pixelfed.open_registration');
+        if (! $open || $request->user()) {
+            return redirect('/');
+        }
 
         $this->validate($request, [
             'email' => 'required|email:rfc,dns,spoof,strict|unique:users,email',

--- a/app/Mail/InAppRegisterEmailVerify.php
+++ b/app/Mail/InAppRegisterEmailVerify.php
@@ -29,7 +29,7 @@ class InAppRegisterEmailVerify extends Mailable
     public function envelope(): Envelope
     {
         return new Envelope(
-            subject: config('pixelfed.domain.app') . ' - Verify Your Email Address',
+            subject: config('pixelfed.domain.app') . __('auth.verifyYourEmailAddress'),
         );
     }
 

--- a/app/Mail/InAppRegisterEmailVerify.php
+++ b/app/Mail/InAppRegisterEmailVerify.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Mail;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+
+class InAppRegisterEmailVerify extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    public $code;
+
+    /**
+     * Create a new message instance.
+     */
+    public function __construct($code)
+    {
+        $this->code = $code;
+    }
+
+    /**
+     * Get the message envelope.
+     */
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            subject: config('pixelfed.domain.app') . ' - Verify Your Email Address',
+        );
+    }
+
+    /**
+     * Get the message content definition.
+     */
+    public function content(): Content
+    {
+        return new Content(
+            markdown: 'emails.iar.email_verify',
+        );
+    }
+
+    /**
+     * Get the attachments for the message.
+     *
+     * @return array<int, \Illuminate\Mail\Mailables\Attachment>
+     */
+    public function attachments(): array
+    {
+        return [];
+    }
+}

--- a/app/Models/AppRegister.php
+++ b/app/Models/AppRegister.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class AppRegister extends Model
+{
+    protected $guarded = [];
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -92,6 +92,10 @@ class AppServiceProvider extends ServiceProvider
             return Limit::perDay(10)->by($request->ip());
         });
 
+        RateLimiter::for('app-code-verify', function (Request $request) {
+            return Limit::perHour(10)->by($request->ip());
+        });
+
         // Model::preventLazyLoading(true);
     }
 

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -36,6 +36,7 @@ use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\ServiceProvider;
 use Laravel\Pulse\Facades\Pulse;
+use Illuminate\Http\Request;
 use URL;
 
 class AppServiceProvider extends ServiceProvider

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -30,6 +30,8 @@ use Horizon;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Pagination\Paginator;
 use Illuminate\Support\Facades\Gate;
+use Illuminate\Cache\RateLimiting\Limit;
+use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\ServiceProvider;
@@ -83,6 +85,10 @@ class AppServiceProvider extends ServiceProvider
                 'extra' => 'DELETED',
                 'avatar' => '/storage/avatars/default.jpg',
             ];
+        });
+
+        RateLimiter::for('app-signup', function (Request $request) {
+            return Limit::perDay(10)->by($request->ip());
         });
 
         // Model::preventLazyLoading(true);

--- a/app/Util/Site/Config.php
+++ b/app/Util/Site/Config.php
@@ -82,6 +82,7 @@ class Config
                         'network' => (bool) config('federation.network_timeline'),
                     ],
                     'mobile_apis' => (bool) config_cache('pixelfed.oauth_enabled'),
+                    'mobile_registration' => config('auth.in_app_registration'),
                     'stories' => (bool) config_cache('instance.stories.enabled'),
                     'video' => Str::contains(config_cache('pixelfed.media_types'), 'video/mp4'),
                     'import' => [

--- a/app/Util/Site/Nodeinfo.php
+++ b/app/Util/Site/Nodeinfo.php
@@ -21,6 +21,7 @@ class Nodeinfo
             $statuses = InstanceService::totalLocalStatuses();
 
             $features = ['features' => \App\Util\Site\Config::get()['features']];
+            unset($features['features']['hls']);
 
             return [
                 'metadata' => [

--- a/config/auth.php
+++ b/config/auth.php
@@ -112,5 +112,5 @@ return [
         ],
     ],
 
-    'iar' => env('APP_REGISTER', false),
+    'in_app_registration' => (bool) env('APP_REGISTER', false),
 ];

--- a/config/auth.php
+++ b/config/auth.php
@@ -112,5 +112,5 @@ return [
         ],
     ],
 
-    'in_app_registration' => (bool) env('APP_REGISTER', false),
+    'in_app_registration' => (bool) env('APP_REGISTER', true),
 ];

--- a/config/auth.php
+++ b/config/auth.php
@@ -112,4 +112,5 @@ return [
         ],
     ],
 
+    'iar' => env('APP_REGISTER', false),
 ];

--- a/database/migrations/2025_01_28_102016_create_app_registers_table.php
+++ b/database/migrations/2025_01_28_102016_create_app_registers_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('app_registers', function (Blueprint $table) {
+            $table->id();
+            $table->string('email');
+            $table->string('verify_code');
+            $table->unique(['email', 'verify_code']);
+            $table->timestamp('email_delivered_at')->nullable();
+            $table->timestamp('email_verified_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('app_registers');
+    }
+};

--- a/resources/lang/en/auth.php
+++ b/resources/lang/en/auth.php
@@ -15,5 +15,5 @@ return [
 
     'failed'   => 'These credentials do not match our records.',
     'throttle' => 'Too many login attempts. Please try again in :seconds seconds.',
-
+    'verifyYourEmailAddress' => ' - Verify Your Email Address',
 ];

--- a/resources/views/auth/iar.blade.php
+++ b/resources/views/auth/iar.blade.php
@@ -1,0 +1,156 @@
+@extends('layouts.blank')
+
+@section('content')
+    <div class="container">
+        <div class="row min-vh-100 align-items-center justify-content-center">
+            <div class="col-12 col-md-6 col-lg-5">
+                <div class="text-center mb-5">
+                    <img src="/img/pixelfed-icon-white.svg" width="90">
+                </div>
+
+                <div class="card shadow-sm">
+                    <div class="card-body p-4">
+                        <h2 class="text-center">Join Pixelfed</h2>
+                        <p class="lead text-center mb-4">Enter Your Email</p>
+
+                        @if ($errors->any())
+                            <div class="alert alert-danger">
+                                <ul class="mb-0">
+                                    @foreach ($errors->all() as $error)
+                                        <li>{{ $error }}</li>
+                                    @endforeach
+                                </ul>
+                            </div>
+                        @endif
+
+                        <form method="POST">
+                            @csrf
+
+                            <div class="form-group">
+                                <label for="email">Email address</label>
+                                <input type="email"
+                                       class="form-control @error('email') is-invalid @enderror"
+                                       id="email"
+                                       name="email"
+                                       required
+                                       autocomplete="email">
+                                @error('email')
+                                    <div class="invalid-feedback">{{ $message }}</div>
+                                @enderror
+                            </div>
+
+                            <div class="form-group text-center">
+                                {!! Captcha::display() !!}
+                            </div>
+
+                            <button type="submit" class="btn btn-primary btn-block">
+                                Send Verification Code
+                            </button>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection
+
+@push('styles')
+    <style>
+        :root {
+            --bg-color: #f8f9fa;
+            --card-bg: #ffffff;
+            --text-color: #212529;
+            --text-muted: #6c757d;
+            --input-bg: #ffffff;
+            --input-border: #ced4da;
+            --input-focus: #80bdff;
+            --card-shadow: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.075);
+        }
+
+        @media (prefers-color-scheme: dark) {
+            :root {
+                --bg-color: #111827;
+                --card-bg: #1f2937;
+                --text-color: #f3f4f6;
+                --text-muted: #9ca3af;
+                --input-bg: #374151;
+                --input-border: #4b5563;
+                --input-focus: #3b82f6;
+                --card-shadow: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.3);
+            }
+        }
+
+        body {
+            background-color: var(--bg-color);
+            color: var(--text-color);
+            transition: background-color 0.3s, color 0.3s;
+            min-height: 100vh;
+            display: flex;
+            align-items: center;
+        }
+
+        .card {
+            background-color: var(--card-bg);
+            border: none;
+            border-radius: 1rem;
+            box-shadow: var(--card-shadow);
+        }
+
+        .benefits-list {
+            color: var(--text-muted);
+        }
+
+        .benefits-list i {
+            color: #3b82f6;
+            margin-right: 0.5rem;
+        }
+
+        .form-control {
+            background-color: var(--input-bg);
+            border-color: var(--input-border);
+            color: var(--text-color);
+            border-radius: 0.5rem;
+            padding: 0.75rem 1rem;
+            transition: all 0.2s;
+        }
+
+        .form-control:focus {
+            background-color: var(--input-bg);
+            border-color: var(--input-focus);
+            color: var(--text-color);
+            box-shadow: 0 0 0 0.2rem rgba(59, 130, 246, 0.25);
+        }
+
+        .btn-primary {
+            padding: 0.75rem 1.5rem;
+            border-radius: 0.5rem;
+            font-weight: 500;
+            transition: transform 0.2s;
+            background-color: #3b82f6;
+            border-color: #3b82f6;
+        }
+
+        .btn-primary:hover {
+            transform: translateY(-1px);
+            background-color: #2563eb;
+            border-color: #2563eb;
+        }
+
+        .form-group label {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        @media (prefers-color-scheme: dark) {
+            a {
+                color: #60a5fa;
+            }
+            a:hover {
+                color: #93c5fd;
+            }
+            .card {
+                border: 1px solid rgba(255, 255, 255, 0.1);
+            }
+        }
+    </style>
+@endpush

--- a/resources/views/auth/iar.blade.php
+++ b/resources/views/auth/iar.blade.php
@@ -57,27 +57,14 @@
 @push('styles')
     <style>
         :root {
-            --bg-color: #f8f9fa;
-            --card-bg: #ffffff;
-            --text-color: #212529;
-            --text-muted: #6c757d;
-            --input-bg: #ffffff;
-            --input-border: #ced4da;
-            --input-focus: #80bdff;
-            --card-shadow: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.075);
-        }
-
-        @media (prefers-color-scheme: dark) {
-            :root {
-                --bg-color: #111827;
-                --card-bg: #1f2937;
-                --text-color: #f3f4f6;
-                --text-muted: #9ca3af;
-                --input-bg: #374151;
-                --input-border: #4b5563;
-                --input-focus: #3b82f6;
-                --card-shadow: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.3);
-            }
+            --bg-color: #111827;
+            --card-bg: #1f2937;
+            --text-color: #f3f4f6;
+            --text-muted: #9ca3af;
+            --input-bg: #374151;
+            --input-border: #4b5563;
+            --input-focus: #3b82f6;
+            --card-shadow: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.3);
         }
 
         body {

--- a/resources/views/emails/iar/email_verify.blade.php
+++ b/resources/views/emails/iar/email_verify.blade.php
@@ -1,0 +1,31 @@
+@component('mail::message')
+<div class="otcontainer">
+
+## Verify Your Email Address
+        
+<p class="ottext">
+    Hello,
+</p>
+
+<p class="ottext">
+    Thank you for signing up to {{config('pixelfed.domain.app')}}!
+</p>
+
+<p class="ottext">
+    To complete your registration, please enter the following verification code:
+</p>
+
+<div class="otcode">
+    {{ $code }}
+</div>
+
+<p class="ottext">
+This code will expire in 60 minutes. If you didn't request this verification, please ignore this email.
+</p>
+
+<div class="otfooter">
+<p>If you're having trouble with the verification code, please contact our <a href="{{route('site.help')}}">support team</a>.</p>
+</div>
+
+</div>
+@endcomponent

--- a/resources/views/vendor/mail/html/themes/default.css
+++ b/resources/views/vendor/mail/html/themes/default.css
@@ -290,3 +290,34 @@ img {
     font-size: 15px;
     text-align: center;
 }
+
+.otcontainer {
+    padding: 2rem;
+    max-width: 600px;
+    margin: 0 auto;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+}
+
+.otcode {
+    letter-spacing: 0.5rem;
+    font-size: 2rem;
+    font-weight: bold;
+    background-color: #f3f4f6;
+    padding: 1rem 2rem;
+    border-radius: 0.5rem;
+    margin: 2rem 0;
+    text-align: center;
+    color: #000000;
+}
+
+.ottext {
+    color: #374151;
+    line-height: 1.6;
+    margin: 1rem 0;
+}
+
+.otfooter {
+    margin-top: 2rem;
+    font-size: 0.875rem;
+    color: #6b7280;
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -18,6 +18,7 @@ Route::redirect('.well-known/change-password', '/settings/password');
 Route::get('api/nodeinfo/2.0.json', 'FederationController@nodeinfo');
 Route::get('api/service/health-check', 'HealthCheckController@get');
 Route::post('api/auth/app-code-verify', 'AppRegisterController@verifyCode')->middleware('throttle:app-code-verify');
+Route::post('api/auth/onboarding', 'AppRegisterController@onboarding')->middleware('throttle:app-code-verify');
 
 Route::prefix('api/v0/groups')->middleware($middleware)->group(function () {
     Route::get('config', 'Groups\GroupsApiController@getConfig');

--- a/routes/api.php
+++ b/routes/api.php
@@ -17,6 +17,7 @@ Route::get('.well-known/host-meta', 'FederationController@hostMeta')->name('well
 Route::redirect('.well-known/change-password', '/settings/password');
 Route::get('api/nodeinfo/2.0.json', 'FederationController@nodeinfo');
 Route::get('api/service/health-check', 'HealthCheckController@get');
+Route::post('api/auth/app-code-verify', 'AppRegisterController@verifyCode')->middleware('throttle:app-code-verify');
 
 Route::prefix('api/v0/groups')->middleware($middleware)->group(function () {
     Route::get('config', 'Groups\GroupsApiController@getConfig');

--- a/routes/web.php
+++ b/routes/web.php
@@ -139,6 +139,9 @@ Route::domain(config('pixelfed.domain.app'))->middleware(['validemail', 'twofact
     Route::get('discover/places/{id}/{slug}', 'PlaceController@show');
     Route::get('discover/location/country/{country}', 'PlaceController@directoryCities');
 
+    Route::get('/i/app-email-verify', 'AppRegisterController@index');
+    Route::post('/i/app-email-verify', 'AppRegisterController@store');
+
     Route::group(['prefix' => 'i'], function () {
         Route::redirect('/', '/');
         Route::get('compose', 'StatusController@compose')->name('compose');

--- a/routes/web.php
+++ b/routes/web.php
@@ -140,7 +140,7 @@ Route::domain(config('pixelfed.domain.app'))->middleware(['validemail', 'twofact
     Route::get('discover/location/country/{country}', 'PlaceController@directoryCities');
 
     Route::get('/i/app-email-verify', 'AppRegisterController@index');
-    Route::post('/i/app-email-verify', 'AppRegisterController@store');
+    Route::post('/i/app-email-verify', 'AppRegisterController@store')->middleware('throttle:app-signup');
 
     Route::group(['prefix' => 'i'], function () {
         Route::redirect('/', '/');

--- a/routes/web.php
+++ b/routes/web.php
@@ -141,6 +141,7 @@ Route::domain(config('pixelfed.domain.app'))->middleware(['validemail', 'twofact
 
     Route::get('/i/app-email-verify', 'AppRegisterController@index');
     Route::post('/i/app-email-verify', 'AppRegisterController@store')->middleware('throttle:app-signup');
+    Route::post('/i/app-code-verify', 'AppRegisterController@verifyCode');
 
     Route::group(['prefix' => 'i'], function () {
         Route::redirect('/', '/');

--- a/routes/web.php
+++ b/routes/web.php
@@ -141,7 +141,6 @@ Route::domain(config('pixelfed.domain.app'))->middleware(['validemail', 'twofact
 
     Route::get('/i/app-email-verify', 'AppRegisterController@index');
     Route::post('/i/app-email-verify', 'AppRegisterController@store')->middleware('throttle:app-signup');
-    Route::post('/i/app-code-verify', 'AppRegisterController@verifyCode');
 
     Route::group(['prefix' => 'i'], function () {
         Route::redirect('/', '/');


### PR DESCRIPTION
Add new app register API to allow in-app registration.

To keep the user in the app during the flow as much as possible, while allowing for captcha support, we open a browser session on the pixelfed server to enter their email address and handle the captcha if required.

They are redirected back to the app using a Deep Link and their email as a query parameter, while the backend emails them a 6 digit code they input into the app to verify their session.

From their they can set a username, password and additional optional onboarding steps.

Todo:

- [x] Final registration
- [x] Optional onboarding steps (avatar, bio)
- [x] Open registration detection in app