### PR TITLE
Bugfix: Remote home fanout ignores mutes/blocks due to user_id vs profile_id mismatch

### DIFF
--- a/app/Jobs/HomeFeedPipeline/FeedInsertPipeline.php
+++ b/app/Jobs/HomeFeedPipeline/FeedInsertPipeline.php
@@ -118,7 +118,8 @@ class FeedInsertPipeline implements ShouldBeUniqueUntilProcessing, ShouldQueue
         $filters = UserFilter::whereFilterableType('App\Profile')
             ->whereFilterableId($status['account']['id'])
             ->whereIn('filter_type', ['mute', 'block'])
-            ->pluck('user_id')
+            ->join('profiles', 'user_filters.user_id', '=', 'profiles.user_id')
+            ->pluck('profiles.id')
             ->toArray();
 
         if ($filters && count($filters)) {

--- a/app/Jobs/HomeFeedPipeline/FeedInsertRemotePipeline.php
+++ b/app/Jobs/HomeFeedPipeline/FeedInsertRemotePipeline.php
@@ -116,7 +116,8 @@ class FeedInsertRemotePipeline implements ShouldBeUniqueUntilProcessing, ShouldQ
         $filters = UserFilter::whereFilterableType('App\Profile')
             ->whereFilterableId($status['account']['id'])
             ->whereIn('filter_type', ['mute', 'block'])
-            ->pluck('user_id')
+            ->join('profiles', 'user_filters.user_id', '=', 'profiles.user_id')
+            ->pluck('profiles.id')
             ->toArray();
 
         if ($filters && count($filters)) {

--- a/app/Jobs/HomeFeedPipeline/HashtagInsertFanoutPipeline.php
+++ b/app/Jobs/HomeFeedPipeline/HashtagInsertFanoutPipeline.php
@@ -113,7 +113,12 @@ class HashtagInsertFanoutPipeline implements ShouldBeUniqueUntilProcessing, Shou
             $skipIds = UserDomainBlock::where('domain', $domain)->pluck('profile_id')->toArray();
         }
 
-        $filters = UserFilter::whereFilterableType('App\Profile')->whereFilterableId($status['account']['id'])->whereIn('filter_type', ['mute', 'block'])->pluck('user_id')->toArray();
+        $filters = UserFilter::whereFilterableType('App\Profile')
+            ->whereFilterableId($status['account']['id'])
+            ->whereIn('filter_type', ['mute', 'block'])
+            ->join('profiles', 'user_filters.user_id', '=', 'profiles.user_id')
+            ->pluck('profiles.id')
+            ->toArray();
 
         if ($filters && count($filters)) {
             $skipIds = array_merge($skipIds, $filters);


### PR DESCRIPTION
`Bug: The job mixes user_id values from the user_filters table with profile_id values from follower queries, causing filter comparison to fail.`