### PR TITLE
Make autolink test URLs environment-agnostic

### DIFF
--- a/tests/Unit/Lexer/StatusLexerTest.php
+++ b/tests/Unit/Lexer/StatusLexerTest.php
@@ -61,7 +61,7 @@ class StatusLexerTest extends TestCase
     #[Test]
     public function autolink()
     {
-        $expected = '<a class="u-url mention" href="https://pixelfed.dev/pixelfed" rel="external nofollow noopener" target="_blank">@pixelfed</a> hi, really like the website! <a href="https://pixelfed.dev/discover/tags/píxelfed?src=hash" title="#píxelfed" class="u-url hashtag" rel="external nofollow noopener">#píxelfed</a>';
+        $expected = '<a class="u-url mention" href="' . config('app.url') . '/pixelfed" rel="external nofollow noopener" target="_blank">@pixelfed</a> hi, really like the website! <a href="' . config('app.url') . '/discover/tags/píxelfed?src=hash" title="#píxelfed" class="u-url hashtag" rel="external nofollow noopener">#píxelfed</a>';
         $this->assertEquals($this->autolink, $expected);
     }
 

--- a/tests/Unit/Lexer/UsernameTest.php
+++ b/tests/Unit/Lexer/UsernameTest.php
@@ -15,7 +15,7 @@ class UsernameTest extends TestCase
         $username = '@dansup';
         $entities = Extractor::create()->extract($username);
         $autolink = Autolink::create()->autolink($username);
-        $expectedAutolink = '<a class="u-url mention" href="https://pixelfed.dev/dansup" rel="external nofollow noopener" target="_blank">@dansup</a>';
+        $expectedAutolink = '<a class="u-url mention" href="' . config('app.url') . '/dansup" rel="external nofollow noopener" target="_blank">@dansup</a>';
         $expectedEntity = [
             'hashtags' => [],
             'urls' => [],
@@ -45,7 +45,7 @@ class UsernameTest extends TestCase
         $username = '@dansup.two';
         $autolink = Autolink::create()->autolink($username);
         $entities = Extractor::create()->extract($username);
-        $expectedAutolink = '<a class="u-url mention" href="https://pixelfed.dev/dansup.two" rel="external nofollow noopener" target="_blank">@dansup.two</a>';
+        $expectedAutolink = '<a class="u-url mention" href="' . config('app.url') . '/dansup.two" rel="external nofollow noopener" target="_blank">@dansup.two</a>';
         $expectedEntity = [
             'hashtags' => [],
             'urls' => [],
@@ -75,7 +75,7 @@ class UsernameTest extends TestCase
         $username = '@dansup-too';
         $autolink = Autolink::create()->autolink($username);
         $entities = Extractor::create()->extract($username);
-        $expectedAutolink = '<a class="u-url mention" href="https://pixelfed.dev/dansup-too" rel="external nofollow noopener" target="_blank">@dansup-too</a>';
+        $expectedAutolink = '<a class="u-url mention" href="' . config('app.url') . '/dansup-too" rel="external nofollow noopener" target="_blank">@dansup-too</a>';
         $expectedEntity = [
             'hashtags' => [],
             'urls' => [],
@@ -105,7 +105,7 @@ class UsernameTest extends TestCase
         $username = '@dansup_too';
         $autolink = Autolink::create()->autolink($username);
         $entities = Extractor::create()->extract($username);
-        $expectedAutolink = '<a class="u-url mention" href="https://pixelfed.dev/dansup_too" rel="external nofollow noopener" target="_blank">@dansup_too</a>';
+        $expectedAutolink = '<a class="u-url mention" href="' . config('app.url') . '/dansup_too" rel="external nofollow noopener" target="_blank">@dansup_too</a>';
         $expectedEntity = [
             'hashtags' => [],
             'urls' => [],
@@ -135,7 +135,7 @@ class UsernameTest extends TestCase
         $text = 'hello @dansup and @pixelfed.team from @username_underscore';
         $autolink = Autolink::create()->autolink($text);
         $entities = Extractor::create()->extract($text);
-        $expectedAutolink = 'hello <a class="u-url mention" href="https://pixelfed.dev/dansup" rel="external nofollow noopener" target="_blank">@dansup</a> and <a class="u-url mention" href="https://pixelfed.dev/pixelfed.team" rel="external nofollow noopener" target="_blank">@pixelfed.team</a> from <a class="u-url mention" href="https://pixelfed.dev/username_underscore" rel="external nofollow noopener" target="_blank">@username_underscore</a>';
+        $expectedAutolink = 'hello <a class="u-url mention" href="' . config('app.url') . '/dansup" rel="external nofollow noopener" target="_blank">@dansup</a> and <a class="u-url mention" href="' . config('app.url') . '/pixelfed.team" rel="external nofollow noopener" target="_blank">@pixelfed.team</a> from <a class="u-url mention" href="' . config('app.url') . '/username_underscore" rel="external nofollow noopener" target="_blank">@username_underscore</a>';
         $expectedEntity = [
             'hashtags' => [],
             'urls' => [],
@@ -182,7 +182,7 @@ class UsernameTest extends TestCase
         $mentions = "@März and @königin and @Glück";
         $autolink = Autolink::create()->autolink($mentions);
 
-        $expectedAutolink = '<a class="u-url mention" href="https://pixelfed.dev/März" rel="external nofollow noopener" target="_blank">@März</a> and <a class="u-url mention" href="https://pixelfed.dev/königin" rel="external nofollow noopener" target="_blank">@königin</a> and <a class="u-url mention" href="https://pixelfed.dev/Glück" rel="external nofollow noopener" target="_blank">@Glück</a>';
+        $expectedAutolink = '<a class="u-url mention" href="' . config('app.url') . '/März" rel="external nofollow noopener" target="_blank">@März</a> and <a class="u-url mention" href="' . config('app.url') . '/königin" rel="external nofollow noopener" target="_blank">@königin</a> and <a class="u-url mention" href="' . config('app.url') . '/Glück" rel="external nofollow noopener" target="_blank">@Glück</a>';
         $this->assertEquals($expectedAutolink, $autolink);
     }
 
@@ -236,7 +236,7 @@ class UsernameTest extends TestCase
         $mentions = "hello @märz@example.org!";
         $autolink = Autolink::create()->autolink($mentions);
 
-        $expectedAutolink = 'hello <a class="u-url list-slug" href="https://pixelfed.dev/@märz@example.org" rel="external nofollow noopener" target="_blank">@märz@example.org</a>!';
+        $expectedAutolink = 'hello <a class="u-url list-slug" href="' . config('app.url') . '/@märz@example.org" rel="external nofollow noopener" target="_blank">@märz@example.org</a>!';
         $this->assertEquals($expectedAutolink, $autolink);
     }
 }


### PR DESCRIPTION
Currently the tests that involve link generation (`StatusLexerTest` and `UsernameTest`) will fail when run under a test environment that doesn't use the `https://pixelfed.dev` domain (DDEV, for instance). This PR alters the tests to use `config('app.url')`, as used by the `Autolink` implementation code, instead. 