### PR TITLE
generate gif thumbnail

### DIFF
--- a/app/Http/Controllers/ComposeController.php
+++ b/app/Http/Controllers/ComposeController.php
@@ -35,6 +35,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Str;
 use League\Fractal;
 use League\Fractal\Serializer\ArraySerializer;
+use App\Jobs\ImageOptimizePipeline\ImageGifThumbnail;
 
 class ComposeController extends Controller
 {
@@ -142,6 +143,10 @@ class ComposeController extends Controller
                 VideoThumbnail::dispatch($media)->onQueue('mmo');
                 $preview_url = '/storage/no-preview.png';
                 $url = '/storage/no-preview.png';
+                break;
+
+            case 'image/gif':
+                ImageGifThumbnail::dispatch($media)->onQueue('mmo');
                 break;
 
             default:

--- a/app/Jobs/ImageOptimizePipeline/ImageGifThumbnail.php
+++ b/app/Jobs/ImageOptimizePipeline/ImageGifThumbnail.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Jobs\ImageOptimizePipeline;
+
+use App\Media;
+use FFMpeg;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+class ImageGifThumbnail implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    protected $media;
+
+    /**
+     * Delete the job if its models no longer exist.
+     *
+     * @var bool
+     */
+    public $deleteWhenMissingModels = true;
+
+    /**
+     * Create a new job instance.
+     *
+     * @return void
+     */
+    public function __construct(Media $media)
+    {
+        $this->media = $media;
+    }
+
+    /**
+     * Execute the job.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $media = $this->media;
+
+        if (!$media) {
+            error("Media not found in ImageGifThumbnail job.\n");
+            return;
+        }
+
+        $path = storage_path('app/' . $media->media_path);
+
+        if (!is_file($path)) {
+            error("Tried gerenerate thmbnail to media that does not exist or is not readable: $path \n");
+            return;
+        }
+
+        $pathInfo = pathinfo($media->media_path);
+        $thumbPath = $pathInfo['dirname'] . '/' . $pathInfo['filename'] . '_thumb.png';
+
+        FFMpeg::fromDisk(config('filesystems.default'))
+            ->open($media->media_path)
+            ->getFrameFromSeconds(1)
+            ->export()
+            ->save($thumbPath);
+
+        $media->update([
+            'thumbnail_path' => $thumbPath
+        ]);
+    }
+}


### PR DESCRIPTION
## Description

This PR adds an **asynchronous Job** that automatically generates a **thumbnail** for GIF files.

✅ This enhancement resolves an issue where certain parts of the system could not properly display GIF content due to the **lack of a preview thumbnail**.

### Fixed issues:
- **#6021**: Legacy UI failed to render GIF content correctly.
- Admin panel: Media list showed raw GIFs without preview thumbnails.

With this Job, GIFs will now automatically have a **static preview image**, ensuring:
- Better compatibility.
- Improved system performance.
- More consistent user experience.

---

### Summary of changes:
- Added new Job for GIF thumbnail generation.
- Uses `pbmedia/laravel-ffmpeg` for frame extraction.
- Automatically updates the media model with `thumbnail_path`.

