### PR TITLE
[Bug Fix] Fix expected filename in .zip file of instagram export

### DIFF
--- a/resources/assets/components/AccountImport.vue
+++ b/resources/assets/components/AccountImport.vue
@@ -394,7 +394,7 @@
                 let file = this.$refs.zipInput.files[0];
                 let entries = await this.model(file);
                 if (entries && entries.length) {
-                    let files = await entries.filter(e => e.filename === 'content/posts_1.json' || e.filename === 'your_instagram_activity/content/posts_1.json');
+                    let files = await entries.filter(e => e.filename === 'content/posts_1.json' || e.filename === 'your_instagram_activity/content/posts_1.json' || e.filename === 'your_instagram_activity/media/posts_1.json');
 
                     if(!files || !files.length) {
                         this.contactModal(
@@ -415,7 +415,7 @@
                 let entries = await this.model(file);
                 if (entries && entries.length) {
                     this.zipFiles = entries;
-                    let media = await entries.filter(e => e.filename === 'content/posts_1.json' || e.filename === 'your_instagram_activity/content/posts_1.json')[0].getData(new zip.TextWriter());
+                    let media = await entries.filter(e => e.filename === 'content/posts_1.json' || e.filename === 'your_instagram_activity/content/posts_1.json' || e.filename === 'your_instagram_activity/media/posts_1.json')[0].getData(new zip.TextWriter());
                     this.filterPostMeta(media);
 
                     let imgs = await Promise.all(entries.filter(entry => {


### PR DESCRIPTION
I've just received an instagram export of my data, and it turns out that the contents of the .zip file have been changed. At least in my export, there's no file named `your_instagram_activity/content/posts_1.json`, so the import in Pixelfed fails with the error message that the zip file is invalid or corrupt.

The new location is in `your_instagram_activity/media/posts_1.json`.

This PR fixes issue #5639.