### PR TITLE
Larastan: Update StatusHashtag.php

### DIFF
--- a/app/StatusHashtag.php
+++ b/app/StatusHashtag.php
@@ -1,6 +1,10 @@
 <?php
 
 namespace App;
+use App\Status;
+use App\Profile;
+use App\Hashtag;
+use App\Media;
 
 use Illuminate\Database\Eloquent\Model;
 


### PR DESCRIPTION
```
 ------ ------------------------------------------------------------ 
  Line   Console/Commands/UpdateCommand.php                          
 ------ ------------------------------------------------------------ 
  53     Relation 'status' is not found in App\StatusHashtag model.  
         🪪  larastan.relationExistence                              
 ------ ------------------------------------------------------------ 
 
 ------ ------------------------------------------------------------- 
  Line   Console/Commands/FixHashtags.php                             
 ------ ------------------------------------------------------------- 
  59     Relation 'profile' is not found in App\StatusHashtag model.  
         🪪  larastan.relationExistence                               
  59     Relation 'status' is not found in App\StatusHashtag model.   
         🪪  larastan.relationExistence                               
  65     Relation 'profile' is not found in App\StatusHashtag model.  
         🪪  larastan.relationExistence                               
  65     Relation 'status' is not found in App\StatusHashtag model.   
         🪪  larastan.relationExistence                               
  92     Relation 'status' is not found in App\StatusHashtag model.   
         🪪  larastan.relationExistence                               
 ------ ------------------------------------------------------------- 
 ```