### PR TITLE
Fix/6399 add multi admin notify for curated onboarding and opt out/in option

### DIFF
--- a/app/Http/Controllers/Settings/PrivacySettings.php
+++ b/app/Http/Controllers/Settings/PrivacySettings.php
@@ -46,6 +46,13 @@ trait PrivacySettings
             'show_atom',
         ];
 
+        // Handle admin-only curated onboarding notification opt-out
+        if ($request->user()->is_admin) {
+            $optOut = $request->input('opt_out_curated_onboarding_notifications') == 'on';
+            $settings->opt_out_curated_onboarding_notifications = $optOut;
+            $settings->save();
+        }
+
         $profile->indexable = $request->input('indexable') == 'on';
         $profile->is_suggestable = $request->input('is_suggestable') == 'on';
         $profile->save();

--- a/app/Jobs/CuratedOnboarding/CuratedOnboardingNotifyAdminNewApplicationPipeline.php
+++ b/app/Jobs/CuratedOnboarding/CuratedOnboardingNotifyAdminNewApplicationPipeline.php
@@ -9,6 +9,7 @@ use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use App\Models\CuratedRegister;
 use App\User;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\Storage;
 use App\Mail\CuratedRegisterNotifyAdmin;
@@ -44,22 +45,87 @@ class CuratedOnboardingNotifyAdminNewApplicationPipeline implements ShouldQueue
     protected function handleBundled()
     {
         $cr = $this->cr;
-        Storage::append('conanap.json', json_encode([
-            'id' => $cr->id,
-            'email' => $cr->email,
-            'created_at' => $cr->created_at,
-            'updated_at' => $cr->updated_at,
-        ]));
+        
+        try {
+            $disk = Storage::disk('local');
+            $filePath = 'conanap.json';
+            
+            $data = json_encode([
+                'id' => $cr->id,
+                'email' => $cr->email,
+                'created_at' => $cr->created_at ? $cr->created_at->toIso8601String() : null,
+                'updated_at' => $cr->updated_at ? $cr->updated_at->toIso8601String() : null,
+            ]);
+            
+            // Use JSONL format (one JSON object per line)
+            // Note: This file should be processed by a scheduled task to send
+            // bundled notifications to all admins
+            $disk->append($filePath, $data . "\n");
+        } catch (\Exception $e) {
+            Log::error('CuratedOnboardingNotifyAdminNewApplicationPipeline: Failed to write bundled notification', [
+                'error' => $e->getMessage(),
+                'curated_register_id' => $cr->id ?? null,
+            ]);
+        }
     }
 
     protected function handleUnbundled()
     {
         $cr = $this->cr;
+        
+        // Get all admins with email addresses
+        $admins = User::whereIsAdmin(true)
+            ->whereNotNull('email')
+            ->where('email', '!=', '')
+            ->get();
+        
+        // Also check if a specific admin is configured
+        $configuredAdmin = null;
         if($aid = config_cache('instance.admin.pid')) {
-            $admin = User::whereProfileId($aid)->first();
-            if($admin && $admin->email) {
-                Mail::to($admin->email)->send(new CuratedRegisterNotifyAdmin($cr));
+            $configuredAdmin = User::whereProfileId($aid)
+                ->whereIsAdmin(true)
+                ->whereNotNull('email')
+                ->where('email', '!=', '')
+                ->first();
+        }
+        
+        // Collect all unique admin emails
+        $adminEmails = $admins->pluck('email')->unique()->filter()->toArray();
+        
+        // Add configured admin email if not already in the list
+        if($configuredAdmin && $configuredAdmin->email && !in_array($configuredAdmin->email, $adminEmails)) {
+            $adminEmails[] = $configuredAdmin->email;
+        }
+        
+        // Get CC addresses from config if set
+        $ccAddresses = config('instance.curated_registration.notify.admin.on_verify_email.cc_addresses');
+        $ccEmails = [];
+        if($ccAddresses) {
+            $ccEmails = array_filter(array_map('trim', explode(',', $ccAddresses)));
+        }
+        
+        // Send email to all admins
+        if(!empty($adminEmails)) {
+            foreach($adminEmails as $email) {
+                try {
+                    $mail = new CuratedRegisterNotifyAdmin($cr);
+                    $mailer = Mail::to($email);
+                    if(!empty($ccEmails)) {
+                        $mailer->cc($ccEmails);
+                    }
+                    $mailer->send($mail);
+                } catch (\Exception $e) {
+                    Log::error('CuratedOnboardingNotifyAdminNewApplicationPipeline: Failed to send notification email', [
+                        'error' => $e->getMessage(),
+                        'admin_email' => $email,
+                        'curated_register_id' => $cr->id ?? null,
+                    ]);
+                }
             }
+        } else {
+            Log::warning('CuratedOnboardingNotifyAdminNewApplicationPipeline: No admin emails found to send notification', [
+                'curated_register_id' => $cr->id ?? null,
+            ]);
         }
     }
 }

