### PR TITLE
Refactor: Migrate Intervention/image to Intervention/image-laravel

### DIFF
--- a/app/Http/Controllers/StoryComposeController.php
+++ b/app/Http/Controllers/StoryComposeController.php
@@ -19,6 +19,7 @@ use App\Services\StoryService;
 use App\Services\UserRoleService;
 use App\Status;
 use App\Story;
+use App\Util\Media\ImageDriverManager;
 use FFMpeg;
 use Illuminate\Http\Request;
 use Illuminate\Support\Str;
@@ -33,18 +34,7 @@ class StoryComposeController extends Controller
 
     public function __construct()
     {
-        $driver = match (config('image.driver')) {
-            'imagick' => \Intervention\Image\Drivers\Imagick\Driver::class,
-            'vips' => \Intervention\Image\Drivers\Vips\Driver::class,
-            default => \Intervention\Image\Drivers\Gd\Driver::class
-        };
-        $this->imageManager = new ImageManager(
-            $driver,
-            autoOrientation: true,
-            decodeAnimation: true,
-            blendingColor: 'ffffff',
-            strip: true
-        );
+        $this->imageManager = ImageDriverManager::createImageManager();
     }
 
     public function apiV1Add(Request $request)

--- a/app/Jobs/AvatarPipeline/AvatarOptimize.php
+++ b/app/Jobs/AvatarPipeline/AvatarOptimize.php
@@ -4,6 +4,7 @@ namespace App\Jobs\AvatarPipeline;
 
 use App\Avatar;
 use App\Profile;
+use App\Util\Media\ImageDriverManager;
 use Cache;
 use Carbon\Carbon;
 use Illuminate\Bus\Queueable;
@@ -57,19 +58,7 @@ class AvatarOptimize implements ShouldQueue
         $fileInfo = pathinfo($file);
         $extension = strtolower($fileInfo['extension'] ?? 'jpg');
 
-        $driver = match(config('image.driver')) {
-            'imagick' => \Intervention\Image\Drivers\Imagick\Driver::class,
-            'vips' => \Intervention\Image\Drivers\Vips\Driver::class,
-            default => \Intervention\Image\Drivers\Gd\Driver::class
-        };
-
-        $imageManager = new ImageManager(
-            $driver,
-            autoOrientation: true,
-            decodeAnimation: true,
-            blendingColor: 'ffffff',
-            strip: true
-        );
+        $imageManager = ImageDriverManager::createImageManager();
 
         $quality = config_cache('pixelfed.image_quality');
 

--- a/app/Jobs/GroupsPipeline/ImageResizePipeline.php
+++ b/app/Jobs/GroupsPipeline/ImageResizePipeline.php
@@ -96,7 +96,7 @@ class ImageResizePipeline implements ShouldQueue
             }
 
             $encoded = $img->encode($encoder);
