### PR TITLE
Fix id domain mismatch

### DIFF
--- a/app/Util/ActivityPub/Helpers.php
+++ b/app/Util/ActivityPub/Helpers.php
@@ -554,9 +554,7 @@ class Helpers
         $idDomain = parse_url($id, PHP_URL_HOST);
         $urlDomain = parse_url($url, PHP_URL_HOST);
 
-        return $idDomain &&
-               $urlDomain &&
-               strtolower($idDomain) === strtolower($urlDomain);
+        return $idDomain && $urlDomain;
     }
 
     /**
@@ -586,13 +584,12 @@ class Helpers
      */
     public static function storeStatus(string $url, Profile $profile, array $activity): Status
     {
-        $originalUrl = $url;
         $id = self::getStatusId($activity, $url);
         $url = self::getStatusUrl($activity, $id);
 
         if ((! isset($activity['type']) ||
              in_array($activity['type'], ['Create', 'Note'])) &&
-            ! self::validateStatusDomains($originalUrl, $id, $url)) {
+            ! self::validateStatusDomains($id, $url)) {
             throw new \Exception('Invalid status domains');
         }
 
@@ -647,20 +644,11 @@ class Helpers
     }
 
     /**
-     * Validate status domain consistency
+     * Validate the status URL and ID are valid
      */
-    public static function validateStatusDomains(string $originalUrl, string $id, string $url): bool
+    public static function validateStatusDomains(string $id, string $url): bool
     {
-        if (! self::validateUrl($id) || ! self::validateUrl($url)) {
-            return false;
-        }
-
-        $originalDomain = parse_url($originalUrl, PHP_URL_HOST);
-        $idDomain = parse_url($id, PHP_URL_HOST);
-        $urlDomain = parse_url($url, PHP_URL_HOST);
-
-        return strtolower($originalDomain) === strtolower($idDomain) &&
-               strtolower($originalDomain) === strtolower($urlDomain);
+        return self::validateUrl($id) && self::validateUrl($url);
     }
 
     /**


### PR DESCRIPTION
For an ActivityStream object, such as a note, the code currently validates
the domain of the object id, matches the domain of the object url.
However, the current implementation of threads has objects where the id is
threads.net/ap/... and the url is www.threads.com/...
The AS spec does not guarantee any particular relationship between the
id and url. The only requirement is that the id is globally unique.
Additionally, mastodon also does not appear to require the domains to
match

See https://github.com/search?q=repo%3Amastodon%2Fmastodon%20non_matching_uri_hosts&type=code for the relevant mastodon code search

# Test plan
Without the fix, this code fails:
```
use App\Util\ActivityPub\Helpers;
$url = "https://threads.net/ap/users/17841405938254630/post/17932512083907949/";
Helpers::createStatusFromUrl($url, false);
```

after the fix, `createStatusFromUrl` returns true

You can use docker pull ghcr.io/intentionally-left-nil/pixelfed-fpm:0.12.5-fix-id-url-check to test the fix

# Security concerns
I do think this PR deserves extra care and attention to make sure it's doing the right thing. I can't find any reference as to why this check was added in the first place. Here is the original commit: https://github.com/pixelfed/pixelfed/commit/fb0bb9a34f63b58eb2729e3fc0ddbec8e26c2068

As mentioned earlier, I also can't find any mention in the ActivityStream spec that indicates that this domain check _should_match. However, the spec leaves security considerations largely outside the spec, so there could be a reason to keep this. @dansup can you provide more information as to why the domain check exists here? Can you also double check what other ActivityStream clients do, to ensure we're in alignment with the broader ecosystem? 