### PR TITLE
use config_cache for max_caption_length

### DIFF
--- a/app/Http/Requests/Status/StoreStatusEditRequest.php
+++ b/app/Http/Requests/Status/StoreStatusEditRequest.php
@@ -44,7 +44,7 @@ class StoreStatusEditRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'status' => 'sometimes|max:'.config('pixelfed.max_caption_length', 500),
+            'status' => 'sometimes|max:'.config_cache('pixelfed.max_caption_length', 500),
             'spoiler_text' => 'nullable|string|max:140',
             'sensitive' => 'sometimes|boolean',
             'media_ids' => [


### PR DESCRIPTION
`max_caption_length` isn't using the config cache in the API call for editing captions, so if the value is only bumped in the admin UI and not in the environment variable, editing a caption to be longer than the value configured in the environment variables fails.


Fixes #5300
