### PR TITLE
[Bug Fix] accept bare domains without http scheme in domain block controller

### DIFF
--- a/app/Http/Controllers/Api/V1/DomainBlockController.php
+++ b/app/Http/Controllers/Api/V1/DomainBlockController.php
@@ -56,7 +56,7 @@ class DomainBlockController extends Controller
         abort_if(!$request->user(), 403);
 
         $this->validate($request, [
-            'domain' => 'required|active_url|min:1|max:120'
+            'domain' => 'required|min:1|max:120'
         ]);
 
         $pid = $request->user()->profile_id;


### PR DESCRIPTION
The [`active_url` validator](https://laravel.com/docs/11.x/validation#rule-active-url) calls [PHP's `parse_url` function](https://www.php.net/manual/en/function.parse-url.php) to extract the domain, but if you pass a domain to `parse_url` without the `//` that indicates the scheme, `parse_url` returns it in the `path` field, not the `hostname` field. Consequently, the validator says there's no valid domain passed in.

This doesn't match mastodon's behavior, and the original PR for the domain block (#4834) says it's meant to match mastodon's behavior.

Fixes #5645
