### PR TITLE
Update iar.blade.php - Fix in-app reg without hcaptcha (#5807)

### DIFF
--- a/resources/views/auth/iar.blade.php
+++ b/resources/views/auth/iar.blade.php
@@ -39,9 +39,11 @@
                                 @enderror
                             </div>
 
+                            @if((bool) config_cache('captcha.enabled') && (bool) config_cache('captcha.active.register'))
                             <div class="form-group text-center">
                                 {!! Captcha::display() !!}
                             </div>
+                            @endif
 
                             <button type="submit" class="btn btn-primary btn-block">
                                 Send Verification Code


### PR DESCRIPTION
* Staging (#5674)

* Update .env.docker

Registry has changed. Old registry has been discontinued in August 2024. New Registry added, format of Docker tag has been adjusted as it now contains the Debian Release as well.

Sample Version is set to current stable but can be adjusted to any of the available branches.

* Update .env.docker

Stick major.minor according to https://jippi.github.io/docker-pixelfed/customize/tags/#pixelfed-version

Disable Debian Release Check until it's solved in dottie.

Closes https://github.com/pixelfed/pixelfed/issues/5264

* New translations web.php (Finnish) [ci skip]

* New translations web.php (Finnish) [ci skip]

* fix: don't restore memory limit after cities import

Since this command can only be invoked by CLI, the process will exit after a successful import, so restoring the transient PHP memory limit doesn't really have any affect.

In PHP 8.4, this throws the following error (which doesn't happen in 8.3 and below)

> [entrypoint / 11-first-time-setup.sh] - (stderr) 128769/128769 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%[2025-01-20 11:29:23] production.ERROR: Failed to set memory limit to 134217728 bytes (Current memory usage is 134746112 bytes) {"exception":"[object] (ErrorException(code: 0): Failed to set memory limit to 134217728 bytes (Current memory usage is 134746112 bytes) at /var/www/app/Console/Commands/ImportCities.php:140)

It seems to be a 8.4 behavior change, so removing the logic would make it go away

* New translations web.php (Finnish) [ci skip]

* New translations web.php (Finnish) [ci skip]

* New translations web.php (Portuguese) [ci skip]

* New translations web.php (Portuguese) [ci skip]

* fix(compose-modal): avoid WebGL if it's not needed

* fix(compose-modal): update webgl-media-editor

* New translations web.php (Hungarian) [ci skip]

* New translations web.php (Russian) [ci skip]

* New translations web.php (Russian) [ci skip]

* Update .env.example

Adding the parameter INSTANCE_DISCOVER_PUBLIC="true" to prevent a HTTP 403 error at the explorer tab in the instance preview.

* New variable for lang spanish

* Variable for lang spanish

* Update Dockerfile, fixes #5535 #5559

* Fix #5582

* Fix #5632

* Update status twitter:card to summary_large_image for images/albums

* Update changelog

---------







* Update iar.blade.php

---------