### PR TITLE
[Improvement] notifications - pixelfed 

### DIFF
--- a/app/Console/Commands/RemoveOldNotification.php
+++ b/app/Console/Commands/RemoveOldNotification.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use App\Jobs\NotificationPipeline\RemoveOldNotificaion;
+
+class RemoveOldNotification extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'app:remove-old-notification';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Remove old notifications read from the database';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        RemoveOldNotificaion::dispatch()
+            ->onQueue('low');
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -52,6 +52,7 @@ class Kernel extends ConsoleKernel
         $schedule->command('app:hashtag-cached-count-update')->hourlyAt(25)->onOneServer();
         $schedule->command('app:account-post-count-stat-update')->everySixHours(25)->onOneServer();
         $schedule->command('app:instance-update-total-local-posts')->twiceDailyAt(1, 13, 45)->onOneServer();
+        $schedule->command('app:remove-old-notification')->everySixHours()->onOneServer();
     }
 
     /**

--- a/app/Http/Controllers/Api/ApiV1Controller.php
+++ b/app/Http/Controllers/Api/ApiV1Controller.php
@@ -4557,6 +4557,9 @@ class ApiV1Controller extends Controller
         abort_if(! $request->user(), 403);
         abort_unless($request->user()->tokenCan('write'), 403);
 
+        $user = $request->user();
+        $pid = $user->profile_id;
+
         Notification::whereNull('read_at')
         ->whereProfileId($pid)
         ->chunk(100, function ($chunk) {
@@ -4584,7 +4587,9 @@ class ApiV1Controller extends Controller
         $limit = $request->input('limit', 100);
         $types = $request->input('types', []);
         $exclude = $request->input('exclude_types', []);
-        //$account_id = $request->input('account_id');
+
+        $user = $request->user();
+        $pid = $user->profile_id;
 
         $validTypes = ['mention', 'favourite', 'reblog', 'follow', 'follow_request', 'poll'];
 
@@ -4593,7 +4598,7 @@ class ApiV1Controller extends Controller
 
         $query = Notification::query()
             ->whereNull('read_at')
-            //->when($account_id, fn($q) => $q->where('account_id', $account_id))
+            ->where('profile_id', $pid )
             ->when(!empty($types), fn($q) => $q->whereIn('type', $types))
             ->when(!empty($exclude), fn($q) => $q->whereNotIn('type', $exclude))
             ->limit($limit);

--- a/app/Http/Controllers/Api/ApiV1Controller.php
+++ b/app/Http/Controllers/Api/ApiV1Controller.php
@@ -4520,31 +4520,6 @@ class ApiV1Controller extends Controller
         return $this->json(['success' => true]);
     }
 
-    /**
-     * POST /api/v1/notifications/:id/dismiss
-     *
-     * @return array
-     */
-    public function accountNotificationsMarkAsUnread(Request $request, $id)
-    {
-
-        abort_if(! $request->user(), 403);
-        abort_unless($request->user()->tokenCan('write'), 403);
-
-        $user = $request->user();
-        $pid = $user->profile_id;
-
-        if (! $id) {
-            return $this->json(['error' => 'Missing id'], 422);
-        }
-
-        $notification = Notification::whereProfileId($pid)->findOrFail($id);
-        $notification->read_at = null;
-        $notification->save();
-
-        Cache::forget('service:notification:'.$id);
-        return $this->json(['success' => true]);
-    }
 
     /**
      * POST /api/v1/notifications/clear

--- a/app/Http/Controllers/Api/ApiV1Controller.php
+++ b/app/Http/Controllers/Api/ApiV1Controller.php
@@ -4496,7 +4496,7 @@ class ApiV1Controller extends Controller
     }
 
     /**
-     * GET /api/v1/notifications/{id}/dismiss
+     * POST /api/v1/notifications/{id}/dismiss
      *
      * @return array
      */

