### PR TITLE
Bug: Update Helpers.php profileUpdateOrCreate method - Integrity constraint violation: 1062 Duplicate entry for profiles_key_id_unique

### DIFF
--- a/app/Util/ActivityPub/Helpers.php
+++ b/app/Util/ActivityPub/Helpers.php
@@ -1170,14 +1170,33 @@ class Helpers
         $webfinger = "@{$username}@{$domain}";
         $instance = self::getOrCreateInstance($domain);
         $movedToPid = $movedToCheck ? null : self::handleMovedTo($res);
+        $keyId = $res['publicKey']['id'] ?? null;
 
-        $profile = Profile::updateOrCreate(
-            [
-                'domain' => strtolower($domain),
-                'username' => Purify::clean($webfinger),
-            ],
-            self::buildProfileData($res, $webfinger, $movedToPid)
-        );
+        // First try to find by key_id to handle race conditions
+        if ($keyId) {
+            $existingByKeyId = Profile::where('key_id', $keyId)->first();
+            if ($existingByKeyId) {
+                // Update existing profile with new data
+                $existingByKeyId->update(self::buildProfileData($res, $webfinger, $movedToPid));
+                self::handleProfileAvatar($existingByKeyId);
+                return $existingByKeyId;
+            }
+        }
+
+        try {
+            $profile = Profile::updateOrCreate(
+                [
+                    'domain' => strtolower($domain),
+                    'username' => Purify::clean($webfinger),
+                ],
+                self::buildProfileData($res, $webfinger, $movedToPid)
+            );
+        } catch (\Illuminate\Database\QueryException $e) {
+            // TODO Handle unique constraint violation on key_id
+            // if ($e->getCode() === '23000' && $keyId) {
+            // }
+            throw $e;
+        }
 
         self::handleProfileAvatar($profile);
 

--- a/app/Util/ActivityPub/Helpers.php
+++ b/app/Util/ActivityPub/Helpers.php
@@ -26,6 +26,7 @@ use App\Util\Media\License;
 use Cache;
 use Carbon\Carbon;
 use Illuminate\Validation\Rule;
+use Illuminate\Support\Facades\Log;
 use League\Uri\Exceptions\UriException;
 use League\Uri\Uri;
 use Purify;

--- a/app/Util/ActivityPub/Helpers.php
+++ b/app/Util/ActivityPub/Helpers.php
@@ -1173,12 +1173,12 @@ class Helpers
 
         // First try to find by key_id to handle race conditions
         if ($keyId) {
-            $existingByKeyId = Profile::where('key_id', $keyId)->first();
-            if ($existingByKeyId) {
+            $profileByKeyId = Profile::where('key_id', $keyId)->first();
+            if ($profileByKeyId) {
                 // Update existing profile with new data
-                $existingByKeyId->update(self::buildProfileData($res, $webfinger, $movedToPid));  // same as line 1192 - ONLY update existing profile, not updateOrCreate
-                self::handleProfileAvatar($existingByKeyId);  // same as line 1201
-                return $existingByKeyId;
+                $profileByKeyId->update(self::buildProfileData($res, $webfinger, $movedToPid));  // same as line 1192 - ONLY update existing profile, not updateOrCreate
+                self::handleProfileAvatar($profileByKeyId);  // same as line 1201
+                return $profileByKeyId;
             }
         }
 

--- a/app/Util/ActivityPub/Helpers.php
+++ b/app/Util/ActivityPub/Helpers.php
@@ -1177,8 +1177,8 @@ class Helpers
             $existingByKeyId = Profile::where('key_id', $keyId)->first();
             if ($existingByKeyId) {
                 // Update existing profile with new data
-                $existingByKeyId->update(self::buildProfileData($res, $webfinger, $movedToPid));
-                self::handleProfileAvatar($existingByKeyId);
+                $existingByKeyId->update(self::buildProfileData($res, $webfinger, $movedToPid));  // same as line 1192
+                self::handleProfileAvatar($existingByKeyId);  // same as line 1201
                 return $existingByKeyId;
             }
         }

--- a/app/Util/ActivityPub/Helpers.php
+++ b/app/Util/ActivityPub/Helpers.php
@@ -1148,6 +1148,7 @@ class Helpers
         return ! $profile?->last_fetched_at ||
                $profile->last_fetched_at->lt(now()->subHours(24));
     }
+
     /**
      * Update or create a profile from ActivityPub data
      */

