### PR TITLE
[Bug Fix] Fix server post stats

### DIFF
--- a/app/Console/Commands/InstanceUpdateTotalLocalPosts.php
+++ b/app/Console/Commands/InstanceUpdateTotalLocalPosts.php
@@ -53,9 +53,8 @@ class InstanceUpdateTotalLocalPosts extends Command
 
     protected function initCache()
     {
-        $count = DB::table('statuses')->whereNull(['url', 'deleted_at'])->count();
         $res = [
-            'count' => $count,
+            'count' => $this->getTotalLocalPosts(),
         ];
         Storage::put('total_local_posts.json', json_encode($res, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
         ConfigCacheService::put('instance.stats.total_local_posts', $res['count']);
@@ -68,12 +67,20 @@ class InstanceUpdateTotalLocalPosts extends Command
 
     protected function updateAndCache()
     {
-        $count = DB::table('statuses')->whereNull(['url', 'deleted_at'])->count();
         $res = [
-            'count' => $count,
+            'count' => $this->getTotalLocalPosts(),
         ];
         Storage::put('total_local_posts.json', json_encode($res, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
         ConfigCacheService::put('instance.stats.total_local_posts', $res['count']);
 
+    }
+
+    protected function getTotalLocalPosts()
+    {
+        return DB::table('statuses')
+            ->whereNull('deleted_at')
+            ->where('local', true)
+            ->whereNot('type', 'share') # Ignore boosts for the post count
+            ->count();
     }
 }


### PR DESCRIPTION
This fixes the homepage, showing how many posts have been made by the server.
The prior logic includes posts from remote servers by an indirect check for if it's a local post.
This commit changes the query behavior to directly check for the local flag in the statuses column, and additionally excludes shares

# Test plan

Install docker ghcr.io/intentionally-left-nil/pixelfed-fpm:0.12.5-with-post-fix

Start the app, then run `php artisan app:instance-update-total-local-posts`
See that the post count goes from 225k to 416 posts