--- a/app/Http/Controllers/Api/ApiV1Controller.php
+++ b/app/Http/Controllers/Api/ApiV1Controller.php
@@ -4494,4 +4494,48 @@ class ApiV1Controller extends Controller
 
         return $this->json($status);
     }
+
+    /**
+     * GET /api/v1/notifications
+     *
+     * @return array
+     */
+    public function accountNotificationsMarkAsRead(Request $request)
+    {
+        /* abort_if(! $request->user(), 403);
+        abort_unless($request->user()->tokenCan('write'), 403);*/
+
+        $user = $request->user();
+        $pid = $user->profile_id;
+        $id = $request->input('id');
+        if (! $id) {
+            return $this->json(['error' => 'Missing id'], 422);
+        }
+
+        $notification = Notification::whereProfileId($pid)->findOrFail($id);
+        $notification->read_at = 'now()';
+        $notification->save();
+
+        return $this->json(['success' => true]);
+    }
+
+    public function accountNotificationsMarkAsUnread(Request $request)
+    {
+        /*
+        abort_if(! $request->user(), 403);
+        abort_unless($request->user()->tokenCan('write'), 403);*/
+
+        $user = $request->user();
+        $pid = $user->profile_id;
+        $id = $request->input('id');
+        if (! $id) {
+            return $this->json(['error' => 'Missing id'], 422);
+        }
+
+        $notification = Notification::whereProfileId($pid)->findOrFail($id);
+        $notification->read_at = null;
+        $notification->save();
+
+        return $this->json(['success' => true]);
+    }
 }

--- a/app/Jobs/NotificationPipeline/RemoveOldNotificaion.php
+++ b/app/Jobs/NotificationPipeline/RemoveOldNotificaion.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Jobs\NotificationPipeline;
+
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Foundation\Bus\Dispatchable;
+use App\Services\NotificationService;
+
+class RemoveOldNotificaion implements ShouldQueue, ShouldBeUnique
+{
+    use Dispatchable, Queueable;
+
+    /**
+     * The number of seconds after which the job's unique lock will be released.
+     *
+     * @var int
+     */
+    public $uniqueFor = 3600; // 1 hour
+
+
+    /**
+     * Get the unique ID for the job.
+     */
+    public function uniqueId(): string
+    {
+        return 'notifications:remove-old-sync';
+    }
+
+    /**
+     * Create a new job instance.
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Execute the job.
+     */
+    public function handle(): void
+    {
+        try{
+            NotificationService::removeOldNotifications();
+        }catch (\Exception $e){
+            Log::error(
+                'Error removing old notifications.',
+                [
+                    'exception' => get_class($e),
+                    'message' => $e->getMessage(),
+                    'attempt' => $this->attempts(),
+                ]
+            );
+        }
+    }
+}

--- a/app/Services/NotificationService.php
+++ b/app/Services/NotificationService.php
@@ -322,4 +322,18 @@ class NotificationService
 
         return 0;
     }
+
+    public static function removeOldNotifications()
+    {
+        Notification::whereNotNull('read_at')
+            ->where('read_at', '<', now()->subMonths(3))
+            ->chunkById(
+                100, function ($notifications) {
+                    foreach ($notifications as $notification) {
+                        $notification->forceDelete();
+                        self::del($notification->id, $notification->id);
+                    }
+                }
+            );
+    }
 }

--- a/app/Transformer/Api/NotificationTransformer.php
+++ b/app/Transformer/Api/NotificationTransformer.php
@@ -16,6 +16,7 @@ class NotificationTransformer extends Fractal\TransformerAbstract
             'id' => (string) $notification->id,
             'type' => $this->replaceTypeVerb($notification->action),
             'created_at' => (string) str_replace('+00:00', 'Z', $notification->created_at->format(DATE_RFC3339_EXTENDED)),
+            'read' => (bool) $notification->read_at,
         ];
 
         $n = $notification;

