### PR TITLE
Enhancement: Create app/Util/storage/safeDeleteDirectory.php with deleteRecursive functions

### DIFF
--- a/app/Util/storage/deleteDirectory.php
+++ b/app/Util/storage/deleteDirectory.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Facades\Log;
+
+class StorageService
+{
+    /**
+     * Safely delete a directory only if it's empty.
+     * Logs a warning if the directory is not empty or deletion fails.
+     *
+     * @param string $path
+     * @return bool
+     */
+    public static function safeDeleteDirectory($path)
+    {
+        if (!Storage::exists($path)) {
+            return true;
+        }
+
+        if (!empty(Storage::allFiles($path))) {
+            Log::warning("Cannot delete directory: {$path} - directory is not empty");
+            return false;
+        }
+
+        try {
+            Storage::deleteDirectory($path);
+            return true;
+        } catch (\Exception $e) {
+            Log::warning("Failed to delete directory: {$path} - " . $e->getMessage());
+            return false;
+        }
+    }
+
+    /**
+     * Recursively delete all files and subdirectories, then delete the directory.
+     *
+     * @param string $path
+     * @return bool
+     */
+    public static function deleteDirectoryRecursive($path)
+    {
+        if (!Storage::exists($path)) {
+            return true;
+        }
+
+        try {
+            // Delete all files in the directory
+            $files = Storage::allFiles($path);
+            if (!empty($files)) {
+                Storage::delete($files);
+            }
+
+            // Delete all subdirectories recursively
+            $directories = Storage::directories($path);
+            foreach ($directories as $directory) {
+                self::deleteDirectoryRecursive($directory);
+            }
+
+            // Delete the directory itself
+            Storage::deleteDirectory($path);
+            return true;
+        } catch (\Exception $e) {
+            Log::warning("Failed to recursively delete directory: {$path} - " . $e->getMessage());
+            return false;
+        }
+    }
+}

--- a/app/Util/storage/safeDeleteDirectory.php
+++ b/app/Util/storage/safeDeleteDirectory.php
@@ -36,6 +36,7 @@ class SafeDeleteDirectory
 
     /**
      * Recursively delete all files and subdirectories, then delete the directory.
+     * Logs a warning if the deletion fails.
      *
      * @param string $path
      * @return bool

--- a/app/Util/storage/safeDeleteDirectory.php
+++ b/app/Util/storage/safeDeleteDirectory.php
@@ -12,21 +12,29 @@ class SafeDeleteDirectory
      * Logs a warning if the directory is not empty or deletion fails.
      *
      * @param string $path
+     * @param string $disk Disk name (e.g., 'local', 's3'). Required.
      * @return bool
+     * @throws \InvalidArgumentException
      */