-            file_put_contents($file, $encoded);
+            file_put_contents($file, $encoded->toString());
 
         } catch (Exception $e) {
             Log::error($e);

--- a/app/Jobs/GroupsPipeline/ImageResizePipeline.php
+++ b/app/Jobs/GroupsPipeline/ImageResizePipeline.php
@@ -3,6 +3,7 @@
 namespace App\Jobs\GroupsPipeline;
 
 use App\Models\GroupMedia;
+use App\Util\Media\ImageDriverManager;
 use Exception;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -75,19 +76,7 @@ class ImageResizePipeline implements ShouldQueue
         ];
 
         try {
-            $driver = match (config('image.driver')) {
-                'imagick' => \Intervention\Image\Drivers\Imagick\Driver::class,
-                'vips' => \Intervention\Image\Drivers\Vips\Driver::class,
-                default => \Intervention\Image\Drivers\Gd\Driver::class
-            };
-
-            $imageManager = new ImageManager(
-                $driver,
-                autoOrientation: true,
-                decodeAnimation: true,
-                blendingColor: 'ffffff',
-                strip: true
-            );
+            $imageManager = ImageDriverManager::createImageManager();
 
             $img = $imageManager->read($file);
 

--- a/app/Jobs/GroupsPipeline/ImageResizePipeline.php
+++ b/app/Jobs/GroupsPipeline/ImageResizePipeline.php
@@ -86,10 +86,7 @@ class ImageResizePipeline implements ShouldQueue
             $orientation = $aspect === 1 ? 'square' : ($aspect > 1 ? 'landscape' : 'portrait');
             $ratio = $orientations[$orientation];
 
-            $img = $img->resize($ratio['width'], $ratio['height'], function ($constraint) {
-                $constraint->aspectRatio();
-                $constraint->upsize();
-            });
+            $img = $img->scaleDown($ratio['width'], $ratio['height']);
 
             $extension = pathinfo($file, PATHINFO_EXTENSION);
             if (in_array(strtolower($extension), ['jpg', 'jpeg'])) {

--- a/app/Util/Media/Image.php
+++ b/app/Util/Media/Image.php
@@ -4,6 +4,7 @@ namespace App\Util\Media;
 
 use App\Media;
 use App\Services\StatusService;
+use App\Util\Media\ImageDriverManager;
 use Cache;
 use Intervention\Image\Encoders\JpegEncoder;
 use Intervention\Image\Encoders\PngEncoder;
@@ -52,19 +53,7 @@ class Image
 
         $this->defaultDisk = config('filesystems.default');
 
-        $driver = match (config('image.driver')) {
-            'imagick' => \Intervention\Image\Drivers\Imagick\Driver::class,
-            'vips' => \Intervention\Image\Drivers\Vips\Driver::class,
-            default => \Intervention\Image\Drivers\Gd\Driver::class
-        };
-
-        $this->imageManager = new ImageManager(
-            $driver,
-            autoOrientation: true,
-            decodeAnimation: true,
-            blendingColor: 'ffffff',
-            strip: true
-        );
+        $this->imageManager = ImageDriverManager::createImageManager();
     }
 
     public function orientations()

--- a/app/Util/Media/ImageDriverManager.php
+++ b/app/Util/Media/ImageDriverManager.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Util\Media;
+
+use Intervention\Image\ImageManager;
+
+class ImageDriverManager
+{
+    /**
+     * Get the appropriate image driver class based on configuration.
+     *
+     * @return string
+     */
+    public static function getDriverClass(): string
+    {
+        return match (config('image.driver')) {
+            'gd' => \Intervention\Image\Drivers\Gd\Driver::class,
+            'imagick' => \Intervention\Image\Drivers\Imagick\Driver::class,
+            'vips' => \Intervention\Image\Drivers\Vips\Driver::class,
+            default => \Intervention\Image\Drivers\Gd\Driver::class
+        };
+    }
+
+    /**
+     * Create a new ImageManager instance with the configured driver.
+     *
+     * @param array $options Additional options for ImageManager
+     * @return ImageManager
+     */
+    public static function createImageManager(array $options = []): ImageManager
+    {
+        $configOptions = config('image.options', []);
+        
+        $options = array_merge($configOptions, $options);
+
+        return new ImageManager(
+            self::getDriverClass(),
+            autoOrientation: $options['autoOrientation'] ?? true,
+            decodeAnimation: $options['decodeAnimation'] ?? true,
+            blendingColor: $options['blendingColor'] ?? 'ffffff',
+            strip: $options['strip'] ?? true
+        );
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "buzz/laravel-h-captcha": "^1.0.4",
         "doctrine/dbal": "^3.0",
         "endroid/qr-code": "^6.0",
-        "intervention/image": "^3.11.2",
+        "intervention/image-laravel": "^1.5",
         "jenssegers/agent": "^2.6",
         "laravel-notification-channels/expo": "^2.0.0",
         "laravel-notification-channels/webpush": "^10.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d4d3258bc9d1e7e2dc5f5e93bced6384",
+    "content-hash": "812ff1563ecbe2478298561f9f2f353a",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -2125,6 +2125,90 @@
                 }
             ],
             "time": "2025-07-30T13:13:19+00:00"
+        },
+        {
+            "name": "intervention/image-laravel",
+            "version": "1.5.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Intervention/image-laravel.git",
+                "reference": "056029431400a5cc56036172787a578f334683c4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Intervention/image-laravel/zipball/056029431400a5cc56036172787a578f334683c4",
+                "reference": "056029431400a5cc56036172787a578f334683c4",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/http": "^8|^9|^10|^11|^12",
+                "illuminate/routing": "^8|^9|^10|^11|^12",
+                "illuminate/support": "^8|^9|^10|^11|^12",
+                "intervention/image": "^3.11",
+                "php": "^8.1"
+            },
+            "require-dev": {
+                "ext-fileinfo": "*",
+                "orchestra/testbench": "^8.18 || ^9.9",
+                "phpunit/phpunit": "^10.0 || ^11.0 || ^12.0"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "Image": "Intervention\\Image\\Laravel\\Facades\\Image"
+                    },
+                    "providers": [
+                        "Intervention\\Image\\Laravel\\ServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Intervention\\Image\\Laravel\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Oliver Vogel",
+                    "email": "oliver@intervention.io",
+                    "homepage": "https://intervention.io/"
+                }
+            ],
+            "description": "Laravel Integration of Intervention Image",
+            "homepage": "https://image.intervention.io/",
+            "keywords": [
+                "gd",
+                "image",
+                "imagick",
+                "laravel",
+                "resize",
+                "thumbnail",
+                "watermark"
+            ],
+            "support": {
+                "issues": "https://github.com/Intervention/image-laravel/issues",
+                "source": "https://github.com/Intervention/image-laravel/tree/1.5.6"
+            },
+            "funding": [
+                {
+                    "url": "https://paypal.me/interventionio",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/Intervention",
+                    "type": "github"
+                },
+                {
+                    "url": "https://ko-fi.com/interventionphp",
+                    "type": "ko_fi"
+                }
+            ],
+            "time": "2025-04-04T15:09:55+00:00"
         },
         {
             "name": "jaybizzle/crawler-detect",

--- a/config/image.php
+++ b/config/image.php
@@ -7,12 +7,40 @@ return [
     | Image Driver
     |--------------------------------------------------------------------------
     |
-    | Intervention Image supports "GD Library" or "Imagick" to process
-    | images internally. You may choose one of them according to your PHP
-    | configuration. By default PHP's "GD Library" implementation is used.
+    | Intervention Image supports “GD Library” and “Imagick” to process images
+    | internally. Depending on your PHP setup, you can choose one of them.
     |
-    | Supported: "gd", "imagick"
+    | Included options:
+    |   - \Intervention\Image\Drivers\Gd\Driver::class
+    |   - \Intervention\Image\Drivers\Imagick\Driver::class
     |
     */
-    'driver' => env('IMAGE_DRIVER', 'gd'),
+
+    'driver' => env('IMAGE_DRIVER', '\Intervention\Image\Drivers\Gd\Driver::class'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Configuration Options
+    |--------------------------------------------------------------------------
+    |
+    | These options control the behavior of Intervention Image.
+    |
+    | - "autoOrientation" controls whether an imported image should be
+    |    automatically rotated according to any existing Exif data.
+    |
+    | - "decodeAnimation" decides whether a possibly animated image is
+    |    decoded as such or whether the animation is discarded.
+    |
+    | - "blendingColor" Defines the default blending color.
+    |
+    | - "strip" controls if meta data like exif tags should be removed when
+    |    encoding images.
+    */
+
+    'options' => [
+        'autoOrientation' => true,
+        'decodeAnimation' => true,
+        'blendingColor' => 'ffffff',
+        'strip' => false,
+    ]
 ];

--- a/config/image.php
+++ b/config/image.php
@@ -42,6 +42,6 @@ return [
         'autoOrientation' => true,
         'decodeAnimation' => true,
         'blendingColor' => env('IMAGE_BLENDINGCOLOR', 'ffffff'),
-        'strip' => env('IMAGE_STRIP', 'false'),
+        'strip' => env('IMAGE_STRIP', 'true'),
     ]
 ];

--- a/config/image.php
+++ b/config/image.php
@@ -41,7 +41,7 @@ return [
     'options' => [
         'autoOrientation' => true,
         'decodeAnimation' => true,
-        'blendingColor' => 'ffffff',
-        'strip' => false,
+        'blendingColor' => env('IMAGE_BLENDINGCOLOR', 'ffffff'),
+        'strip' => env('IMAGE_STRIP', 'false'),
     ]
 ];

--- a/config/image.php
+++ b/config/image.php
@@ -11,13 +11,13 @@ return [
     | internally. Depending on your PHP setup, you can choose one of them.
     |
     | Included options:
-    |   - \Intervention\Image\Drivers\Gd\Driver::class
-    |   - \Intervention\Image\Drivers\Imagick\Driver::class
-    |   - \Intervention\Image\Drivers\vips\Driver::class
+    |   - gd      = \Intervention\Image\Drivers\Gd\Driver::class
+    |   - imagick = \Intervention\Image\Drivers\Imagick\Driver::class
+    |   - vips    = \Intervention\Image\Drivers\vips\Driver::class
     |
     */
 
-    'driver' => env('IMAGE_DRIVER', '\Intervention\Image\Drivers\Gd\Driver::class'),
+    'driver' => env('IMAGE_DRIVER', 'gd'),
 
     /*
     |--------------------------------------------------------------------------

--- a/config/image.php
+++ b/config/image.php
@@ -13,6 +13,7 @@ return [
     | Included options:
     |   - \Intervention\Image\Drivers\Gd\Driver::class
     |   - \Intervention\Image\Drivers\Imagick\Driver::class
+    |   - \Intervention\Image\Drivers\vips\Driver::class
     |
     */
 


### PR DESCRIPTION
I need to confirm the "IMAGE_DRIVER" change.

```
    | Included options:
    |   - \Intervention\Image\Drivers\Gd\Driver::class
    |   - \Intervention\Image\Drivers\Imagick\Driver::class
    |   - \Intervention\Image\Drivers\vips\Driver::class
    ```