### PR TITLE
Bug: Update StatusRemoteUpdatePipeline.php updateMedia method - Integrity constraint violation: 1062 Duplicate entry for media_status_id_media_path_unique

### DIFF
--- a/app/Jobs/StatusPipeline/StatusRemoteUpdatePipeline.php
+++ b/app/Jobs/StatusPipeline/StatusRemoteUpdatePipeline.php
@@ -102,6 +102,9 @@ class StatusRemoteUpdatePipeline implements ShouldQueue
             in_array($nm['mediaType'], explode(',', config_cache('pixelfed.media_types')));
         });
 
+        // Deduplicate attachments by URL to avoid constraint violations
+        $nm = $nm->unique('url');
+
         // Skip when no media
         if (! $ogm->count() && ! $nm->count()) {
             return;

--- a/app/Jobs/StatusPipeline/StatusRemoteUpdatePipeline.php
+++ b/app/Jobs/StatusPipeline/StatusRemoteUpdatePipeline.php
@@ -102,7 +102,17 @@ class StatusRemoteUpdatePipeline implements ShouldQueue
             in_array($nm['mediaType'], explode(',', config_cache('pixelfed.media_types')));
         });
 
-        // Deduplicate attachments by URL to avoid constraint violations
+        // Check for duplicate URLs before removing them
+        $allUrls = $nm->pluck('url');
+        $uniqueUrls = $allUrls->unique();
+        
+        if ($allUrls->count() > $uniqueUrls->count()) {
+            // Find which URLs are duplicated
+            $duplicateUrls = $allUrls->diff($uniqueUrls->values())->unique()->values();
+            Log::warning("StatusRemoteUpdatePipeline: Found duplicate media URLs in status {$status->id}: " . $duplicateUrls->implode(', '));
+        }
+        
+        // Remove duplicates
         $nm = $nm->unique('url');
 
         // Skip when no media


### PR DESCRIPTION
Half patch to #6369

App\Jobs\StatusPipeline\StatusRemoteUpdatePipeline fails with

`PDOException: SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry '897718393792551101-https://abolitionmedia.noblogs.org/files/2...' for key 'media_status_id_media_path_unique' in /home/pixelfed/pixelfed/vendor/laravel/framework/src/Illuminate/Database/MySqlConnection.php:53`


```
"activity": {
"id": "https://abolitionmedia.noblogs.org/?p=23534",
"type": "Note",
"attachment": [
{
"type": "Image",
"url": "https://abolitionmedia.noblogs.org/files/2025/11/pflpgc.cleaned-e1763788936719.jpeg",
"mediaType": "image/jpeg"
},
{
"type": "Image",
"url": "https://abolitionmedia.noblogs.org/files/2025/11/pflpgc.cleaned-e1763788936719.jpeg",
"mediaType": "image/jpeg"
}
],
```