-    public static function deleteEmpty($path)
+    public static function deleteEmpty($path, $disk)
     {
-        if (!Storage::exists($path)) {
+        if (empty($disk)) {
+            throw new \InvalidArgumentException('Disk parameter is required. Use "local" or "s3" or other configured disk name.');
+        }
+
+        $disk = Storage::disk($disk);
+
+        if (!$disk->exists($path)) {
             return true;
         }
 
-        if (!empty(Storage::allFiles($path))) {
+        if (!empty($disk->allFiles($path))) {
             Log::warning("Cannot delete directory: {$path} - directory is not empty");
             return false;
         }
 
         try {
-            Storage::deleteDirectory($path);
+            $disk->deleteDirectory($path);
             return true;
         } catch (\Exception $e) {
             Log::warning("Failed to delete directory: {$path} - " . $e->getMessage());
@@ -39,29 +47,37 @@ class SafeDeleteDirectory
      * Logs a warning if the deletion fails.
      *
      * @param string $path
+     * @param string $disk Disk name (e.g., 'local', 's3'). Required.
      * @return bool
+     * @throws \InvalidArgumentException
      */
-    public static function deleteRecursive($path)
+    public static function deleteRecursive($path, $disk)
     {
-        if (!Storage::exists($path)) {
+        if (empty($disk)) {
+            throw new \InvalidArgumentException('Disk parameter is required. Use "local" or "s3" or other configured disk name.');
+        }
+
+        $disk = Storage::disk($disk);
+
+        if (!$disk->exists($path)) {
             return true;
         }
 
         try {
             // Delete all files in the directory
-            $files = Storage::allFiles($path);
+            $files = $disk->allFiles($path);
             if (!empty($files)) {
-                Storage::delete($files);
+                $disk->delete($files);
             }
 
             // Delete all subdirectories recursively
-            $directories = Storage::directories($path);
+            $directories = $disk->directories($path);
             foreach ($directories as $directory) {
-                self::deleteRecursive($directory);
+                self::deleteRecursive($directory, $disk);
             }
 
             // Delete the directory itself
-            Storage::deleteDirectory($path);
+            $disk->deleteDirectory($path);
             return true;
         } catch (\Exception $e) {
             Log::warning("Failed to recursively delete directory: {$path} - " . $e->getMessage());

--- a/app/Util/storage/safeDeleteDirectory.php
+++ b/app/Util/storage/safeDeleteDirectory.php
@@ -21,7 +21,7 @@ class SafeDeleteDirectory
     {
         if ($diskName === '') {
             throw new \InvalidArgumentException(
-                'Disk parameter is required. Use "local", "s3" or another configured disk name.'
+                'SafeDeleteDirectory: diskName parameter required. Use "local" or "s3".'
             );
         }
 
@@ -39,7 +39,7 @@ class SafeDeleteDirectory
 
                 // If the driver reports a failure, log and stop here
                 if ($deletedFiles === false) {
-                    Log::warning("Failed to delete one or more files in directory {$path} on disk {$diskName}.");
+                    Log::warning("SafeDeleteDirectory: Failed to delete one or more files in directory {$path} on disk {$diskName}.");
                     return false;
                 }
             }
@@ -56,14 +56,14 @@ class SafeDeleteDirectory
             $deletedDir = $disk->deleteDirectory($path);
 
             if (!$deletedDir) {
-                Log::warning("Failed to delete directory {$path} on disk {$diskName}.");
+                Log::warning("SafeDeleteDirectory: Failed to delete directory {$path} on disk {$diskName}.");
                 return false;
             }
 
             return true;
         } catch (\Exception $e) {
             Log::warning(
-                "Failed to recursively delete directory {$path} on disk {$diskName}: " . $e->getMessage()
+                "SafeDeleteDirectory: Failed to recursively delete directory {$path} on disk {$diskName}: " . $e->getMessage()
             );
 
             return false;

--- a/app/Util/storage/safeDeleteDirectory.php
+++ b/app/Util/storage/safeDeleteDirectory.php
@@ -11,30 +11,30 @@ class SafeDeleteDirectory
      * Safely delete a directory only if it's empty.
      * Logs a warning if the directory is not empty or deletion fails.
      *
-     * @param string $path
      * @param string $disk Disk name (e.g., 'local', 's3'). Required.
+     * @param string $path
      * @return bool
      * @throws \InvalidArgumentException
      */
-    public static function deleteEmpty($path, $disk)
+    public static function deleteEmpty($disk, $path)
     {
         if (empty($disk)) {
             throw new \InvalidArgumentException('Disk parameter is required. Use "local" or "s3" or other configured disk name.');
         }
 
-        $disk = Storage::disk($disk);
+        $diskInstance = Storage::disk($disk);
 
-        if (!$disk->exists($path)) {
+        if (!$diskInstance->exists($path)) {
             return true;
         }
 
-        if (!empty($disk->allFiles($path))) {
+        if (!empty($diskInstance->allFiles($path))) {
             Log::warning("Cannot delete directory: {$path} - directory is not empty");
             return false;
         }
 
         try {
-            $disk->deleteDirectory($path);
+            $diskInstance->deleteDirectory($path);
             return true;
         } catch (\Exception $e) {
             Log::warning("Failed to delete directory: {$path} - " . $e->getMessage());
@@ -46,38 +46,38 @@ class SafeDeleteDirectory
      * Recursively delete all files and subdirectories, then delete the directory.
      * Logs a warning if the deletion fails.
      *
-     * @param string $path
      * @param string $disk Disk name (e.g., 'local', 's3'). Required.
+     * @param string $path
      * @return bool
      * @throws \InvalidArgumentException
      */
-    public static function deleteRecursive($path, $disk)
+    public static function deleteRecursive($disk, $path)
     {
         if (empty($disk)) {
             throw new \InvalidArgumentException('Disk parameter is required. Use "local" or "s3" or other configured disk name.');
         }
 
-        $disk = Storage::disk($disk);
+        $diskInstance = Storage::disk($disk);
 
-        if (!$disk->exists($path)) {
+        if (!$diskInstance->exists($path)) {
             return true;
         }
 
         try {
             // Delete all files in the directory
-            $files = $disk->allFiles($path);
+            $files = $diskInstance->allFiles($path);
             if (!empty($files)) {
-                $disk->delete($files);
+                $diskInstance->delete($files);
             }
 
             // Delete all subdirectories recursively
-            $directories = $disk->directories($path);
+            $directories = $diskInstance->directories($path);
             foreach ($directories as $directory) {
-                self::deleteRecursive($directory, $disk);
+                self::deleteRecursive($disk, $directory);
             }
 
             // Delete the directory itself
-            $disk->deleteDirectory($path);
+            $diskInstance->deleteDirectory($path);
             return true;
         } catch (\Exception $e) {
             Log::warning("Failed to recursively delete directory: {$path} - " . $e->getMessage());

--- a/app/Util/storage/safeDeleteDirectory.php
+++ b/app/Util/storage/safeDeleteDirectory.php
@@ -8,79 +8,64 @@ use Illuminate\Support\Facades\Log;
 class SafeDeleteDirectory
 {
     /**
-     * Safely delete a directory only if it's empty.
-     * Logs a warning if the directory is not empty or deletion fails.
-     *
-     * @param string $disk Disk name (e.g., 'local', 's3'). Required.
-     * @param string $path
-     * @return bool
-     * @throws \InvalidArgumentException
-     */
-    public static function deleteEmpty($disk, $path)
-    {
-        if (empty($disk)) {
-            throw new \InvalidArgumentException('Disk parameter is required. Use "local" or "s3" or other configured disk name.');
-        }
-
-        $disk = Storage::disk($disk);
-
-        if (!$disk->exists($path)) {
-            return true;
-        }
-
-        if (!empty($disk->allFiles($path))) {
-            Log::warning("Cannot delete directory: {$path} - directory is not empty");
-            return false;
-        }
-
-        try {
-            $disk->deleteDirectory($path);
-            return true;
-        } catch (\Exception $e) {
-            Log::warning("Failed to delete directory: {$path} - " . $e->getMessage());
-            return false;
-        }
-    }
-
-    /**
      * Recursively delete all files and subdirectories, then delete the directory.
      * Logs a warning if the deletion fails.
      *
-     * @param string $disk Disk name (e.g., 'local', 's3'). Required.
+     * @param string $diskName Disk name (e.g. 'local', 's3'). Required.
      * @param string $path
      * @return bool
+     *
      * @throws \InvalidArgumentException
      */
-    public static function deleteRecursive($disk, $path)
+    public static function deleteRecursive(string $diskName, string $path): bool
     {
-        if (empty($disk)) {
-            throw new \InvalidArgumentException('Disk parameter is required. Use "local" or "s3" or other configured disk name.');
+        if ($diskName === '') {
+            throw new \InvalidArgumentException(
+                'Disk parameter is required. Use "local", "s3" or another configured disk name.'
+            );
         }
 
-        $disk = Storage::disk($disk);
+        $disk = Storage::disk($diskName);
 
         if (!$disk->exists($path)) {
             return true;
         }
 
         try {
-            // Delete all files in the directory
+            // Delete all files in the directory (recursively)
             $files = $disk->allFiles($path);
             if (!empty($files)) {
-                $disk->delete($files);
+                $deletedFiles = $disk->delete($files);
+
+                // If the driver reports a failure, log and stop here
+                if ($deletedFiles === false) {
+                    Log::warning("Failed to delete one or more files in directory {$path} on disk {$diskName}.");
+                    return false;
+                }
             }
 
             // Delete all subdirectories recursively
             $directories = $disk->directories($path);
             foreach ($directories as $directory) {
-                self::deleteRecursive($disk, $directory);
+                if (!self::deleteRecursive($diskName, $directory)) {
+                    return false;
+                }
             }
 
             // Delete the directory itself
-            $disk->deleteDirectory($path);
+            $deletedDir = $disk->deleteDirectory($path);
+
+            if (!$deletedDir) {
+                Log::warning("Failed to delete directory {$path} on disk {$diskName}.");
+                return false;
+            }
+
             return true;
         } catch (\Exception $e) {
-            Log::warning("Failed to recursively delete directory: {$path} - " . $e->getMessage());
+            Log::warning(
+                "Failed to recursively delete directory {$path} on disk {$diskName}: " . $e->getMessage()
+            );
+
             return false;
         }
     }

--- a/app/Util/storage/safeDeleteDirectory.php
+++ b/app/Util/storage/safeDeleteDirectory.php
@@ -14,7 +14,7 @@ class SafeDeleteDirectory
      * @param string $path
      * @return bool
      */
-    public static function safe($path)
+    public static function deleteEmpty($path)
     {
         if (!Storage::exists($path)) {
             return true;
@@ -40,7 +40,7 @@ class SafeDeleteDirectory
      * @param string $path
      * @return bool
      */
-    public static function recursive($path)
+    public static function deleteRecursive($path)
     {
         if (!Storage::exists($path)) {
             return true;

--- a/app/Util/storage/safeDeleteDirectory.php
+++ b/app/Util/storage/safeDeleteDirectory.php
@@ -57,7 +57,7 @@ class SafeDeleteDirectory
             // Delete all subdirectories recursively
             $directories = Storage::directories($path);
             foreach ($directories as $directory) {
-                self::recursive($directory);
+                self::deleteRecursive($directory);
             }
 
             // Delete the directory itself

--- a/app/Util/storage/safeDeleteDirectory.php
+++ b/app/Util/storage/safeDeleteDirectory.php
@@ -22,19 +22,19 @@ class SafeDeleteDirectory
             throw new \InvalidArgumentException('Disk parameter is required. Use "local" or "s3" or other configured disk name.');
         }
 
-        $diskInstance = Storage::disk($disk);
+        $disk = Storage::disk($disk);
 
-        if (!$diskInstance->exists($path)) {
+        if (!$disk->exists($path)) {
             return true;
         }
 
-        if (!empty($diskInstance->allFiles($path))) {
+        if (!empty($disk->allFiles($path))) {
             Log::warning("Cannot delete directory: {$path} - directory is not empty");
             return false;
         }
 
         try {
-            $diskInstance->deleteDirectory($path);
+            $disk->deleteDirectory($path);
             return true;
         } catch (\Exception $e) {
             Log::warning("Failed to delete directory: {$path} - " . $e->getMessage());
@@ -57,27 +57,27 @@ class SafeDeleteDirectory
             throw new \InvalidArgumentException('Disk parameter is required. Use "local" or "s3" or other configured disk name.');
         }
 
-        $diskInstance = Storage::disk($disk);
+        $disk = Storage::disk($disk);
 
-        if (!$diskInstance->exists($path)) {
+        if (!$disk->exists($path)) {
             return true;
         }
 
         try {
             // Delete all files in the directory
-            $files = $diskInstance->allFiles($path);
+            $files = $disk->allFiles($path);
             if (!empty($files)) {
-                $diskInstance->delete($files);
+                $disk->delete($files);
             }
 
             // Delete all subdirectories recursively
-            $directories = $diskInstance->directories($path);
+            $directories = $disk->directories($path);
             foreach ($directories as $directory) {
                 self::deleteRecursive($disk, $directory);
             }
 
             // Delete the directory itself
-            $diskInstance->deleteDirectory($path);
+            $disk->deleteDirectory($path);
             return true;
         } catch (\Exception $e) {
             Log::warning("Failed to recursively delete directory: {$path} - " . $e->getMessage());

--- a/app/Util/storage/safeDeleteDirectory.php
+++ b/app/Util/storage/safeDeleteDirectory.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace App\Services;
+namespace App\Util\Storage;
 
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Facades\Log;
 
-class StorageService
+class SafeDeleteDirectory
 {
     /**
      * Safely delete a directory only if it's empty.
@@ -14,7 +14,7 @@ class StorageService
      * @param string $path
      * @return bool
      */
-    public static function safeDeleteDirectory($path)
+    public static function safe($path)
     {
         if (!Storage::exists($path)) {
             return true;
@@ -40,7 +40,7 @@ class StorageService
      * @param string $path
      * @return bool
      */
-    public static function deleteDirectoryRecursive($path)
+    public static function recursive($path)
     {
         if (!Storage::exists($path)) {
             return true;
@@ -56,7 +56,7 @@ class StorageService
             // Delete all subdirectories recursively
             $directories = Storage::directories($path);
             foreach ($directories as $directory) {
-                self::deleteDirectoryRecursive($directory);
+                self::recursive($directory);
             }
 
             // Delete the directory itself


### PR DESCRIPTION
Context: I've noticed that Fastly Object storage doesn't delete a folder recursively. 
This causes "Storage::deleteDirectory" to fail on fastly, but work as expected on wasabi.

This is a platform agnostic function to delete all of the files/folders on local disk or s3.

Tested on staging environment.
* AWS tested
* Wasabi tested
* fastly tested