--- a/resources/assets/components/partials/timeline/Notification.vue
+++ b/resources/assets/components/partials/timeline/Notification.vue
@@ -1,12 +1,5 @@
 <template>
 	<div :class="['media mb-2 align-items-center px-3 shadow-sm py-2 bg-white',  n.read ? '': 'unread']" style="border-radius: 15px;">
-
-        <a href="#" v-if="n.read" @click="markUnRead()"  class="mx-2 border-0 bg-transparent">
-            <i class="far fa-envelope-open"></i>
-        </a>
-        <a href="#" v-else  @click="markRead()" class="mx-2 border-0 bg-transparent">
-            <i class="fas fa-envelope"></i>
-        </a>
         <a href="#" @click.prevent="getProfileUrl(n.account)" v-b-tooltip.hover :title="n.account.acct">
 			<img class="mr-3 shadow-sm" style="border-radius:8px" :src="n.account.avatar" alt="" width="40" height="40" onerror="this.onerror=null;this.src='/storage/avatars/default.jpg';">
 		</a>
@@ -122,6 +115,10 @@
 				<a v-if="viewContext(n) != '/'" class="btn btn-outline-primary py-0 font-weight-bold" href="#" @click.prevent="viewContext(n)">View</a>
 			</div> -->
 		</div>
+
+        <a href="#" v-if="!n.read"  title="Mark as Read"    @click="markRead()" class="mx-2 border-0 bg-transparent">
+            <i class="fas fa-envelope"></i>
+        </a>
 	</div>
 </template>
 

--- a/resources/assets/components/partials/timeline/Notification.vue
+++ b/resources/assets/components/partials/timeline/Notification.vue
@@ -1,11 +1,11 @@
 <template>
 	<div :class="['media mb-2 align-items-center px-3 shadow-sm py-2 bg-white',  n.read ? '': 'unread']" style="border-radius: 15px;">
 
-        <a href="#" v-if="n.read"  class="mx-2 border-0 bg-transparent">
+        <a href="#" v-if="n.read" @click="markUnRead()"  class="mx-2 border-0 bg-transparent">
             <i class="far fa-envelope-open"></i>
         </a>
-        <a href="#" v-else  class="mx-2 border-0 bg-transparent">
-            <i class="far fa-envelope"></i>
+        <a href="#" v-else  @click="markRead()" class="mx-2 border-0 bg-transparent">
+            <i class="fas fa-envelope"></i>
         </a>
         <a href="#" @click.prevent="getProfileUrl(n.account)" v-b-tooltip.hover :title="n.account.acct">
 			<img class="mr-3 shadow-sm" style="border-radius:8px" :src="n.account.avatar" alt="" width="40" height="40" onerror="this.onerror=null;this.src='/storage/avatars/default.jpg';">
@@ -213,7 +213,31 @@
 						cachedProfile: this.profile
 					}
 				});
-			}
+			},
+
+            markRead() {
+                if(this.n.read) {
+                    return;
+                }
+                axios.post(`/api/v1/notifications/mark_as_read`, {
+                    id: this.n.id
+                })
+                .then(res => {
+                    this.n.read = true;
+                });
+            },
+            markUnRead(){
+                if(!this.n.read) {
+                    return;
+                }
+                axios.post(`/api/v1/notifications/mark_as_unread`, {
+                    id: this.n.id
+                })
+                .then(res => {
+                    this.n.read = false;
+                });
+
+            },
 		}
 	}
 </script>

--- a/resources/assets/components/partials/timeline/Notification.vue
+++ b/resources/assets/components/partials/timeline/Notification.vue
@@ -223,18 +223,6 @@
                     this.n.read = true;
                 });
             },
-            markUnRead(){
-                if(!this.n.read) {
-                    return;
-                }
-                axios.post(`/api/v1/notifications/mark_as_unread`, {
-                    id: this.n.id
-                })
-                .then(res => {
-                    this.n.read = false;
-                });
-
-            },
 		}
 	}
 </script>

--- a/resources/assets/components/partials/timeline/Notification.vue
+++ b/resources/assets/components/partials/timeline/Notification.vue
@@ -1,6 +1,13 @@
 <template>
