### PR TITLE
[Bug Fix] Fix unchecked media types HEIC and MOV in admin settings

### DIFF
--- a/resources/assets/components/admin/AdminSettings.vue
+++ b/resources/assets/components/admin/AdminSettings.vue
@@ -1021,16 +1021,20 @@
                         res += 'image/webp,'
                     }
 
-                    if(this.mediaTypes.mp4) {
-                        res += 'video/mp4,'
+                    if(this.mediaTypes.avif) {
+                        res += 'image/avif,'
                     }
 
                     if(this.mediaTypes.heic) {
                         res += 'image/heic,'
                     }
 
-                    if(this.mediaTypes.avif) {
-                        res += 'image/avif,'
+                    if(this.mediaTypes.mp4) {
+                        res += 'video/mp4,'
+                    }
+
+                    if(this.mediaTypes.mov) {
+                        res += 'video/mov,'
                     }
 
                     if(res.endsWith(',')) {
@@ -1096,7 +1100,7 @@
                 if(types && types.length) {
                     types.forEach((type) => {
                         let mime = type.split('/')[1];
-                        if(['jpeg', 'png', 'gif', 'webp', 'mp4', 'avif'].includes(mime)) {
+                        if(['jpeg', 'png', 'gif', 'webp', 'avif', 'heic', 'mp4', 'mov'].includes(mime)) {
                             this.mediaTypes[mime] = true;
                         }
                     })


### PR DESCRIPTION
Hello there!

Thank you very much for this wonderful piece of software. Here is my very first contribution; hopefully it is useful!

---

Currently, the admin settings view of medias mime types seems to ignore HEIC and MOV files, even though I have enabled then via `.env` variables. I believe this is “only” a front-end problem, in the sense that the front-end will show HEIC and MOV as unchecked no matter what, even when they are enabled in the back-end. Moreover, I think that saving the form does work fine for HEIC, but will ignore MOV. However, a subsequent save of the form (where HEIC is disabled by default) might disable HEIC by mistake.

![image](https://github.com/user-attachments/assets/3850cf3a-293a-41b3-8a3e-9d7a0c1b40fb)
_(Image taken from [this Reddit post](https://www.reddit.com/r/PixelFed/comments/1iezxfy/i_cant_enable_avif_heic_or_mov_uploads_the/) that seems to report the same issue.)_

This is possibly what @ning1no is encountering in https://github.com/pixelfed/pixelfed/issues/5309#issuecomment-2455571354, but it is hard to say without more information on what “[it] seems still not be activating avif support” and “the same issue” mean there.

---

The first part of this happens in `fetchInitialData`:

https://github.com/pixelfed/pixelfed/blob/e5dc95953a9574b8cf74a4c08f8d0cbdc393f19d/resources/assets/components/admin/AdminSettings.vue#L1072-L1092

On my instance, querying `/i/admin/api/settings/fetch` by hand does report the right string of mime types, containing `image/heic` and `video/mov`. However, `fetchInitialData` calls `setMediaTypes`:

https://github.com/pixelfed/pixelfed/blob/e5dc95953a9574b8cf74a4c08f8d0cbdc393f19d/resources/assets/components/admin/AdminSettings.vue#L1094-L1104

which will only ever recognise the hard-coded list of types. The current PR simply adds `heic` and `mov` to that list. Another solution would be to grab the keys of the dictionary `mediaTypes` in that same file:

https://github.com/pixelfed/pixelfed/blob/e5dc95953a9574b8cf74a4c08f8d0cbdc393f19d/resources/assets/components/admin/AdminSettings.vue#L906-L915

to limit duplication and avoid re-encountering the same issue in the future when more media types are added. I will happily amend my PR with such a change if it is preferred.

---

The second part of this happens in `activeMediaTypes.get`:

https://github.com/pixelfed/pixelfed/blob/e5dc95953a9574b8cf74a4c08f8d0cbdc393f19d/resources/assets/components/admin/AdminSettings.vue#L1004-L1042

that lists everything but MOV. There too, it might be worth trying to find a way to have a unique source of truth and generate this code from there. However, the `mediaTypes` dictionary might not contain enough information for this.

---

Potentially related: I have tried uploading an HEIC file to my instance, where the back-end does report `image/heic` when I query `/i/admin/api/settings/fetch`, and I get

> The file you are trying to add is not a valid mime type. Please upload a ...,image/heic,... only.

I haven't inspected more because it is maybe fixed by this small PR, but if not I will investigate and report on this.