### PR TITLE
Bug: Update Helpers.php createMediaAttachment method - Integrity constraint violation: 1062 Duplicate entry for media_status_id_media_path_unique

### DIFF
--- a/app/Util/ActivityPub/Helpers.php
+++ b/app/Util/ActivityPub/Helpers.php
@@ -923,6 +923,15 @@ class Helpers
      */
     public static function createMediaAttachment(array $media, Status $status, int $key): Media
     {
+        // Check if media already exists to avoid duplicate key constraint violation
+        $existingMedia = Media::where('status_id', $status->id)
+            ->where('media_path', $media['url'])
+            ->first();
+
+        if ($existingMedia) {
+            return $existingMedia;
+        }
+
         $mediaModel = new Media;
 
         self::setBasicMediaAttributes($mediaModel, $media, $status, $key);


### PR DESCRIPTION
App\Jobs\InboxPipeline\ActivityHandler is failing

`PDOException: SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry '897671940262846588-https://cdn.masto.host/urbanistssocial/med...' for key 'media_status_id_media_path_unique' in /home/pixelfed/pixelfed/vendor/laravel/framework/src/Illuminate/Database/MySqlConnection.php:53`

<img width="1200" height="534" alt="image" src="https://github.com/user-attachments/assets/08d6bc68-a197-4893-959b-cefb56158027" />
