### PR TITLE
Larastan: Update SeedFollows.php

### DIFF
--- a/app/Console/Commands/SeedFollows.php
+++ b/app/Console/Commands/SeedFollows.php
@@ -6,6 +6,7 @@ use App\Follower;
 use App\Jobs\FollowPipeline\FollowPipeline;
 use App\Profile;
 use Illuminate\Console\Command;
+use Exception;
 
 class SeedFollows extends Command
 {


### PR DESCRIPTION
fixes
```
 ------ ---------------------------------------------------------------------- 
  Line   Console/Commands/SeedFollows.php                                      
 ------ ---------------------------------------------------------------------- 
  61     Caught class App\Console\Commands\Exception not found.                
         🪪  class.notFound                                                    
         💡  Learn more at https://phpstan.org/user-guide/discovering-symbols  
 ------ ---------------------------------------------------------------------- 
```