### PR TITLE
Correct some typos in Spanish translations

### DIFF
--- a/resources/lang/es/exception.php
+++ b/resources/lang/es/exception.php
@@ -4,7 +4,7 @@ return [
 
 	'compose' => [
 		'invalid' => [
-			'album' => 'Debe contener solo una foto o video, o multiples.',
+			'album' => 'Debe contener solo una foto o video, o múltiples.',
 		],
 	],
 

--- a/resources/lang/es/notification.php
+++ b/resources/lang/es/notification.php
@@ -2,10 +2,10 @@
 
 return [
 
-  'likedPhoto'          => 'le gustó tu foto.',  
+  'likedPhoto'          => 'le gustó tu foto.',
   'likedComment'        => 'le gustó tu comentario.',
   'startedFollowingYou' => 'empezó a seguirte.',
   'commented'           => 'comentó tu foto.',
-  'mentionedYou'        => 'te menciono.',
-  'shared'				=> 'compartir tu foto.',
+  'mentionedYou'        => 'te mencionó.',
+  'shared'				=> 'compartió tu foto.',
 ];


### PR DESCRIPTION
I know these translations were just recently added, but they have some typos. Two of the typos change the meanings ("to comento" = "I comment to you" vs "te comentó" = "they commented to you" and "compartir" = "share" vs "compartió" = "shared")
