### PR TITLE
Larastan: Update HttpSignature.php

### DIFF
--- a/app/Util/ActivityPub/HttpSignature.php
+++ b/app/Util/ActivityPub/HttpSignature.php
@@ -80,7 +80,7 @@ class HttpSignature
 
             return $instance->private_key;
         });
-        abort_if(! $privateKey || empty($privateKey), 400, 'Missing instance actor key, please run php artisan instance:actor');
+        abort_if(! $privateKey, 400, 'Missing instance actor key, please run php artisan instance:actor');
         if ($body) {
             $digest = self::_digest($body);
         }


### PR DESCRIPTION
fix
```
------ ----------------------------------------------------------------- 
  Line   Util/ActivityPub/HttpSignature.php                               
 ------ ----------------------------------------------------------------- 
  83     Variable $privateKey in empty() always exists and is not falsy.  
         🪪  empty.variable                                               
 ------ ----------------------------------------------------------------- 
```