### PR TITLE
Refactor/Bug: Clean orphaned files/folders in local \storage\app\public\avatars after uploadToCloud in AvatarOptimize.php

### DIFF
--- a/app/Jobs/AvatarPipeline/AvatarOptimize.php
+++ b/app/Jobs/AvatarPipeline/AvatarOptimize.php
@@ -132,7 +132,15 @@ class AvatarOptimize implements ShouldQueue
         $avatar->media_path = $path;
         $avatar->cdn_url = $disk->url($path);
         $avatar->save();
-        Storage::delete($localPath);  //Delete avatar from local temp storage
+        
+        //Delete local avatar 
+        Storage::delete($localPath);
+        //Delete empty folder called Profile_id
+        $dir = dirname($localPath);
+        if (Storage::exists($dir) && empty(Storage::files($dir))) {
+            Storage::deleteDirectory($dir);
+        }
+        
         Cache::forget('avatar:'.$avatar->profile_id);
     }
 }

--- a/app/Jobs/AvatarPipeline/AvatarOptimize.php
+++ b/app/Jobs/AvatarPipeline/AvatarOptimize.php
@@ -123,39 +123,49 @@ class AvatarOptimize implements ShouldQueue
 
     protected function uploadToCloud($avatar)
     {
-        // Store local path to prepare to delete it
+        // Store local path before clearing it
         $localPath = $avatar->media_path;
-        
-        // Prepare cloud storage path
-        $base = 'cache/avatars/'.$avatar->profile_id;
-        $disk = Storage::disk(config('filesystems.cloud'));
-        
-        // Delete existing avatar folder in the cloud
-        $disk->deleteDirectory($base);
-        
-        // Generate new cloud path with unique identifier
-        $path = $base.'/'.'avatar_'.strtolower(Str::random(random_int(3, 6))).$avatar->change_count.'.'.pathinfo($avatar->media_path, PATHINFO_EXTENSION);
-        
-        // Upload avatar to cloud storage
-        $disk->put($path, Storage::get($localPath));
-        
-        // Set CDN URL for cloud-served avatar
-        $avatar->cdn_url = $disk->url($path);
-        
-        // Clear local path since we're using cloud storage only
-        $avatar->media_path = null;
-        $avatar->save();
-        
-        // Delete local avatar file
-        Storage::disk('local')->delete($localPath);
-        
-        // Delete empty folder on local storage if folder is empty (it should be)
-        $dir = dirname($localPath);
-        if (Storage::disk('local')->exists($dir) && empty(Storage::disk('local')->files($dir))) {
-            Storage::disk('local')->deleteDirectory($dir);
+
+        try {
+            // Prepare cloud storage path
+            $base = 'cache/avatars/'.$avatar->profile_id;
+            $disk = Storage::disk(config('filesystems.cloud'));
+
+            // Delete existing avatar folder in the cloud
+            $disk->deleteDirectory($base);
+
+            // Generate new cloud path with unique identifier
+            $path = $base.'/'.'avatar_'.strtolower(Str::random(random_int(3, 6))).$avatar->change_count.'.'.pathinfo($avatar->media_path, PATHINFO_EXTENSION);
+
+            // Upload avatar to cloud storage
+            $disk->put($path, Storage::get($localPath));
+
+            // Verify remote file exists before deleting local
+            if (!$disk->exists($path)) {
+                Log::warning("AvatarOptimize: uploadToCloud failed to upload avatar to cloud for profile: ". $avatar->profile_id;
+                return;
+            }
+
+            // Set CDN URL for cloud-served avatar
+            $avatar->cdn_url = $disk->url($path);
+
+            // Clear local path since we're using cloud storage only
+            $avatar->media_path = null;
+            $avatar->save();
+
+            // Clear avatar cache to force refresh
+            Cache::forget('avatar:'.$avatar->profile_id);
+        } finally {
+            // Only delete local file if upload was successful (cdn_url is set)
+            if ($avatar->cdn_url) {
+                Storage::disk('local')->delete($localPath);
+
+                // Delete empty folder if no other avatars exist
+                $dir = dirname($localPath);
+                if (Storage::disk('local')->exists($dir) && empty(Storage::disk('local')->files($dir))) {
+                    Storage::disk('local')->deleteDirectory($dir);
+                }
+            }
         }
-        
-        // Clear avatar cache to force refresh
-        Cache::forget('avatar:'.$avatar->profile_id);
     }
 }

--- a/app/Jobs/AvatarPipeline/AvatarOptimize.php
+++ b/app/Jobs/AvatarPipeline/AvatarOptimize.php
@@ -123,6 +123,7 @@ class AvatarOptimize implements ShouldQueue
 
     protected function uploadToCloud($avatar)
     {
+        $localPath = $avatar->media_path;
         $base = 'cache/avatars/'.$avatar->profile_id;
         $disk = Storage::disk(config('filesystems.cloud'));
         $disk->deleteDirectory($base);
@@ -131,7 +132,7 @@ class AvatarOptimize implements ShouldQueue
         $avatar->media_path = $path;
         $avatar->cdn_url = $disk->url($path);
         $avatar->save();
-        Storage::delete($avatar->media_path);
+        Storage::delete($localPath);  //Delete avatar from local temp storage
         Cache::forget('avatar:'.$avatar->profile_id);
     }
 }

