### PR TITLE
Larastan: Update FixLikes.php

### DIFF
--- a/app/Console/Commands/FixLikes.php
+++ b/app/Console/Commands/FixLikes.php
@@ -40,7 +40,7 @@ class FixLikes extends Command
     public function handle()
     {
         $chunk = 100;
-        $limit = Like::select('status_id')->groupBy('status_id')->get()->count();
+        $limit = Like::select('status_id')->groupBy('status_id')->count();
         
         if($limit > 1000) {
             if($this->confirm('We have found more than 1000 records to update, this may take a few moments. Are you sure you want to continue?') == false) {


### PR DESCRIPTION
```
 ------ --------------------------------------------------------------------------------- 
  Line   Console/Commands/FixLikes.php                                                    
 ------ --------------------------------------------------------------------------------- 
  43     Called 'count' on Laravel collection, but could have been retrieved as a query.  
         🪪  larastan.noUnnecessaryCollectionCall                                         
 ------ --------------------------------------------------------------------------------- 
 ```