### PR TITLE
Fix null dereference error when updating the sharedInbox 

### DIFF
--- a/app/Jobs/ProfilePipeline/HandleUpdateActivity.php
+++ b/app/Jobs/ProfilePipeline/HandleUpdateActivity.php
@@ -47,8 +47,9 @@ class HandleUpdateActivity implements ShouldQueue
             return;
         }
 
-        if ($profile->sharedInbox == null || $profile->sharedInbox != $payload['object']['endpoints']['sharedInbox']) {
-            $profile->sharedInbox = $payload['object']['endpoints']['sharedInbox'];
+        $sharedInbox = isset($payload['object']['endpoints']['sharedInbox']) ? $payload['object']['endpoints']['sharedInbox'] : null;
+        if ($profile->sharedInbox !== $sharedInbox) {
+            $profile->sharedInbox = $sharedInbox;
         }
 
         if ($profile->public_key !== $payload['object']['publicKey']['publicKeyPem']) {


### PR DESCRIPTION
# Summary
The old code assumes that all update messages have an endpoints key. However, both the endpoints key, as well as the sharedInbox may be missing or null per spec. This commit fixes the bug by using isset to check for the key to exist, otherwise coalescing it to null

server to server update messages are PUT operations, not PATCH, so if the sharedInbox is missing in the update, it should always be removed (if previously set).

# Spec references
https://www.w3.org/TR/activitypub/#update-activity-inbox

>7.3 Update Activity
>
>For server to server interactions, an Update activity means that the receiving server SHOULD update its copy of the >object of the same id to the copy supplied in the Update activity. Unlike the[ client to server handling of the Update >activity](https://www.w3.org/TR/activitypub/#update-activity-outbox), this is not a partial update but a complete >replacement of the object.
>
>The receiving server MUST take care to be sure that the Update is authorized to modify its object. At minimum, this may >be done by ensuring that the Update and its object are of same origin.

https://www.w3.org/TR/activitypub/#actors
>Actor objects MUST have, in addition to the properties mandated by [3.1 Object Identifiers](https://www.w3.org/TR/>activitypub/#obj-id), the following properties:
>...
> Implementations SHOULD, in addition, provide the following properties:
>....
> Implementations MAY provide the following properties:
>endpoints
>A json object which maps additional (typically server/domain-wide) endpoints which may be useful either for this actor or someone referencing this actor. This mapping may be nested inside the actor document as the value or may be a link to a JSON-LD document with these properties. 

>The endpoints mapping MAY include the following properties: 
>sharedInbox
>An optional endpoint[ used for wide delivery of publicly addressed activities and activities sent to followers](https://>www.w3.org/TR/activitypub/#shared-inbox-delivery). sharedInbox endpoints SHOULD also be publicly readable >OrderedCollection objects containing objects addressed to the [Public](https://www.w3.org/TR/activitypub/#public->addressing) special collection. Reading from the sharedInbox endpoint MUST NOT present objects which are not >addressed to the Public endpoint.

# Test plan
Manual code inspection for now, needs a separate patch for 0.12.6 since the file has changed since then for docker testing. Given the history of code maintainers not timely reviewing PR's, I am choosing to not test this PR at this time, as it would need to be retested anyways