### PR TITLE
Prevent pulse crash when it is not configured

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -74,19 +74,21 @@ class AppServiceProvider extends ServiceProvider
             return $user->is_admin === 1;
         });
 
-        Pulse::user(function ($user) {
-            $acct = AccountService::get($user->profile_id, true);
+        if (config('pulse.enabled', false)) {
+            Pulse::user(function ($user) {
+                $acct = AccountService::get($user->profile_id, true);
 
-            return $acct ? [
-                'name' => $acct['username'],
-                'extra' => $user->email,
-                'avatar' => $acct['avatar'],
-            ] : [
-                'name' => $user->username,
-                'extra' => 'DELETED',
-                'avatar' => '/storage/avatars/default.jpg',
-            ];
-        });
+                return $acct ? [
+                    'name' => $acct['username'],
+                    'extra' => $user->email,
+                    'avatar' => $acct['avatar'],
+                ] : [
+                    'name' => $user->username,
+                    'extra' => 'DELETED',
+                    'avatar' => '/storage/avatars/default.jpg',
+                ];
+            });
+        }
 
         RateLimiter::for('app-signup', function (Request $request) {
             return Limit::perDay(10)->by($request->ip());


### PR DESCRIPTION
Fixes the following error:
```
[entrypoint / 10-storage.sh] - (stderr) [2025-02-08 21:51:52] production.ERROR: Target [Laravel\Pulse\Contracts\ResolvesUsers] is not instantiable while building [App\Providers\AppServiceProvider]. {"exception":"[object] (Illuminate\Contracts\Container\BindingResolutionException(code: 0): Target [Laravel\Pulse\Contracts\ResolvesUsers] is not instantiable while building [App\Providers\AppServiceProvider]. at /var/www/vendor/laravel/framework/src/Illuminate/Container/Container.php:1201)
[entrypoint / 10-storage.sh] - (stderr) [stacktrace]
[entrypoint / 10-storage.sh] - (stderr) #0 /var/www/vendor/laravel/framework/src/Illuminate/Container/Container.php(953): Illuminate\Container\Container->notInstantiable()
[entrypoint / 10-storage.sh] - (stderr) #1 /var/www/vendor/laravel/framework/src/Illuminate/Container/Container.php(819): Illuminate\Container\Container->build()
[entrypoint / 10-storage.sh] - (stderr) #2 /var/www/vendor/laravel/framework/src/Illuminate/Foundation/Application.php(1048): Illuminate\Container\Container->resolve()
[entrypoint / 10-storage.sh] - (stderr) #3 /var/www/vendor/laravel/framework/src/Illuminate/Container/Container.php(755): Illuminate\Foundation\Application->resolve()
[entrypoint / 10-storage.sh] - (stderr) #4 /var/www/vendor/laravel/framework/src/Illuminate/Foundation/Application.php(1030): Illuminate\Container\Container->make()
[entrypoint / 10-storage.sh] - (stderr) #5 /var/www/vendor/laravel/pulse/src/Pulse.php(430): Illuminate\Foundation\Application->make()
[entrypoint / 10-storage.sh] - (stderr) #6 /var/www/vendor/laravel/framework/src/Illuminate/Support/Facades/Facade.php(361): Laravel\Pulse\Pulse->user()
[entrypoint / 10-storage.sh] - (stderr) #7 /var/www/app/Providers/AppServiceProvider.php(77): Illuminate\Support\Facades\Facade::__callStatic()
[entrypoint / 10-storage.sh] - (stderr) #8 /var/www/vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php(36): App\Providers\AppServiceProvider->boot()
[entrypoint / 10-storage.sh] - (stderr) #9 /var/www/vendor/laravel/framework/src/Illuminate/Container/Util.php(43): Illuminate\Container\BoundMethod::Illuminate\Container\{closure}()
[entrypoint / 10-storage.sh] - (stderr) #10 /var/www/vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php(95): Illuminate\Container\Util::unwrapIfClosure()
[entrypoint / 10-storage.sh] - (stderr) #11 /var/www/vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php(35): Illuminate\Container\BoundMethod::callBoundMethod()
[entrypoint / 10-storage.sh] - (stderr) #12 /var/www/vendor/laravel/framework/src/Illuminate/Container/Container.php(694): Illuminate\Container\BoundMethod::call()
[entrypoint / 10-storage.sh] - (stderr) #13 /var/www/vendor/laravel/framework/src/Illuminate/Foundation/Application.php(1121): Illuminate\Container\Container->call()
[entrypoint / 10-storage.sh] - (stderr) #14 /var/www/vendor/laravel/framework/src/Illuminate/Foundation/Application.php(1102): Illuminate\Foundation\Application->bootProvider()
[entrypoint / 10-storage.sh] - (stderr) #15 [internal function]: Illuminate\Foundation\Application->Illuminate\Foundation\{closure}()
[entrypoint / 10-storage.sh] - (stderr) #16 /var/www/vendor/laravel/framework/src/Illuminate/Foundation/Application.php(1101): array_walk()
[entrypoint / 10-storage.sh] - (stderr) #17 /var/www/vendor/laravel/framework/src/Illuminate/Foundation/Bootstrap/BootProviders.php(17): Illuminate\Foundation\Application->boot()
[entrypoint / 10-storage.sh] - (stderr) #18 /var/www/vendor/laravel/framework/src/Illuminate/Foundation/Application.php(316): Illuminate\Foundation\Bootstrap\BootProviders->bootstrap()
[entrypoint / 10-storage.sh] - (stderr) #19 /var/www/vendor/laravel/framework/src/Illuminate/Foundation/Console/Kernel.php(474): Illuminate\Foundation\Application->bootstrapWith()
[entrypoint / 10-storage.sh] - (stderr) #20 /var/www/vendor/laravel/framework/src/Illuminate/Foundation/Console/Kernel.php(196): Illuminate\Foundation\Console\Kernel->bootstrap()
[entrypoint / 10-storage.sh] - (stdout) 
[entrypoint / 10-storage.sh] - (stdout) Illuminate\Contracts\Container\BindingResolutionException
[entrypoint / 10-storage.sh] - (stderr) #21 /var/www/artisan(35): Illuminate\Foundation\Console\Kernel->handle()
[entrypoint / 10-storage.sh] - (stdout) 
[entrypoint / 10-storage.sh] - (stderr) #22 {main}
[entrypoint / 10-storage.sh] - (stdout) Target [Laravel\Pulse\Contracts\ResolvesUsers] is not instantiable while building [App\Providers\AppServiceProvider].
[entrypoint / 10-storage.sh] - (stderr) "}
[entrypoint / 10-storage.sh] - (stdout) 
[entrypoint / 10-storage.sh] - (stdout) at vendor/laravel/framework/src/Illuminate/Container/Container.php:1201
[entrypoint / 10-storage.sh] - (stdout) 1197▕         } else {
[entrypoint / 10-storage.sh] - (stdout) 1198▕             $message = "Target [$concrete] is not instantiable.";
[entrypoint / 10-storage.sh] - (stdout) 1199▕         }
[entrypoint / 10-storage.sh] - (stdout) 1200▕
[entrypoint / 10-storage.sh] - (stdout) ➜ 1201▕         throw new BindingResolutionException($message);
[entrypoint / 10-storage.sh] - (stdout) 1202▕     }
[entrypoint / 10-storage.sh] - (stdout) 1203▕
[entrypoint / 10-storage.sh] - (stdout) 1204▕     /**
[entrypoint / 10-storage.sh] - (stdout) 1205▕      * Throw an exception for an unresolvable primitive.
[entrypoint / 10-storage.sh] - (stdout) 
[entrypoint / 10-storage.sh] - (stdout) +7 vendor frames 
[entrypoint / 10-storage.sh] - (stdout) 
[entrypoint / 10-storage.sh] - (stdout) 8   app/Providers/AppServiceProvider.php:77
[entrypoint / 10-storage.sh] - (stdout) Illuminate\Support\Facades\Facade::__callStatic()
[entrypoint / 10-storage.sh] - (stdout) +7 vendor frames 
[entrypoint / 10-storage.sh] - (stdout) 
[entrypoint / 10-storage.sh] - (stdout) 16  [internal]:0
[entrypoint / 10-storage.sh] - (stdout) Illuminate\Foundation\Application::Illuminate\Foundation\{closure}()
[entrypoint / 10-storage.sh] - (stdout) 
[entrypoint / 10-storage.sh] - ERROR - ❌ Error!
[entrypoint / entrypoint.sh] - 🔓 Releasing lock [/var/www/storage/docker/lock/entrypoint.sh]
```

# Test plan
Built the image without pulse and ensured the error went away. I DID NOT test anything related to pulse being enabled, but presume this shouldn't affect properly configured environments