### PR TITLE
Larastan: Update Inbox.php

### DIFF
--- a/app/Util/ActivityPub/Inbox.php
+++ b/app/Util/ActivityPub/Inbox.php
@@ -637,7 +637,7 @@ class Inbox
 
         $parent = Helpers::statusFetch($activity);
 
-        if (! $parent || empty($parent)) {
+        if (! $parent) {
             return;
         }
 


### PR DESCRIPTION
Fix
```
 640    Variable $parent in empty() always exists and is not falsy.                               
         🪪  empty.variable  
```