-	<div class="media mb-2 align-items-center px-3 shadow-sm py-2 bg-white" style="border-radius: 15px;">
-		<a href="#" @click.prevent="getProfileUrl(n.account)" v-b-tooltip.hover :title="n.account.acct">
+	<div :class="['media mb-2 align-items-center px-3 shadow-sm py-2 bg-white',  n.read ? '': 'unread']" style="border-radius: 15px;">
+
+        <a href="#" v-if="n.read"  class="mx-2 border-0 bg-transparent">
+            <i class="far fa-envelope-open"></i>
+        </a>
+        <a href="#" v-else  class="mx-2 border-0 bg-transparent">
+            <i class="far fa-envelope"></i>
+        </a>
+        <a href="#" @click.prevent="getProfileUrl(n.account)" v-b-tooltip.hover :title="n.account.acct">
 			<img class="mr-3 shadow-sm" style="border-radius:8px" :src="n.account.avatar" alt="" width="40" height="40" onerror="this.onerror=null;this.src='/storage/avatars/default.jpg';">
 		</a>
 
@@ -210,3 +217,8 @@
 		}
 	}
 </script>
+<style lang="scss">
+ .unread{
+            background: #F8F9FA !important;
+        }
+</style>

--- a/resources/assets/components/sections/Notifications.vue
+++ b/resources/assets/components/sections/Notifications.vue
@@ -422,9 +422,7 @@
                 if(this.feed[index].read) {
                     return;
                 }
