### PR TITLE
fix: ordery by statutes profile

### DIFF
--- a/app/Http/Controllers/PublicApiController.php
+++ b/app/Http/Controllers/PublicApiController.php
@@ -720,7 +720,7 @@ class PublicApiController extends Controller
             })
             ->whereIn('type', $scope)
             ->whereIn('scope', $visibility)
-            ->orderByDesc('id')
+            ->orderByDesc('created_at')
             ->cursorPaginate($remainingLimit)
             ->withQueryString();
 


### PR DESCRIPTION
## Description:
Currently, posts on a user's profile are ordered by _**id**_. This causes remote posts  which are synced at different times  to appear out of order, based on the time they were imported rather than when they were originally published.

This PR fixes that by ordering posts using _**created_at**_. With this small change, both local and remote posts are displayed in proper chronological order on the profile, improving the user experience and preserving a coherent timeline.

# 

Follow me in Pixelfed Brasil [@eufelipemateus@pixelfed.com.br](https://pixelfed.com.br/eufelipemateus)