### PR TITLE
Update DDEV PHP, MariaDB and Redis versions

### DIFF
--- a/.ddev/addon-metadata/redis/manifest.yaml
+++ b/.ddev/addon-metadata/redis/manifest.yaml
@@ -1,0 +1,38 @@
+name: redis
+repository: ddev/ddev-redis
+version: v2.1.2
+install_date: "2025-09-18T23:53:47+01:00"
+project_files:
+    - docker-compose.redis.yaml
+    - redis/scripts/settings.ddev.redis.php
+    - redis/scripts/setup-drupal-settings.sh
+    - redis/scripts/setup-redis-optimized-config.sh
+    - redis/redis.conf
+    - redis/advanced.conf
+    - redis/append.conf
+    - redis/general.conf
+    - redis/io.conf
+    - redis/memory.conf
+    - redis/network.conf
+    - redis/security.conf
+    - redis/snapshots.conf
+    - commands/host/redis-backend
+    - commands/redis/redis-cli
+    - commands/redis/redis-flush
+global_files: []
+removal_actions:
+    - |
+      #ddev-description:Remove redis settings if applicable
+      files=(
+        "${DDEV_APPROOT}/${DDEV_DOCROOT}/sites/default/settings.ddev.redis.php"
+        "${DDEV_APPROOT}/.ddev/docker-compose.redis_extra.yaml"
+      )
+      for file in "${files[@]}"; do
+        if [ -f "$file" ]; then
+          if grep -q '#ddev-generated' "$file"; then
+            rm -f "$file"
+          else
+            echo "Unwilling to remove '$file' because it does not have #ddev-generated in it; you can manually delete it if it is safe to delete."
+          fi
+        fi
+      done

--- a/.ddev/commands/host/redis-backend
+++ b/.ddev/commands/host/redis-backend
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+#ddev-generated
+
+## Description: Use a different key-value store for Redis
+## Usage: redis-backend <image> [optimize]
+## Example: ddev redis-backend redis-alpine optimize
+
+REDIS_DOCKER_IMAGE=${1:-}
+REDIS_CONFIG=${2:-}
+NAME=$REDIS_DOCKER_IMAGE
+
+function show_help() {
+  cat <<EOF
+Usage: ddev redis-backend <image|alias> [optimize]
+
+Choose from predefined aliases, or provide any Redis-compatible Docker image.
+Note that not every Docker image can work right away, and you may need to override
+the "command:" in the docker-compose.redis_extra.yaml file
+
+Available aliases:
+  redis            redis:7
+  redis-alpine     redis:7-alpine
+  valkey           valkey/valkey:8
+  valkey-alpine    valkey/valkey:8-alpine
+
+Custom backend:
+  You can specify any Docker image, e.g.:
+    ddev redis-backend redis:6
+
+Optional:
+  optimize         Apply additional Redis configuration with resource limits
+  optimized        Same as optimize
+
+Examples:
+  ddev redis-backend redis-alpine optimize
+  ddev redis-backend valkey
+  ddev redis-backend redis:7.2-alpine
+EOF
+  exit 0
+}
+
+function optimize_config() {
+  [[ "$REDIS_CONFIG" != "optimized" && "$REDIS_CONFIG" != "optimize" ]] && return
+  ddev dotenv set .ddev/.env.redis --redis-optimized=true
+}
+
+function cleanup() {
+  rm -f "$DDEV_APPROOT/.ddev/.env.redis"
+  rm -rf "$DDEV_APPROOT/.ddev/redis/"
+  rm -f "$DDEV_APPROOT/.ddev/docker-compose.redis.yaml" "$DDEV_APPROOT/.ddev/docker-compose.redis_extra.yaml"
+
+  redis_volume="ddev-$(ddev status -j | docker run -i --rm ddev/ddev-utilities jq -r '.raw.name')_redis"
+  if docker volume ls -q | grep -qw "$redis_volume"; then
+    ddev stop
+    docker volume rm "$redis_volume"
+  fi
+}
+
+function check_docker_image() {
+  echo "Pulling ${REDIS_DOCKER_IMAGE}..."
+  if ! docker pull "$REDIS_DOCKER_IMAGE"; then
+    echo >&2 "❌ Unable to pull ${REDIS_DOCKER_IMAGE}"
+    exit 2
+  fi
+}
+
+function use_docker_image() {
+  [[ "$REDIS_DOCKER_IMAGE" != "redis:7" ]] && ddev dotenv set .ddev/.env.redis --redis-docker-image="$REDIS_DOCKER_IMAGE"
+  REPO=$(ddev add-on list --installed -j 2>/dev/null | docker run -i --rm ddev/ddev-utilities jq -r '.raw[] | select(.Name=="redis") | .Repository // empty' 2>/dev/null)
+  ddev add-on get "${REPO:-ddev/ddev-redis}"
+}
+
+case "$REDIS_DOCKER_IMAGE" in
+  redis)
+    NAME="Redis 7"
+    REDIS_DOCKER_IMAGE="redis:7"
+    ;;
+  redis-alpine)
+    NAME="Redis 7 Alpine"
+    REDIS_DOCKER_IMAGE="redis:7-alpine"
+    ;;
+  valkey)
+    NAME="Valkey 8"
+    REDIS_DOCKER_IMAGE="valkey/valkey:8"
+    ;;
+  valkey-alpine)
+    NAME="Valkey 8 Alpine"
+    REDIS_DOCKER_IMAGE="valkey/valkey:8-alpine"
+    ;;
+  ""|--help|-h)
+    show_help
+    ;;
+  *)
+    NAME="$REDIS_DOCKER_IMAGE"
+    # Allow unknown image, nothing to override
+    ;;
+esac
+
+check_docker_image
+cleanup
+optimize_config
+use_docker_image
+
+echo
+echo "✅ Redis backend: $REDIS_DOCKER_IMAGE"
+if [[ "$REDIS_CONFIG" == "optimized" || "$REDIS_CONFIG" == "optimize" ]]; then
+  echo "⚙️ Redis config: optimized"
+else
+  echo "⚙️ Redis config: default"
+fi
+
+echo
+echo "📝 Commit the '.ddev' directory to version control"
+
+echo
+echo "🔄 Redis config available after 'ddev restart'"

