### PR TITLE
Docker: Update .dockerignore - Don't copy local storage to container images v2

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,6 +4,8 @@
 ## local storage of media excluided from image
 !storage/app/public/m/
 storage/app/public/m/*
+!bootstrap/cache/
+bootstrap/cache/*
 tests/
 # Docker
 mariadb-11-data/

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,9 +1,14 @@
 # Folders
 .git/
-storage/app/public/
+# Laravel
+## local storage of media excluided from image
+!storage/app/public/m/
+storage/app/public/m/*
+tests/
+# Docker
 mariadb-11-data/
 redis-data/
-tests/
+# Packages
 node_modules/
 vendor/
 .ddev/


### PR DESCRIPTION
More specific rule for the `storage/app/public/m/*` folder.

This will help us build an image and upload to the docker hub.