-                axios.post(`/api/v1/notifications/mark_as_read`, {
-                    id: this.feed[index].id
-                })
+                axios.post(`/api/v1/notifications/${this.feed[index].id}/dismiss`)
                 .then(res => {
                     this.feed[index].read = true;
                     this.totalUnread = this.totalUnread - 1;
@@ -434,9 +432,7 @@
                 if(!this.feed[index].read) {
                     return;
                 }
-                axios.post(`/api/v1/notifications/mark_as_unread`, {
-                    id: this.feed[index].id
-                })
+                axios.post(`/api/v1/notifications/${this.feed[index].id}/mark_as_unread`)
                 .then(res => {
                     this.feed[index].read = false;
                     this.totalUnread = this.totalUnread + 1;
@@ -448,7 +444,7 @@
                     return;
                 }
 
-                axios.post(`/api/v1/notifications/mark_as_read`)
+                axios.post(`/api/v1/notifications/clear`)
                 .then(res => {
                     for(let i = 0; i < this.feed.length; i++) {
                         this.feed[i].read = true;

--- a/resources/assets/components/sections/Notifications.vue
+++ b/resources/assets/components/sections/Notifications.vue
@@ -42,12 +42,6 @@
 					<template v-else>
 						<div v-for="(n, index) in feed" :class="['my-2 p-2 px-0', n.read ? '': 'unread' ]"  :key="index">
 							<div class="media align-items-center">
-                                <a href="#" v-if="n.read" @click="markUnRead(index)"  class="mx-1 border-0 bg-transparent">
-                                    <i class="far fa-envelope-open"></i>
-                                </a>
-                                <a href="#" v-else  @click="markRead(index)" class="mx-1 border-0 bg-transparent">
-                                    <i class="fas fa-envelope"></i>
-                                </a>
 								<img
 									v-if="n.type === 'autospam.warning'"
 									class="mr-2 rounded-circle shadow-sm p-1"
@@ -164,6 +158,10 @@
 									</div>
 								</div>
 								<div class="small text-muted font-weight-bold"  style="font-size: 12px;" :title="n.created_at">{{timeAgo(n.created_at)}}</div>
+
+                                <a href="#" v-if="!n.read"  title="Mark as Read"   @click="markRead(index)" class="mx-1 border-0 bg-transparent">
+                                    <i class="fas fa-envelope"></i>
+                                </a>
 							</div>
 						</div>
 

--- a/resources/assets/components/sections/Notifications.vue
+++ b/resources/assets/components/sections/Notifications.vue
@@ -34,8 +34,14 @@
 					</template>
 
 					<template v-else>
-						<div v-for="(n, index) in feed" class="mb-2">
+						<div v-for="(n, index) in feed" :class="['my-2 p-2 px-0', n.read ? '': 'unread' ]"  :key="index">
 							<div class="media align-items-center">
+                                <a href="#" v-if="n.read"  class="mx-2 border-0 bg-transparent">
+                                    <i class="far fa-envelope-open"></i>
+                                </a>
+                                <a href="#" v-else  class="mx-2 border-0 bg-transparent">
+                                    <i class="far fa-envelope"></i>
+                                </a>
 								<img
 									v-if="n.type === 'autospam.warning'"
 									class="mr-2 rounded-circle shadow-sm p-1"
@@ -443,5 +449,9 @@
 		.card-body {
 			width: 100%;
 		}
+
+        .unread{
+            background: #F8F9FA !important;
+        }
 	}
 </style>

--- a/resources/assets/components/sections/Notifications.vue
+++ b/resources/assets/components/sections/Notifications.vue
@@ -5,8 +5,11 @@
 				<div class="d-flex justify-content-between align-items-center mb-3">
 					<span class="text-muted font-weight-bold">{{ $t("notifications.title")}}</span>
 					<div v-if="feed && feed.length">
-                        <button type="button" @click="markAllRead()" class="btn btn-primary btn-sm">
-                            <i class="fas fa-envelope"></i> <span class="badge text-bg-secondary text-red">4</span>
+                        <button v-if="totalUnread>0" type="button" @click="markAllRead()" class="btn btn-primary btn-sm">
+                            <i class="fas fa-envelope"></i> <span class="badge text-bg-secondary text-red">{{totalUnread}}</span>
+                        </button>
+                        <button v-else type="button" @click="markAllRead()" class="btn btn-outline-light btn-sm" disabled>
+                            <i class="far fa-envelope-open"></i>
                         </button>
 						<router-link to="/i/web/notifications" class="btn btn-outline-light btn-sm mr-2" style="color: #B8C2CC !important">
 							<i class="far fa-filter"></i>
@@ -212,7 +215,8 @@
 				hasLoaded: false,
 				isEmpty: false,
 				retryTimeout: undefined,
-				retryAttempts: 0
+				retryAttempts: 0,
+                totalUnread: 0,
 			}
 		},
 
@@ -232,6 +236,10 @@
 					clearTimeout(this.retryTimeout);
 					return;
 				}
+                axios.get('/api/v1/notifications/status').then(res => {
+                    this.totalUnread = res.data.total_unread;
+                });
+
 				axios.get('/api/pixelfed/v1/notifications', {
 					params: {
 						limit: 9,
@@ -419,6 +427,7 @@
                 })
                 .then(res => {
                     this.feed[index].read = true;
+                    this.totalUnread = this.totalUnread - 1;
                 });
             },
             markUnRead(index){
@@ -430,6 +439,7 @@
                 })
                 .then(res => {
                     this.feed[index].read = false;
+                    this.totalUnread = this.totalUnread + 1;
                 });
 
             },
@@ -442,6 +452,7 @@
                 .then(res => {
                     for(let i = 0; i < this.feed.length; i++) {
                         this.feed[i].read = true;
+                        this.totalUnread = 0;
                     }
                 });
 

--- a/resources/assets/components/sections/Notifications.vue
+++ b/resources/assets/components/sections/Notifications.vue
@@ -42,10 +42,10 @@
 					<template v-else>
 						<div v-for="(n, index) in feed" :class="['my-2 p-2 px-0', n.read ? '': 'unread' ]"  :key="index">
 							<div class="media align-items-center">
