### PR TITLE
Larastan: Update DiscoverCategory.php

### DIFF
--- a/app/DiscoverCategory.php
+++ b/app/DiscoverCategory.php
@@ -3,7 +3,7 @@
 namespace App;
 
 use Illuminate\Database\Eloquent\Model;
-use App\{Status, StatusHashtag};
+use App\{Status, StatusHashtag, Media};
 
 class DiscoverCategory extends Model
 {


### PR DESCRIPTION
Fixed
```
 ------ --------------------------------------------------------------------------------------- 
  Line   DiscoverCategory.php                                                                   
 ------ --------------------------------------------------------------------------------------- 
  29     Access to an undefined property App\DiscoverCategory::$media.                          
         🪪  property.notFound                                                                  
         💡  Learn more: https://phpstan.org/blog/solving-phpstan-access-to-undefined-property  
  34     Access to an undefined property App\DiscoverCategory::$media.                          
         🪪  property.notFound                                                                  
         💡  Learn more: https://phpstan.org/blog/solving-phpstan-access-to-undefined-property  
 ------ --------------------------------------------------------------------------------------- 
```
