### PR TITLE
[Feature]: Limit sessions users active - Pixelfed

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -38,6 +38,8 @@ class Kernel extends HttpKernel
             \App\Http\Middleware\VerifyCsrfToken::class,
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
             \Laravel\Passport\Http\Middleware\CreateFreshApiToken::class,
+            \App\Http\Middleware\RefreshSessionActivity::class,
+
             // 'restricted',
         ],
 

--- a/app/Http/Middleware/RefreshSessionActivity.php
+++ b/app/Http/Middleware/RefreshSessionActivity.php
@@ -1,0 +1,39 @@
+<?php
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Support\Facades\Session;
+use App\Services\SessionService;
+
+class RefreshSessionActivity
+{
+    public function handle($request, Closure $next)
+    {
+        if (config('instance.limit_users_active.enabled')) {
+
+            if (auth()->check()) {
+                $sessionId = Session::getId();
+                $activeSessions = SessionService::getActiveSessions();
+
+                if (!isset($activeSessions[$sessionId]) && count($activeSessions) >= config('instance.limit_users_active.max_users_active')) {
+                    if ($request->routeIs('waiting-room')) {
+                        return $next($request);
+                    }
+                    return redirect()->route('waiting-room');
+                }
+
+                SessionService::setActiveSession($sessionId, auth()->id());
+
+                if ($request->routeIs('waiting-room') ) {
+                    return redirect()->to(route('home'));
+                }
+            }
+        } else {
+            if ($request->routeIs('waiting-room')) {
+                return redirect()->to(route('home'));
+            }
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Services/SessionService.php
+++ b/app/Services/SessionService.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Services;
+
+
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Session;
+
+class SessionService
+{
+    const CACHE_KEY = 'pf:services:session:active_sessions';
+
+    public static function getActiveSessions()
+    {
+        $activeSessions = Cache::get(self::CACHE_KEY, []);
+        $activeSessions = array_filter(
+            $activeSessions, function ($session) {
+                return $session['last_seen'] > now()->subMinutes(
+                    config('instance.limit_users_active.user_session_timeout')
+                )->timestamp;
+            }
+        );
+        Cache::put(self::CACHE_KEY, $activeSessions, now()->addMinutes(config('instance.limit_users_active.user_session_timeout')));
+        return $activeSessions;
+    }
+
+    public static function setActiveSession($sessionId, $userId)
+    {
+        $activeSessions = self::getActiveSessions();
+        $activeSessions[$sessionId] = [
+            'user_id' => $userId,
+            'last_seen' => now()->timestamp,
+        ];
+        Cache::put(self::CACHE_KEY, $activeSessions, now()->addMinutes(config('instance.limit_users_active.user_session_timeout')));
+    }
+
+    public static function removeActiveSession($sessionId)
+    {
+        $activeSessions = self::getActiveSessions();
+        unset($activeSessions[$sessionId]);
+        Cache::put(self::CACHE_KEY, $activeSessions, now()->addMinutes(config('instance.limit_users_active.user_session_timeout')));
+    }
+    public static function getTotalActiveSessions()
+    {
+        $activeSessions = self::getActiveSessions();
+        return count($activeSessions);
+    }
+
+}

--- a/config/instance.php
+++ b/config/instance.php
@@ -264,4 +264,10 @@ return [
          */
         'max_updates_per_hour' => env('PF_CF_MAX_UPDATES_PER_HOUR', 40),
     ],
+
+    'limit_users_active' =>[
+        'enabled' => env('LIMIT_USERS_ACTIVE', false),
+        'max_users_active' => env('MAX_USER_ACTIVE', 100),
+        'user_session_timeout' => env('USER_SESSION_TIMEOUT', 15), // in minutes
+    ]
 ];

--- a/resources/views/waiting-room.blade.php
+++ b/resources/views/waiting-room.blade.php
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>We Are Full 😔</title>
+    <meta http-equiv="refresh" content="300">
+    <script>
+        document.addEventListener("DOMContentLoaded", function() {
+            let countdown = 300; // 5 minutes in seconds
+            const timerElement = document.getElementById("timer");
+
+            function updateTimer() {
+                const minutes = Math.floor(countdown / 60);
+                const seconds = countdown % 60;
+                timerElement.textContent = `${minutes}:${seconds.toString().padStart(2, '0')}`;
+                if (countdown > 0) {
+                    countdown--;
+                    setTimeout(updateTimer, 1000);
+                }
+            }
+
+            updateTimer();
+        });
+    </script>
+</head>
+<body style="text-align:center; padding: 40px;">
+    <div style="display: flex; justify-content: center; align-items: center; height: 90vh; flex-direction: column;">
+        <img src="{{ asset('/img/pixelfed-icon-color.svg') }}" alt="Pixelfed Logo" >
+        <h1>😓 The system is at full capacity.</h1>
+        <p>Please wait a few minutes and try again.</p>
+        <p>Time to reload the page: <span id="timer">5:00</span></p>
+    </div>
+</body>
+</html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -6,6 +6,9 @@ Route::domain(config('pixelfed.domain.app'))->middleware(['validemail', 'twofact
     Route::get('web/directory', 'LandingController@directoryRedirect');
     Route::get('web/explore', 'LandingController@exploreRedirect');
     Route::get('authorize_interaction', 'AuthorizeInteractionController@get');
+    Route::get('/waiting-room', function () {
+        return response()->view('waiting-room', [], 503);
+    })->name('waiting-room');
 
     Auth::routes();
     Route::get('auth/raw/mastodon/start', 'RemoteAuthController@startRedirect');


### PR DESCRIPTION
## ✨ Feature: Limit Active User Sessions

This PR introduces a new optional feature that **limits the maximum number of active user sessions** in the system. The goal is to prevent system overload during peak times by controlling access based on active sessions and inactivity duration.

---

### ✅ Behavior

- **Active session limit:**
  - When the maximum number of active sessions is reached, **no new logins will be allowed**.
  - Users attempting to log in during this period will see a **"system at full capacity"** message.

- **Inactive sessions:**
  - Users who were previously logged in but became inactive (no requests for a certain time) and return during a peak moment will be **redirected to a waiting room page** (`/waiting-room`).

- **Waiting room page:**
  - The page automatically refreshes periodically, trying to reconnect users as soon as slots become available.

---

### ⚙️ Environment Configuration (`.env`)

This feature is **disabled by default** and can be activated and configured through environment variables:

| Variable                 | Description                                                                                   | Default |
|--------------------------|-----------------------------------------------------------------------------------------------|---------|
| `LIMIT_USERS_ACTIVE`     | Enables (`true`) or disables (`false`) the active user session limit.                        | `false` |
| `MAX_USER_ACTIVE`        | Maximum number of concurrent active sessions allowed.                                        | `100`   |
| `USER_SESSION_TIMEOUT`   | Time in minutes of inactivity before a session is considered expired and cleaned up.         | `15`    |

---

### 🧪 Technical Behavior

- On each authenticated request:
  - The user's `last_seen` timestamp is updated.
  - Expired sessions are automatically removed based on `USER_SESSION_TIMEOUT`.
  - If the number of active sessions exceeds `MAX_USER_ACTIVE`:
    - New login attempts are blocked.
    - Inactive users returning to the system are redirected to the waiting room.

---

### 🔒 Security & Scalability

- Session logic is handled via Laravel’s `Cache` system (compatible with Redis, Memcached, etc.).
- The feature is **opt-in** and does not affect systems unless explicitly enabled.

---

### 📂 Components Involved

- `RefreshSessionActivity` – Middleware responsible for managing and tracking active sessions.
- `waiting-room.blade.php` – A simple waiting page with auto-refresh behavior.
- Login flow updates to block new sessions when the limit is exceeded.