--- a/app/Jobs/AvatarPipeline/AvatarOptimize.php
+++ b/app/Jobs/AvatarPipeline/AvatarOptimize.php
@@ -125,41 +125,45 @@ class AvatarOptimize implements ShouldQueue
     {
         // Store local path before clearing it
         $localPath = $avatar->media_path;
-
+        $uploadSuccess = false;
+        
         try {
             // Prepare cloud storage path
             $base = 'cache/avatars/'.$avatar->profile_id;
             $disk = Storage::disk(config('filesystems.cloud'));
-
+            
             // Delete existing avatar folder in the cloud
             $disk->deleteDirectory($base);
-
+            
             // Generate new cloud path with unique identifier
             $path = $base.'/'.'avatar_'.strtolower(Str::random(random_int(3, 6))).$avatar->change_count.'.'.pathinfo($avatar->media_path, PATHINFO_EXTENSION);
-
+            
             // Upload avatar to cloud storage
             $disk->put($path, Storage::get($localPath));
-
+            
             // Verify remote file exists before deleting local
             if (!$disk->exists($path)) {
-                Log::warning("AvatarOptimize: uploadToCloud failed to upload avatar to cloud for profile: ". $avatar->profile_id;
+                Log::warning("AvatarOptimize: uploadToCloud failed to upload avatar to cloud for profile: ". $avatar->profile_id);
                 return;
             }
-
+            
             // Set CDN URL for cloud-served avatar
             $avatar->cdn_url = $disk->url($path);
-
+            
             // Clear local path since we're using cloud storage only
             $avatar->media_path = null;
             $avatar->save();
-
+            
             // Clear avatar cache to force refresh
             Cache::forget('avatar:'.$avatar->profile_id);
+            
+            // Mark upload as successful
+            $uploadSuccess = true;
         } finally {
             // Only delete local file if upload was successful (cdn_url is set)
-            if ($avatar->cdn_url) {
+            if ($uploadSuccess && $avatar->cdn_url) {
                 Storage::disk('local')->delete($localPath);
-
+                
                 // Delete empty folder if no other avatars exist
                 $dir = dirname($localPath);
                 if (Storage::disk('local')->exists($dir) && empty(Storage::disk('local')->files($dir))) {

--- a/app/Jobs/AvatarPipeline/AvatarOptimize.php
+++ b/app/Jobs/AvatarPipeline/AvatarOptimize.php
@@ -134,6 +134,7 @@ class AvatarOptimize implements ShouldQueue
             $disk = Storage::disk(config('filesystems.cloud'));
             
             // Delete existing avatar folder in the cloud (if it exists)
+            //// Fixes: "AvatarOptimize: uploadToCloud exception for profile: 492561745372893187 - Unable to delete directory located at: cache/avatars/xxxxxxxxxxxxxxxxxxxxxxxx"
             if ($disk->exists($base)) {
                 $disk->deleteDirectory($base);
             }

--- a/app/Jobs/AvatarPipeline/AvatarOptimize.php
+++ b/app/Jobs/AvatarPipeline/AvatarOptimize.php
@@ -134,7 +134,7 @@ class AvatarOptimize implements ShouldQueue
             $disk = Storage::disk(config('filesystems.cloud'));
 
             // Delete existing avatar folder in the cloud (if it exists)
-            //// Catches: "AvatarOptimize: uploadToCloud exception for profile: 492561745372893187 - Unable to delete directory located at: cache/avatars/xxxxxxxxxxxxxxxxxxxxxxxx"
+            //// Catches: "AvatarOptimize: uploadToCloud exception for profile: xxxxxxxxxxxxxxxxxxxxxxxx - Unable to delete directory located at: cache/avatars/xxxxxxxxxxxxxxxxxxxxxxxx"
             if ($disk->exists($base)) {
                 try {
                     $disk->deleteDirectory($base);

--- a/app/Jobs/AvatarPipeline/AvatarOptimize.php
+++ b/app/Jobs/AvatarPipeline/AvatarOptimize.php
@@ -133,8 +133,10 @@ class AvatarOptimize implements ShouldQueue
             $base = 'cache/avatars/'.$avatar->profile_id;
             $disk = Storage::disk(config('filesystems.cloud'));
             
-            // Delete existing avatar folder in the cloud
-            $disk->deleteDirectory($base);
+            // Delete existing avatar folder in the cloud (if it exists)
+            if ($disk->exists($base)) {
+                $disk->deleteDirectory($base);
+            }
             
             // Generate new cloud path with unique identifier
             $path = $base.'/'.'avatar_'.strtolower(Str::random(random_int(3, 6))).$avatar->change_count.'.'.pathinfo($avatar->media_path, PATHINFO_EXTENSION);

--- a/app/Jobs/AvatarPipeline/AvatarOptimize.php
+++ b/app/Jobs/AvatarPipeline/AvatarOptimize.php
@@ -13,6 +13,7 @@ use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Str;
+use Illuminate\Support\Facades\Log;
 use Storage;
 use Intervention\Image\ImageManager;
 use Intervention\Image\Encoders\JpegEncoder;

--- a/app/Jobs/AvatarPipeline/AvatarOptimize.php
+++ b/app/Jobs/AvatarPipeline/AvatarOptimize.php
@@ -14,7 +14,7 @@ use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Str;
 use Illuminate\Support\Facades\Log;
-use Storage;
+use Illuminate\Support\Facades\Storage;
 use Intervention\Image\ImageManager;
 use Intervention\Image\Encoders\JpegEncoder;
 use Intervention\Image\Encoders\WebpEncoder;
@@ -132,13 +132,17 @@ class AvatarOptimize implements ShouldQueue
             // Prepare cloud storage path
             $base = 'cache/avatars/'.$avatar->profile_id;
             $disk = Storage::disk(config('filesystems.cloud'));
-            
+
             // Delete existing avatar folder in the cloud (if it exists)
-            //// Fixes: "AvatarOptimize: uploadToCloud exception for profile: 492561745372893187 - Unable to delete directory located at: cache/avatars/xxxxxxxxxxxxxxxxxxxxxxxx"
+            //// Catches: "AvatarOptimize: uploadToCloud exception for profile: 492561745372893187 - Unable to delete directory located at: cache/avatars/xxxxxxxxxxxxxxxxxxxxxxxx"
             if ($disk->exists($base)) {
-                $disk->deleteDirectory($base);
+                try {
+                    $disk->deleteDirectory($base);
+                } catch (\Exception $deleteEx) {
+                    Log::warning("AvatarOptimize: Could not delete existing avatar directory for profile: ". $avatar->profile_id . " - " . $deleteEx->getMessage());
+                }
             }
-            
+
             // Generate new cloud path with unique identifier
             $path = $base.'/'.'avatar_'.strtolower(Str::random(random_int(3, 6))).$avatar->change_count.'.'.pathinfo($avatar->media_path, PATHINFO_EXTENSION);
             
@@ -148,21 +152,24 @@ class AvatarOptimize implements ShouldQueue
             // Verify remote file exists before deleting local
             if (!$disk->exists($path)) {
                 Log::warning("AvatarOptimize: uploadToCloud failed to upload avatar to cloud for profile: ". $avatar->profile_id);
-                return;
+                $uploadSuccess = false;
+            } else {
+                // Set CDN URL for cloud-served avatar
+                $avatar->cdn_url = $disk->url($path);
+                
+                // Clear local path since we're using cloud storage only
+                $avatar->media_path = null;
+                $avatar->save();
+                
+                // Clear avatar cache to force refresh
+                Cache::forget('avatar:'.$avatar->profile_id);
+                
+                // Mark upload as successful
+                $uploadSuccess = true;
             }
-            
-            // Set CDN URL for cloud-served avatar
-            $avatar->cdn_url = $disk->url($path);
-            
-            // Clear local path since we're using cloud storage only
-            $avatar->media_path = null;
-            $avatar->save();
-            
-            // Clear avatar cache to force refresh
-            Cache::forget('avatar:'.$avatar->profile_id);
-            
-            // Mark upload as successful
-            $uploadSuccess = true;
+        } catch (\Exception $e) {
+            Log::error("AvatarOptimize: uploadToCloud exception for profile: ". $avatar->profile_id . " - " . $e->getMessage());
+            $uploadSuccess = false;
         } finally {
             // Only delete local file if upload was successful (cdn_url is set)
             if ($uploadSuccess && $avatar->cdn_url) {

--- a/app/Jobs/AvatarPipeline/AvatarOptimize.php
+++ b/app/Jobs/AvatarPipeline/AvatarOptimize.php
@@ -123,24 +123,39 @@ class AvatarOptimize implements ShouldQueue
 
     protected function uploadToCloud($avatar)
     {
+        // Store local path to prepare to delete it
         $localPath = $avatar->media_path;
+        
+        // Prepare cloud storage path
         $base = 'cache/avatars/'.$avatar->profile_id;
         $disk = Storage::disk(config('filesystems.cloud'));
+        
+        // Delete existing avatar folder in the cloud
         $disk->deleteDirectory($base);
+        
+        // Generate new cloud path with unique identifier
         $path = $base.'/'.'avatar_'.strtolower(Str::random(random_int(3, 6))).$avatar->change_count.'.'.pathinfo($avatar->media_path, PATHINFO_EXTENSION);
-        $url = $disk->put($path, Storage::get($avatar->media_path));
-        $avatar->media_path = $path;
+        
+        // Upload avatar to cloud storage
+        $disk->put($path, Storage::get($localPath));
+        
+        // Set CDN URL for cloud-served avatar
         $avatar->cdn_url = $disk->url($path);
+        
+        // Clear local path since we're using cloud storage only
+        $avatar->media_path = null;
         $avatar->save();
         
-        //Delete local avatar 
-        Storage::delete($localPath);
-        //Delete empty folder called Profile_id
+        // Delete local avatar file
+        Storage::disk('local')->delete($localPath);
+        
+        // Delete empty folder on local storage if folder is empty (it should be)
         $dir = dirname($localPath);
-        if (Storage::exists($dir) && empty(Storage::files($dir))) {
-            Storage::deleteDirectory($dir);
+        if (Storage::disk('local')->exists($dir) && empty(Storage::disk('local')->files($dir))) {
+            Storage::disk('local')->deleteDirectory($dir);
         }
         
+        // Clear avatar cache to force refresh
         Cache::forget('avatar:'.$avatar->profile_id);
     }
 }

--- a/app/Profile.php
+++ b/app/Profile.php
@@ -187,11 +187,6 @@ class Profile extends Model
 				return url('/storage/avatars/default.jpg');
 			}
 
-			// Skip cache if avatar is still being processed (optimization/cloud upload in progress)
-			if($avatar->last_processed_at === null) {
-				return $this->getAvatarUrl($avatar);
-			}
-
 			// Cache the URL for 14 days once processing is complete
 			$url = Cache::remember('avatar:'.$this->id, 1209600, function () use ($avatar) {
 				return $this->getAvatarUrl($avatar);

--- a/app/Profile.php
+++ b/app/Profile.php
@@ -178,13 +178,36 @@ class Profile extends Model
 
 	public function avatarUrl()
 	{
-		$url = Cache::remember('avatar:'.$this->id, 1209600, function () {
+		try {
+			// Retrieve the avatar record for this profile
 			$avatar = $this->avatar;
 
+			// Return default if no avatar exists
 			if(!$avatar) {
 				return url('/storage/avatars/default.jpg');
 			}
 
+			// Skip cache if avatar is still being processed (optimization/cloud upload in progress)
+			if($avatar->last_processed_at === null) {
+				return $this->getAvatarUrl($avatar);
+			}
+
+			// Cache the URL for 14 days once processing is complete
+			$url = Cache::remember('avatar:'.$this->id, 1209600, function () use ($avatar) {
+				return $this->getAvatarUrl($avatar);
+			});
+
+			return $url;
+		} catch (\Exception $e) {
+			// Gracefully return default avatar on any error
+			return url('/storage/avatars/default.jpg');
+		}
+	}
+
+	protected function getAvatarUrl($avatar)
+	{
+		try {
+			// Return CDN URL if avatar is stored in cloud storage
 			if($avatar->cdn_url) {
 				if(substr($avatar->cdn_url, 0, 8) === 'https://') {
 					return $avatar->cdn_url;
@@ -193,12 +216,15 @@ class Profile extends Model
 				}
 			}
 
+			// Get the local media path
 			$path = $avatar->media_path;
 
+			// Return default if no path is set
 			if(!$path) {
 				return url('/storage/avatars/default.jpg');
 			}
 
+			// Return remote URL if this is a federated avatar stored locally
 			if( $avatar->is_remote &&
 				$avatar->remote_url &&
 				boolval(config_cache('federation.avatars.store_local')) == true
@@ -206,24 +232,29 @@ class Profile extends Model
 				return $avatar->remote_url;
 			}
 
+			// Return default for default avatar path
 			if($path === 'public/avatars/default.jpg') {
 				return url('/storage/avatars/default.jpg');
 			}
 
+			// Return default if path doesn't start with 'public' (invalid path)
 			if(substr($path, 0, 6) !== 'public') {
 				return url('/storage/avatars/default.jpg');
 			}
 
+			// Return S3 URL if using cloud storage as default filesystem
 			if(config('filesystems.default') !== 'local') {
 				return Storage::url($path);
 			}
 
+			// Return local URL with cache-busting version parameter
 			$path = "{$path}?v={$avatar->change_count}";
 
 			return url(Storage::url($path));
-		});
-
-		return $url;
+		} catch (\Exception $e) {
+			// Gracefully return default avatar on any error
+			return url('/storage/avatars/default.jpg');
+		}
 	}
 
 	// deprecated


### PR DESCRIPTION
Noticed the local storage had a lot of avatars.
<img width="702" height="216" alt="image" src="https://github.com/user-attachments/assets/2d8f7adc-f63d-447c-b6a9-1b998e216a8d" />
then noticed the duplicated avatar locally and in the cloud.
```
https://pixelfed.au/storage/avatars/896988332790702314/4vffdk.jpg
https://cdn.pixelfed.au/cache/avatars/896988332790702314/avatar_nnmkz1.jpg
```

