### PR TITLE
Fixing Horizon Error for DMs

### DIFF
--- a/app/Util/ActivityPub/Inbox.php
+++ b/app/Util/ActivityPub/Inbox.php
@@ -39,6 +39,7 @@ use App\Services\UserFilterService;
 use App\Status;
 use App\Story;
 use App\StoryView;
+use App\User;
 use App\UserFilter;
 use App\Util\ActivityPub\Validator\Accept as AcceptValidator;
 use App\Util\ActivityPub\Validator\Announce as AnnounceValidator;


### PR DESCRIPTION
Fixing the following horizon error for DMs: 
Error: Class "App\Util\ActivityPub\User" not found in /var/www/pixelfed/app/Util/ActivityPub/Inbox.php:545