### PR TITLE
uses max length of 30 instead of 15

### DIFF
--- a/resources/assets/components/invite/AdminInvite.vue
+++ b/resources/assets/components/invite/AdminInvite.vue
@@ -38,7 +38,7 @@
                                 class="form-control form-control-lg"
                                 placeholder="What should everyone call you?"
                                 minlength="2"
-                                maxlength="15"
+u                                maxlength="30"
                                 v-model="form.username" />
 
                             <p v-if="errors.username" class="form-text text-danger">

--- a/resources/views/auth/email/forgot.blade.php
+++ b/resources/views/auth/email/forgot.blade.php
@@ -55,7 +55,7 @@
                                         type="text"
                                         class="form-control form-control-lg bg-glass text-white"
                                         name="username"
-                                        maxlength="15"
+                                        maxlength="30"
                                         placeholder="{{ __('Your username') }}" required>
                                      @if ($errors->has('username') )
                                         <span class="text-danger small mb-3">


### PR DESCRIPTION
I have also fixed this for the `Admininvite.vue`.

if that's somehow not correct, please revert it, but I guess the limitation makes no sense here too!

Closes issue https://github.com/pixelfed/pixelfed/issues/6373 