### PR TITLE
Larastan: Update FederationController.php

### DIFF
--- a/app/Http/Controllers/FederationController.php
+++ b/app/Http/Controllers/FederationController.php
@@ -166,7 +166,7 @@ class FederationController extends Controller
 
         $headers = $request->headers->all();
         $payload = $request->getContent();
-        if (! $payload || empty($payload)) {
+        if (! $payload) {
             return;
         }
         $obj = json_decode($payload, true, 8);
@@ -220,7 +220,7 @@ class FederationController extends Controller
         $headers = $request->headers->all();
         $payload = $request->getContent();
 
-        if (! $payload || empty($payload)) {
+        if (! $payload) {
             return;
         }
 


### PR DESCRIPTION
Fix
```
 ------ -------------------------------------------------------------- 
  Line   Http/Controllers/FederationController.php                     
 ------ -------------------------------------------------------------- 
  169    Variable $payload in empty() always exists and is not falsy.  
         🪪  empty.variable                                            
  223    Variable $payload in empty() always exists and is not falsy.  
         🪪  empty.variable                                            
 ------ -------------------------------------------------------------- 
```