--- a/.ddev/commands/redis/redis-cli
+++ b/.ddev/commands/redis/redis-cli
@@ -1,7 +1,13 @@
-#!/bin/bash
-#ddev-generated
-## Description: Run redis-cli inside the redis container
-## Usage: redis-cli [flags] [args]
-## Example: "redis-cli KEYS *" or "ddev redis-cli INFO" or "ddev redis-cli --version"
+#!/usr/bin/env sh
 
-exec redis-cli -p 6379 -h redis "$@"
+#ddev-generated
+## Description: Run redis-cli inside the Redis container
+## Usage: redis-cli [flags] [args]
+## Example: "ddev redis-cli KEYS *" or "ddev redis-cli INFO" or "ddev redis-cli --version"
+## Aliases: redis
+
+if [ -f /etc/redis/conf/security.conf ]; then
+  redis-cli -p 6379 -h redis -a redis --no-auth-warning $@
+else
+  redis-cli -p 6379 -h redis $@
+fi

--- a/.ddev/commands/redis/redis-flush
+++ b/.ddev/commands/redis/redis-flush
@@ -1,0 +1,12 @@
+#!/usr/bin/env sh
+
+#ddev-generated
+## Description: Flush all cache inside the Redis container
+## Usage: redis-flush
+## Example: "ddev redis-flush"
+
+if [ -f /etc/redis/conf/security.conf ]; then
+  redis-cli -p 6379 -h redis -a redis --no-auth-warning FLUSHALL ASYNC
+else
+  redis-cli -p 6379 -h redis FLUSHALL ASYNC
+fi

--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -1,17 +1,18 @@
 type: laravel
 docroot: public
-php_version: "8.1"
+php_version: "8.4"
 webserver_type: nginx-fpm
 database:
   type: mariadb
-  version: "10.4"
+  version: "11.8"
 disable_settings_management: true
 web_environment:
-  - DB_CONNECTION=mysql
+  - DB_CONNECTION=mariadb
   - DB_HOST=ddev-pixelfed-db
   - DB_DATABASE=db
   - DB_USERNAME=db
   - DB_PASSWORD=db
+  - REDIS_CLIENT=phpredis
   - REDIS_HOST=ddev-pixelfed-redis
   - MAIL_DRIVER=smtp
   - MAIL_HOST=localhost
@@ -19,7 +20,6 @@ web_environment:
   - MAIL_USERNAME=null
   - MAIL_PASSWORD=null
   - MAIL_ENCRYPTION=null
-  - APP_KEY=placeholder
   - APP_NAME=PixelfedTest
   - APP_ENV=local
   - APP_KEY=base64:lwX95GbNWX3XsucdMe0XwtOKECta3h/B+p9NbH2jd0E=

--- a/.ddev/docker-compose.redis.yaml
+++ b/.ddev/docker-compose.redis.yaml
@@ -1,14 +1,21 @@
 #ddev-generated
-version: '3.6'
 services:
   redis:
     container_name: ddev-${DDEV_SITENAME}-redis
-    image: redis:6
+    image: ${REDIS_DOCKER_IMAGE:-redis:7}
     # These labels ensure this service is discoverable by ddev.
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}
-      com.ddev.approot: $DDEV_APPROOT
+      com.ddev.approot: ${DDEV_APPROOT}
+    restart: "no"
+    expose:
+      - 6379
     volumes:
-    - ".:/mnt/ddev_config"
-    - "./redis:/usr/local/etc/redis"
-    command: ["redis-server", "/usr/local/etc/redis/redis.conf"]
+      - ".:/mnt/ddev_config"
+      - "ddev-global-cache:/mnt/ddev-global-cache"
+      - "./redis:/etc/redis/conf"
+      - "redis:/data"
+    command: /etc/redis/conf/redis.conf
+
+volumes:
+  redis:

--- a/.ddev/redis/redis.conf
+++ b/.ddev/redis/redis.conf
@@ -6,3 +6,8 @@
 
 maxmemory 2048mb
 maxmemory-policy allkeys-lfu
+
+# to disable Redis persistence, remove ddev-generated from this file,
+# and uncomment the two lines below:
+#appendonly no
+#save ""


### PR DESCRIPTION
The current DDEV config isn't compatible with the composer requirements (PHP > 8.2). This bumps the versions of PHP (8.4), MariaDB (11.8) and Redis (7), as well as tweaking the environment variable overrides to use the `mariadb` database connection and the `phpredis` extension, rather than the `predis` library.