### PR TITLE
[Bug Fix] Web UI DM Compose: add debounce to the recipient autocomplete

### DIFF
--- a/resources/assets/components/Direct.vue
+++ b/resources/assets/components/Direct.vue
@@ -92,6 +92,7 @@
 							aria-label="Search usernames"
 							:get-result-value="getTagResultValue"
 							@submit="onTagSubmitLocation"
+							:debounce-time="500"
 							ref="autocomplete"
 						>
 						</autocomplete>


### PR DESCRIPTION
Add debounce to the recipient autocomplete in the compose DM form to reduce # of requests sent to the server.


Typing a long name in the input triggers a lot of requests (one request for each input event). Most of the API responses are ignored and only the last one is processed. This might cause high server load on instances with many profiles.