### PR TITLE
laravel/pint Github Action

### DIFF
--- a/.github/workflows/pint.yaml
+++ b/.github/workflows/pint.yaml
@@ -1,0 +1,27 @@
+name: Laravel pint
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  pint:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        php: [8.4]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: json, dom, curl, libxml, mbstring
+          coverage: none
+
+      - name: Run Pint
+        run: pint --test


### PR DESCRIPTION
Require installing Pint `composer global require laravel/pint`

and then running against staging.. this will likely break all of the existing PRs but would be good to be done sooner than later