--- a/app/Util/ActivityPub/Helpers.php
+++ b/app/Util/ActivityPub/Helpers.php
@@ -1199,7 +1199,7 @@ class Helpers
         } catch (\Illuminate\Database\QueryException $e) {
             // TODO Handle unique constraint violation on key_id
             if ($e->getCode() === '23000' && $keyId) {
-                Log::warning("APHelpers: profileUpdateOrCreate failed with Integrity constraint violation: " . $e->getMessage());
+                Log::warning("APHelpers: profileUpdateOrCreate failed with Integrity constraint violation with keyId: " . $keyId . " - Error: " . $e->getMessage());
             }
             Log::warning("APHelpers: profileUpdateOrCreate failed: " . $e->getMessage());
             throw $e;

--- a/app/Util/ActivityPub/Helpers.php
+++ b/app/Util/ActivityPub/Helpers.php
@@ -1175,12 +1175,12 @@ class Helpers
         // First try to find by key_id to handle race conditions
         if ($keyId) {
             try {
-                $existingByKeyId = Profile::where('key_id', $keyId)->first();
-                if ($existingByKeyId) {
+                $profileByKeyId = Profile::where('key_id', $keyId)->first();
+                if ($profileByKeyId) {
                     // Update existing profile with new data
                     $profileByKeyId->update(self::buildProfileData($res, $webfinger, $movedToPid));  // same as line 1192 - ONLY update existing profile, not updateOrCreate
                     self::handleProfileAvatar($profileByKeyId);  // same as line 1201
-                    return $existingByKeyId;
+                    return $profileByKeyId;
                 }
             } catch (\Illuminate\Database\QueryException $e) {
                 // Log the error but continue to updateOrCreate

--- a/app/Util/ActivityPub/Helpers.php
+++ b/app/Util/ActivityPub/Helpers.php
@@ -1177,7 +1177,7 @@ class Helpers
             $existingByKeyId = Profile::where('key_id', $keyId)->first();
             if ($existingByKeyId) {
                 // Update existing profile with new data
-                $existingByKeyId->update(self::buildProfileData($res, $webfinger, $movedToPid));  // same as line 1192
+                $existingByKeyId->update(self::buildProfileData($res, $webfinger, $movedToPid));  // same as line 1192 - ONLY update existing profile, not updateOrCreate
                 self::handleProfileAvatar($existingByKeyId);  // same as line 1201
                 return $existingByKeyId;
             }

--- a/app/Util/ActivityPub/Helpers.php
+++ b/app/Util/ActivityPub/Helpers.php
@@ -1148,7 +1148,6 @@ class Helpers
         return ! $profile?->last_fetched_at ||
                $profile->last_fetched_at->lt(now()->subHours(24));
     }
-
     /**
      * Update or create a profile from ActivityPub data
      */

--- a/app/Util/ActivityPub/Helpers.php
+++ b/app/Util/ActivityPub/Helpers.php
@@ -1193,8 +1193,10 @@ class Helpers
             );
         } catch (\Illuminate\Database\QueryException $e) {
             // TODO Handle unique constraint violation on key_id
-            // if ($e->getCode() === '23000' && $keyId) {
-            // }
+            if ($e->getCode() === '23000' && $keyId) {
+                Log::warning("APHelpers: profileUpdateOrCreate failed with Integrity constraint violation: " . $e->getMessage());
+            }
+            Log::warning("APHelpers: profileUpdateOrCreate failed: " . $e->getMessage());
             throw $e;
         }
 

--- a/app/Util/ActivityPub/Helpers.php
+++ b/app/Util/ActivityPub/Helpers.php
@@ -1174,12 +1174,17 @@ class Helpers
 
         // First try to find by key_id to handle race conditions
         if ($keyId) {
-            $profileByKeyId = Profile::where('key_id', $keyId)->first();
-            if ($profileByKeyId) {
-                // Update existing profile with new data
-                $profileByKeyId->update(self::buildProfileData($res, $webfinger, $movedToPid));  // same as line 1192 - ONLY update existing profile, not updateOrCreate
-                self::handleProfileAvatar($profileByKeyId);  // same as line 1201
-                return $profileByKeyId;
+            try {
+                $existingByKeyId = Profile::where('key_id', $keyId)->first();
+                if ($existingByKeyId) {
+                    // Update existing profile with new data
+                    $profileByKeyId->update(self::buildProfileData($res, $webfinger, $movedToPid));  // same as line 1192 - ONLY update existing profile, not updateOrCreate
+                    self::handleProfileAvatar($profileByKeyId);  // same as line 1201
+                    return $existingByKeyId;
+                }
+            } catch (\Illuminate\Database\QueryException $e) {
+                // Log the error but continue to updateOrCreate
+                Log::warning("APHelpers: profileUpdateOrCreate: Error checking existing profile by key_id: ". $keyId . ". Error: " . $e->getMessage());
             }
         }
 


### PR DESCRIPTION
Trying to resolve `PDOException: SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry 'https://www.404media.co/.ghost/activitypub/users/index#main-key' for key 'profiles_key_id_unique' in /home/pixelfed/pixelfed/vendor/laravel/framework/src/Illuminate/Database/MySqlConnection.php:53`

My understanding....

in 2018_10_25_030944_update_profile_table.php.. `$table->string('key_id')->nullable()->unique()->index()->after('outbox_url');` requires that the key_id must be unique.

The `profileUpdateOrCreate` task is triggered by `App\Jobs\InboxPipeline\ActivityHandler` -> app/Util/ActivityPub/Inbox.php -> app/Util/ActivityPub/Helpers.php

So putting this check here is universal? but you might want to refactor and add this check higher up? and this might be a bandaid?


