### PR TITLE
Larastan: Update Installer.php

### DIFF
--- a/app/Console/Commands/Installer.php
+++ b/app/Console/Commands/Installer.php
@@ -23,6 +23,7 @@ class Installer extends Command
     protected $description = 'CLI Installer';
 
     public $installType = 'Simple';
+    public $continue;
 
     /**
      * Create a new command instance.
@@ -170,7 +171,7 @@ class Installer extends Command
 
         $ffmpeg = exec('which ffmpeg');
         if (empty($ffmpeg)) {
-            $this->error("- \"{$ext}\" FFmpeg not found, aborting installation");
+            $this->error('- FFmpeg not found, aborting installation');
             exit;
         } else {
             $this->info('- Found FFmpeg!');


### PR DESCRIPTION
fixes:
```
 ------ --------------------------------------------------------------------------------------- 
  Line   Console/Commands/Installer.php                                                         
 ------ --------------------------------------------------------------------------------------- 
  158    Access to an undefined property App\Console\Commands\Installer::$continue.             
         🪪  property.notFound                                                                  
         💡  Learn more: https://phpstan.org/blog/solving-phpstan-access-to-undefined-property  
  173    Undefined variable: $ext                                                               
         🪪  variable.undefined                                                                 
 ------ --------------------------------------------------------------------------------------- 
```