### PR TITLE
feat: default unlist not pixelfed insntance

### DIFF
--- a/config/federation.php
+++ b/config/federation.php
@@ -61,4 +61,14 @@ return [
     ],
 
     'migration' => env('PF_ACCT_MIGRATION_ENABLED', true),
+
+    'pixelfed_only' => [
+        'enabled' => env('PIXELFED_ONLY', false),
+        'exceptions' => [
+            // Add here the domains or identifiers that should be exceptions
+            // Example:
+            // 'example.com',
+            // 'anotherdomain.org',
+        ],
+    ],
 ];


### PR DESCRIPTION
### 🚀 PR Description

This PR implements a new **instance filtering feature** that allows Pixelfed to display **only instances running the Pixelfed software** in the global feed.

Instances using other software (such as Mastodon, Misskey, etc.) will automatically be marked as `unlisted` and, therefore, **will not appear in the global feed**, even if they are federating normally.

---

### ⚙️ Behavior and Exceptions

If you need to display a non-Pixelfed instance, it can be manually set as listed via the admin panel.  
However, if the verification process runs again, that instance may be marked as `unlisted` once more.

To prevent this, simply add the remote domain to the exception list in the `pixelfed_only` configuration:

```php
'pixelfed_only' => [
    'enabled' => env('PIXELFED_ONLY', false),
    'exceptions' => [
        // Add here the domains you want to allow
        // Example:
        // 'example.com',
        // 'anotherdomain.org',
    ],
],
```

Follow me in Pixelfed Brasil: [@eufelipemateus@pixelfed.com.br](https://pixelfed.com.br/eufelipemateus)