### PR TITLE
[Bug]: public API endpoint /accounts/{id}/statuses ignores max_id parameter

### DIFF
--- a/app/Http/Controllers/PublicApiController.php
+++ b/app/Http/Controllers/PublicApiController.php
@@ -673,6 +673,8 @@ class PublicApiController extends Controller
             'pinned' => 'nullable',
             'exclude_replies' => 'nullable',
             'limit' => 'nullable|integer|min:1|max:24',
+            'max_id' => 'nullable|integer|min:0|max:'.PHP_INT_MAX,
+            'min_id' => 'nullable|integer|min:0|max:'.PHP_INT_MAX,
             'cursor' => 'nullable',
         ]);
 
@@ -718,6 +720,8 @@ class PublicApiController extends Controller
             ->when($pinned, function ($query) {
                 return $query->whereNull('pinned_order');
             })
+            ->when($request->max_id, fn ($query, $max_id) => $query->where('id', '<', $max_id))
+            ->when($request->min_id, fn ($query, $min_id) => $query->where('id', '>', $min_id))
             ->whereIn('type', $scope)
             ->whereIn('scope', $visibility)
             ->orderByDesc('created_at')


### PR DESCRIPTION
Hi,

I returned ability to filter by `max_id` and `min_id` in `App\Http\Controllers\PublicApiController::accountStatuses`. However, I'm not quite sure why this ability was removed.

Fixes #5969.