### PR TITLE
[Translation] add missing keys pt site.php

### DIFF
--- a/resources/lang/pt/site.php
+++ b/resources/lang/pt/site.php
@@ -17,4 +17,42 @@ return [
     'places'        => 'Locais',
     'profiles'      => 'Perfis',
 
+    // site/about
+    'photo_sharing_for_everyone'                            => 'Compartilhamento de Fotos. Para Todos',
+    'pixelfed_is_an_image_sharing_platform_etc'             => 'Pixelfed é uma plataforma de compartilhamento de imagens, uma alternativa ética às plataformas centralizadas.',
+    'feature_packed'                                        => 'Repleto de Recursos.',
+    'the_best_for_the_brightest'                            => 'O melhor para os mais brilhantes 📸',
+    'albums'                                                => 'Álbuns',
+    'share_posts_with_up_to'                                => 'Compartilhe postagens com até',
+    'photos'                                                => 'fotos',
+    'comments'                                              => 'Comentários',
+    'comment_on_a_post_or_send_a_reply'                     => 'Comente em uma postagem ou envie uma resposta',
+    'collections'                                           => 'Coleções',
+    'organize_and_share_collections_of_multiple_posts'      => 'Organize e compartilhe coleções de várias postagens',
+    'discover'                                              => 'Descobrir',
+    'explore_categories_hashtags_and_topics'                => 'Explore categorias, hashtags e tópicos',
+    'photo_filters'                                         => 'Filtros de Fotos',
+    'add_a_special_touch_to_your_photos'                    => 'Adicione um toque especial às suas fotos',
+    'stories'                                               => 'Histórias',
+    'share_moments_with_your_followers_that_disappear_etc'  => 'Compartilhe momentos com seus seguidores que desaparecem após 24 horas',
+    'people_have_shared'                                    => 'pessoas compartilharam',
+    'photos_and_videos_on'                                  => 'fotos e vídeos em',
+    'sign_up_today'                                         => 'Inscreva-se hoje',
+    'and_join_our_community_of_photographers_from_etc'      => 'e junte-se à nossa comunidade de fotógrafos de todo o mundo.',
+
+    // site/fediverse
+    'is_a_portmanteau_of_federation_and_universe_etc'       => 'é um portmanteau de “federação” e “universo”. É um nome comum e informal para uma federação de servidores de redes sociais, especializados em diferentes tipos de mídia.',
+    'supported_fediverse_projects'                          => 'Projetos Fediverse Suportados',
+    'some_of_the_better_known_fediverse_projects_include'   => 'Alguns dos projetos Fediverse mais conhecidos incluem:',
+    'a_federated_microblogging_alternative'                 => 'Uma alternativa de microblogging federada.',
+
+    // site/opensource
+    'the_software_that_powers_this_website_is_called'       => 'O software que alimenta este site é chamado',
+    'and_anyone_can'                                        => 'e qualquer pessoa pode',
+    'download'                                              => 'baixar',
+    'opensource.or'                                         => 'ou',
+    'view'                                                  => 'ver',
+    'the_source_code_and_run_their_own_instance'            => 'o código-fonte e executar sua própria instância!',
+    'open_source_in_pixelfed'                               => 'Código aberto no Pixelfed',
+
 ];


### PR DESCRIPTION
###  PR Description:

This PR aims to fix the missing translation keys in the site.php file for the Portuguese language. Two years ago, I had already translated these pages in my instance. However, upon taking over the official translation version, I noticed that the absence of these keys has been causing frequent conflicts with each update.

With this fix, we ensure that all strings are properly translated, preventing content display issues and providing a better experience for users using the application in Portuguese.