--- a/app/Jobs/CuratedOnboarding/CuratedOnboardingNotifyAdminNewApplicationPipeline.php
+++ b/app/Jobs/CuratedOnboarding/CuratedOnboardingNotifyAdminNewApplicationPipeline.php
@@ -73,10 +73,11 @@ class CuratedOnboardingNotifyAdminNewApplicationPipeline implements ShouldQueue
     {
         $cr = $this->cr;
         
-        // Get all admins with email addresses
+        // Get all admins with email addresses and their settings
         $admins = User::whereIsAdmin(true)
             ->whereNotNull('email')
             ->where('email', '!=', '')
+            ->with('settings')
             ->get();
         
         // Also check if a specific admin is configured
@@ -86,15 +87,22 @@ class CuratedOnboardingNotifyAdminNewApplicationPipeline implements ShouldQueue
                 ->whereIsAdmin(true)
                 ->whereNotNull('email')
                 ->where('email', '!=', '')
+                ->with('settings')
                 ->first();
         }
         
-        // Collect all unique admin emails
-        $adminEmails = $admins->pluck('email')->unique()->filter()->toArray();
+        // Filter out admins who have opted out of notifications
+        $adminEmails = $admins->filter(function($admin) {
+            // If settings don't exist or opt_out is false/null, include the admin
+            return !$admin->settings || !$admin->settings->opt_out_curated_onboarding_notifications;
+        })->pluck('email')->unique()->filter()->toArray();
         
-        // Add configured admin email if not already in the list
+        // Add configured admin email if not already in the list and not opted out
         if($configuredAdmin && $configuredAdmin->email && !in_array($configuredAdmin->email, $adminEmails)) {
-            $adminEmails[] = $configuredAdmin->email;
+            $optedOut = $configuredAdmin->settings && $configuredAdmin->settings->opt_out_curated_onboarding_notifications;
+            if(!$optedOut) {
+                $adminEmails[] = $configuredAdmin->email;
+            }
         }
         
         // Get CC addresses from config if set

--- a/database/migrations/2026_01_09_085115_add_opt_out_curated_onboarding_notifications_to_user_settings_table.php
+++ b/database/migrations/2026_01_09_085115_add_opt_out_curated_onboarding_notifications_to_user_settings_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('user_settings', function (Blueprint $table) {
+            $table->boolean('opt_out_curated_onboarding_notifications')->default(false)->after('send_email_on_mention');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('user_settings', function (Blueprint $table) {
+            $table->dropColumn('opt_out_curated_onboarding_notifications');
+        });
+    }
+};

--- a/resources/lang/en/settings.php
+++ b/resources/lang/en/settings.php
@@ -107,6 +107,8 @@ return [
     'privacy.display_following_count_on_profile' =>                     'Display following count on profile',
     'privacy.disable_embeds' =>                                         'Disable Embeds',
     'privacy.disable_post_and_profile_embeds' =>                        'Disable post and profile embeds',
+    'privacy.opt_out_curated_onboarding_notifications' =>               'Opt out of curated onboarding notifications',
+    'privacy.opt_out_curated_onboarding_notifications_help' =>           'When enabled, you will not receive email notifications for new curated onboarding applications.',
     'privacy.enable_atom_feed' =>                                       'Enable Atom Feed',
     'privacy.enable_your_profile_atom_feed_only_public_profiles_etc' => 'Enable your profile atom feed. Only public profiles are eligible.',
     'privacy.confirm_this_action' =>                                    'Confirm this action',

--- a/resources/views/settings/privacy.blade.php
+++ b/resources/views/settings/privacy.blade.php
@@ -105,6 +105,16 @@
       <p class="text-muted small help-text">{{__('settings.privacy.disable_post_and_profile_embeds')}}</p>
     </div>
 
+    @if(auth()->user()->is_admin)
+    <div class="form-check pb-3">
+      <input class="form-check-input" type="checkbox" name="opt_out_curated_onboarding_notifications" id="opt_out_curated_onboarding_notifications" {{$settings->opt_out_curated_onboarding_notifications ? 'checked=""':''}}>
+      <label class="form-check-label font-weight-bold" for="opt_out_curated_onboarding_notifications">
+        {{__('settings.privacy.opt_out_curated_onboarding_notifications')}}
+      </label>
+      <p class="text-muted small help-text">{{__('settings.privacy.opt_out_curated_onboarding_notifications_help')}}</p>
+    </div>
+    @endif
+
     @if(!$settings->is_private)
     <div class="form-check pb-3">
       <input class="form-check-input" type="checkbox" name="show_atom" id="show_atom" {{$settings->show_atom ? 'checked=""':''}}>


### PR DESCRIPTION
This fixes #6399 #6379 #5820 and adds an opt-out/in feature for curated onboarding mails and multi admin functionality.


Screenshot for the opt-out/in:
<img width="930" height="1274" alt="image" src="https://github.com/user-attachments/assets/28c35a5e-0976-42dc-86e0-a369cd933591" />

Screenshot for delivered mails for admins when user `test1` registered and confirmed his mail:
<img width="1279" height="498" alt="image" src="https://github.com/user-attachments/assets/7723644c-32ee-4d07-b14e-48a1550fca90" />