-                                <a href="#" v-if="n.read" @click="markUnRead(index)"  class="mx-2 border-0 bg-transparent">
+                                <a href="#" v-if="n.read" @click="markUnRead(index)"  class="mx-1 border-0 bg-transparent">
                                     <i class="far fa-envelope-open"></i>
                                 </a>
-                                <a href="#" v-else  @click="markRead(index)" class="mx-2 border-0 bg-transparent">
+                                <a href="#" v-else  @click="markRead(index)" class="mx-1 border-0 bg-transparent">
                                     <i class="fas fa-envelope"></i>
                                 </a>
 								<img

--- a/resources/assets/components/sections/Notifications.vue
+++ b/resources/assets/components/sections/Notifications.vue
@@ -5,6 +5,9 @@
 				<div class="d-flex justify-content-between align-items-center mb-3">
 					<span class="text-muted font-weight-bold">{{ $t("notifications.title")}}</span>
 					<div v-if="feed && feed.length">
+                        <button type="button" @click="markAllRead()" class="btn btn-primary btn-sm">
+                            <i class="fas fa-envelope"></i> <span class="badge text-bg-secondary text-red">4</span>
+                        </button>
 						<router-link to="/i/web/notifications" class="btn btn-outline-light btn-sm mr-2" style="color: #B8C2CC !important">
 							<i class="far fa-filter"></i>
 						</router-link>
@@ -428,6 +431,20 @@
                 .then(res => {
                     this.feed[index].read = false;
                 });
+
+            },
+            markAllRead(){
+                if(window.confirm(this.$t('notifications.markAllRead')) == false) {
+                    return;
+                }
+
+                axios.post(`/api/v1/notifications/mark_as_read`)
+                .then(res => {
+                    for(let i = 0; i < this.feed.length; i++) {
+                        this.feed[i].read = true;
+                    }
+                });
+
 
             },
 			showAutospamInfo(status) {

--- a/resources/assets/components/sections/Notifications.vue
+++ b/resources/assets/components/sections/Notifications.vue
@@ -236,8 +236,8 @@
 					clearTimeout(this.retryTimeout);
 					return;
 				}
-                axios.get('/api/v1/notifications/status').then(res => {
-                    this.totalUnread = res.data.total_unread;
+                axios.get('/api/v1/notifications/unread_count').then(res => {
+                    this.totalUnread = res.data.count;
                 });
 
 				axios.get('/api/pixelfed/v1/notifications', {
@@ -451,8 +451,6 @@
                         this.totalUnread = 0;
                     }
                 });
-
-
             },
 			showAutospamInfo(status) {
 				let el = document.createElement('p');

--- a/resources/assets/components/sections/Notifications.vue
+++ b/resources/assets/components/sections/Notifications.vue
@@ -36,11 +36,11 @@
 					<template v-else>
 						<div v-for="(n, index) in feed" :class="['my-2 p-2 px-0', n.read ? '': 'unread' ]"  :key="index">
 							<div class="media align-items-center">
-                                <a href="#" v-if="n.read"  class="mx-2 border-0 bg-transparent">
+                                <a href="#" v-if="n.read" @click="markUnRead(index)"  class="mx-2 border-0 bg-transparent">
                                     <i class="far fa-envelope-open"></i>
                                 </a>
-                                <a href="#" v-else  class="mx-2 border-0 bg-transparent">
-                                    <i class="far fa-envelope"></i>
+                                <a href="#" v-else  @click="markRead(index)" class="mx-2 border-0 bg-transparent">
+                                    <i class="fas fa-envelope"></i>
                                 </a>
 								<img
 									v-if="n.type === 'autospam.warning'"
@@ -407,7 +407,29 @@
 					}
 				})
 			},
