### PR TITLE
Revert s3 delay

### DIFF
--- a/app/Jobs/StatusPipeline/NewStatusPipeline.php
+++ b/app/Jobs/StatusPipeline/NewStatusPipeline.php
@@ -4,12 +4,14 @@ namespace App\Jobs\StatusPipeline;
 
 use App\Media;
 use App\Status;
+use Cache;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Redis;
 
 class NewStatusPipeline implements ShouldQueue
 {
@@ -62,10 +64,17 @@ class NewStatusPipeline implements ShouldQueue
      */
     public function handle()
     {
-        // Skip media check if cloud storage isn't enabled or fast processing is on
-        if (! config_cache('pixelfed.cloud_storage') || config('pixelfed.media_fast_process')) {
-            $this->dispatchFederation();
+        // Check if status still exists
+        if (!Status::where('id', $this->status->id)->exists()) {
+            if(config('federation.activitypub.delivery.logger.enabled')) {
+                Log::info('Status ' . $this->status->id . ' was deleted before federation');
+            }
+            return;
+        }
 
+        // Skip media check if cloud storage isn't enabled or fast processing is on
+        if (!config_cache('pixelfed.cloud_storage') || config('pixelfed.media_fast_process')) {
+            $this->dispatchFederation();
             return;
         }
 
@@ -82,18 +91,16 @@ class NewStatusPipeline implements ShouldQueue
                 ->first();
 
             // If media has been processing for more than 10 minutes, proceed anyway
-            if ($oldestProcessingMedia && $oldestProcessingMedia->replicated_at && $oldestProcessingMedia->replicated_at->diffInMinutes(now()) > 10) {
-                if (config('federation.activitypub.delivery.logger.enabled')) {
-                    Log::warning('Media processing timeout for status '.$this->status->id.'. Proceeding with federation.');
+            if ($oldestProcessingMedia && now()->diffInMinutes($oldestProcessingMedia->created_at) > 10) {
+                if(config('federation.activitypub.delivery.logger.enabled')) {
+                    Log::warning('Media processing timeout for status ' . $this->status->id . '. Proceeding with federation.');
                 }
                 $this->dispatchFederation();
-
                 return;
             }
 
             // Release job back to queue with delay of 30 seconds
             $this->release(30);
-
             return;
         }
 
@@ -111,8 +118,8 @@ class NewStatusPipeline implements ShouldQueue
         try {
             StatusEntityLexer::dispatch($this->status);
         } catch (\Exception $e) {
-            if (config('federation.activitypub.delivery.logger.enabled')) {
-                Log::error('Federation dispatch failed for status '.$this->status->id.': '.$e->getMessage());
+            if(config('federation.activitypub.delivery.logger.enabled')) {
+                Log::error('Federation dispatch failed for status ' . $this->status->id . ': ' . $e->getMessage());
             }
             throw $e;
         }
@@ -121,14 +128,15 @@ class NewStatusPipeline implements ShouldQueue
     /**
      * Handle a job failure.
      *
+     * @param  \Throwable  $exception
      * @return void
      */
     public function failed(\Throwable $exception)
     {
-        if (config('federation.activitypub.delivery.logger.enabled')) {
-            Log::error('NewStatusPipeline failed for status '.$this->status->id, [
+        if(config('federation.activitypub.delivery.logger.enabled')) {
+            Log::error('NewStatusPipeline failed for status ' . $this->status->id, [
                 'exception' => $exception->getMessage(),
-                'trace' => $exception->getTraceAsString(),
+                'trace' => $exception->getTraceAsString()
             ]);
         }
     }

--- a/app/Jobs/StatusPipeline/NewStatusPipeline.php
+++ b/app/Jobs/StatusPipeline/NewStatusPipeline.php
@@ -2,7 +2,6 @@
 
 namespace App\Jobs\StatusPipeline;
 
-use App\Media;
 use App\Status;
 use Cache;
 use Illuminate\Bus\Queueable;
@@ -10,7 +9,6 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
-use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Redis;
 
 class NewStatusPipeline implements ShouldQueue
@@ -18,7 +16,7 @@ class NewStatusPipeline implements ShouldQueue
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
     protected $status;
-
+    
     /**
      * Delete the job if its models no longer exist.
      *
@@ -26,27 +24,9 @@ class NewStatusPipeline implements ShouldQueue
      */
     public $deleteWhenMissingModels = true;
 
-    /**
-     * Increased timeout to handle cloud storage operations
-     *
-     * @var int
-     */
-    public $timeout = 30;
-
-    /**
-     * Number of times to attempt the job
-     *
-     * @var int
-     */
-    public $tries = 3;
-
-    /**
-     * Backoff periods between retries (in seconds)
-     *
-     * @var array
-     */
-    public $backoff = [30, 60, 120];
-
+    public $timeout = 5;
+    public $tries = 1;
+    
     /**
      * Create a new job instance.
      *
@@ -64,80 +44,6 @@ class NewStatusPipeline implements ShouldQueue
      */
     public function handle()
     {
-        // Check if status still exists
-        if (!Status::where('id', $this->status->id)->exists()) {
-            if(config('federation.activitypub.delivery.logger.enabled')) {
-                Log::info('Status ' . $this->status->id . ' was deleted before federation');
-            }
-            return;
-        }
-
-        // Skip media check if cloud storage isn't enabled or fast processing is on
-        if (!config_cache('pixelfed.cloud_storage') || config('pixelfed.media_fast_process')) {
-            $this->dispatchFederation();
-            return;
-        }
-
-        // Check for media still processing
-        $stillProcessing = Media::whereStatusId($this->status->id)
-            ->whereNull('cdn_url')
-            ->exists();
-
-        if ($stillProcessing) {
-            // Get the oldest processing media item
-            $oldestProcessingMedia = Media::whereStatusId($this->status->id)
-                ->whereNull('cdn_url')
-                ->oldest()
-                ->first();
-
-            // If media has been processing for more than 10 minutes, proceed anyway
-            if ($oldestProcessingMedia && now()->diffInMinutes($oldestProcessingMedia->created_at) > 10) {
-                if(config('federation.activitypub.delivery.logger.enabled')) {
-                    Log::warning('Media processing timeout for status ' . $this->status->id . '. Proceeding with federation.');
-                }
-                $this->dispatchFederation();
-                return;
-            }
-
-            // Release job back to queue with delay of 30 seconds
-            $this->release(30);
-            return;
-        }
-
-        // All media processed, proceed with federation
-        $this->dispatchFederation();
-    }
-
-    /**
-     * Dispatch the federation job
-     *
-     * @return void
-     */
-    protected function dispatchFederation()
-    {
-        try {
-            StatusEntityLexer::dispatch($this->status);
-        } catch (\Exception $e) {
-            if(config('federation.activitypub.delivery.logger.enabled')) {
-                Log::error('Federation dispatch failed for status ' . $this->status->id . ': ' . $e->getMessage());
-            }
-            throw $e;
-        }
-    }
-
-    /**
-     * Handle a job failure.
-     *
-     * @param  \Throwable  $exception
-     * @return void
-     */
-    public function failed(\Throwable $exception)
-    {
-        if(config('federation.activitypub.delivery.logger.enabled')) {
-            Log::error('NewStatusPipeline failed for status ' . $this->status->id, [
-                'exception' => $exception->getMessage(),
-                'trace' => $exception->getTraceAsString()
-            ]);
-        }
+        StatusEntityLexer::dispatch($this->status);
     }
 }

--- a/app/Media.php
+++ b/app/Media.php
@@ -22,8 +22,7 @@ class Media extends Model
     protected $casts = [
         'srcset' => 'array',
         'deleted_at' => 'datetime',
-        'skip_optimize' => 'boolean',
-        'replicated_at' => 'datetime',
+        'skip_optimize' => 'boolean'
     ];
 
     public function status()


### PR DESCRIPTION
This is a straight git revert of the two earlier commits to try to improve the delay before federation. It causes the federation job to fail with "Too many attempts". Since this is behind `media_fast_process = false` which most instances aren't running, this code isn't being exercised well anyways.