### PR TITLE
[Bug Fix] Give execute permissions to folders

### DIFF
--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -53,7 +53,7 @@ return [
                 ],
                 'dir' => [
                     'public' => 0755,
-                    'private' => 0700,
+                    'private' => 0711,
                 ],
             ],
         ],


### PR DESCRIPTION
nginx (and presumably every other web server) returns 403 for every url on app/public/storage because of the strict permissions. 

Allowing folders to be created with the execute bit set is enough to solve this without making it possible to list its contents.

Fixes #4275 