+            markRead(index) {
+                if(this.feed[index].read) {
+                    return;
+                }
+                axios.post(`/api/v1/notifications/mark_as_read`, {
+                    id: this.feed[index].id
+                })
+                .then(res => {
+                    this.feed[index].read = true;
+                });
+            },
+            markUnRead(index){
+                if(!this.feed[index].read) {
+                    return;
+                }
+                axios.post(`/api/v1/notifications/mark_as_unread`, {
+                    id: this.feed[index].id
+                })
+                .then(res => {
+                    this.feed[index].read = false;
+                });
 
+            },
 			showAutospamInfo(status) {
 				let el = document.createElement('p');
 				el.classList.add('text-left');

--- a/resources/assets/components/sections/Notifications.vue
+++ b/resources/assets/components/sections/Notifications.vue
@@ -426,17 +426,6 @@
                     this.totalUnread = this.totalUnread - 1;
                 });
             },
-            markUnRead(index){
-                if(!this.feed[index].read) {
-                    return;
-                }
-                axios.post(`/api/v1/notifications/${this.feed[index].id}/mark_as_unread`)
-                .then(res => {
-                    this.feed[index].read = false;
-                    this.totalUnread = this.totalUnread + 1;
-                });
-
-            },
             markAllRead(){
                 if(window.confirm(this.$t('notifications.markAllRead')) == false) {
                     return;

--- a/routes/api.php
+++ b/routes/api.php
@@ -136,7 +136,6 @@ Route::group(['prefix' => 'api'], function () use ($middleware) {
         Route::get('mutes', 'Api\ApiV1Controller@accountMutes')->middleware($middleware);
         Route::get('notifications', 'Api\ApiV1Controller@accountNotifications')->middleware($middleware);
         Route::post('notifications/{id}/dismiss', 'Api\ApiV1Controller@accountNotificationsDimiss')->middleware($middleware);
-        Route::post('notifications/{id}/mark_as_unread', 'Api\ApiV1Controller@accountNotificationsMarkAsUnread')->middleware($middleware);
         Route::post('notifications/clear', 'Api\ApiV1Controller@accountNotificationsDimissAll')->middleware($middleware);
         Route::get('notifications/unread_count', 'Api\ApiV1Controller@accountNotificationsUnreadCount')->middleware($middleware);
         Route::get('suggestions', 'Api\ApiV1Controller@accountSuggestions')->middleware($middleware);

--- a/routes/api.php
+++ b/routes/api.php
@@ -138,6 +138,7 @@ Route::group(['prefix' => 'api'], function () use ($middleware) {
         Route::post('notifications/mark_as_read', 'Api\ApiV1Controller@accountNotificationsMarkAsRead')->middleware($middleware);
         Route::post('notifications/mark_as_unread', 'Api\ApiV1Controller@accountNotificationsMarkAsUnread')->middleware($middleware);
         Route::post('notifications/mark_all_as_read', 'Api\ApiV1Controller@accountNotificationsMarkAllAsRead')->middleware($middleware);
+        Route::get('notifications/status', 'Api\ApiV1Controller@accountNotificationsStatus')->middleware($middleware);
         Route::get('suggestions', 'Api\ApiV1Controller@accountSuggestions')->middleware($middleware);
 
         Route::post('statuses/{id}/favourite', 'Api\ApiV1Controller@statusFavouriteById')->middleware($middleware);

--- a/routes/api.php
+++ b/routes/api.php
@@ -136,9 +136,9 @@ Route::group(['prefix' => 'api'], function () use ($middleware) {
         Route::get('mutes', 'Api\ApiV1Controller@accountMutes')->middleware($middleware);
         Route::get('notifications', 'Api\ApiV1Controller@accountNotifications')->middleware($middleware);
         Route::post('notifications/{id}/dismiss', 'Api\ApiV1Controller@accountNotificationsDimiss')->middleware($middleware);
-        Route::post('notifications/mark_as_unread', 'Api\ApiV1Controller@accountNotificationsMarkAsUnread')->middleware($middleware);
+        Route::post('notifications/{id}/mark_as_unread', 'Api\ApiV1Controller@accountNotificationsMarkAsUnread')->middleware($middleware);
         Route::post('notifications/clear', 'Api\ApiV1Controller@accountNotificationsDimissAll')->middleware($middleware);
-        Route::get('notifications/unread_count', 'Api\ApiV1Controller@accountNotificationsStatus')->middleware($middleware);
+        Route::get('notifications/unread_count', 'Api\ApiV1Controller@accountNotificationsUnreadCount')->middleware($middleware);
         Route::get('suggestions', 'Api\ApiV1Controller@accountSuggestions')->middleware($middleware);
 
         Route::post('statuses/{id}/favourite', 'Api\ApiV1Controller@statusFavouriteById')->middleware($middleware);

--- a/routes/api.php
+++ b/routes/api.php
@@ -135,6 +135,9 @@ Route::group(['prefix' => 'api'], function () use ($middleware) {
         Route::put('media/{id}', 'Api\ApiV1Controller@mediaUpdate')->middleware($middleware);
         Route::get('mutes', 'Api\ApiV1Controller@accountMutes')->middleware($middleware);
         Route::get('notifications', 'Api\ApiV1Controller@accountNotifications')->middleware($middleware);
+        Route::post('notifications/mark_as_read', 'Api\ApiV1Controller@accountNotificationsMarkAsRead')->middleware($middleware);
+        Route::post('notifications/mark_as_unread', 'Api\ApiV1Controller@accountNotificationsMarkAsUnread')->middleware($middleware);
+        Route::post('notifications/mark_all_as_read', 'Api\ApiV1Controller@accountNotificationsMarkAllAsRead')->middleware($middleware);
         Route::get('suggestions', 'Api\ApiV1Controller@accountSuggestions')->middleware($middleware);
 
         Route::post('statuses/{id}/favourite', 'Api\ApiV1Controller@statusFavouriteById')->middleware($middleware);

--- a/routes/api.php
+++ b/routes/api.php
@@ -135,10 +135,10 @@ Route::group(['prefix' => 'api'], function () use ($middleware) {
         Route::put('media/{id}', 'Api\ApiV1Controller@mediaUpdate')->middleware($middleware);
         Route::get('mutes', 'Api\ApiV1Controller@accountMutes')->middleware($middleware);
         Route::get('notifications', 'Api\ApiV1Controller@accountNotifications')->middleware($middleware);
-        Route::post('notifications/mark_as_read', 'Api\ApiV1Controller@accountNotificationsMarkAsRead')->middleware($middleware);
+        Route::post('notifications/{id}/dismiss', 'Api\ApiV1Controller@accountNotificationsDimiss')->middleware($middleware);
         Route::post('notifications/mark_as_unread', 'Api\ApiV1Controller@accountNotificationsMarkAsUnread')->middleware($middleware);
-        Route::post('notifications/mark_all_as_read', 'Api\ApiV1Controller@accountNotificationsMarkAllAsRead')->middleware($middleware);
-        Route::get('notifications/status', 'Api\ApiV1Controller@accountNotificationsStatus')->middleware($middleware);
+        Route::post('notifications/clear', 'Api\ApiV1Controller@accountNotificationsDimissAll')->middleware($middleware);
+        Route::get('notifications/unread_count', 'Api\ApiV1Controller@accountNotificationsStatus')->middleware($middleware);
         Route::get('suggestions', 'Api\ApiV1Controller@accountSuggestions')->middleware($middleware);
 
         Route::post('statuses/{id}/favourite', 'Api\ApiV1Controller@statusFavouriteById')->middleware($middleware);


### PR DESCRIPTION
# Notification System Improvements – Part 1 of 2

This PR aims to improve how notifications are handled by introducing the use of the `read_at` field in the notification list and highlighting unread notifications. This is **part 1 of a 2-part update**.

## Changes Included in This PR

- Updated the front-end to visually highlight unread notifications.
- Created three new API routes:
  - Mark a notification as read.
  - Mark a notification as unread.
  - Get the total count of unread notifications.
- Added a scheduled cron job that runs every 6 hours to delete notifications that have been marked as read for over 3 months.
