### PR TITLE
Bugfix: Reversed follower check in PublicApiController::scopeCheck for private accounts.

### DIFF
--- a/app/Http/Controllers/PublicApiController.php
+++ b/app/Http/Controllers/PublicApiController.php
@@ -191,7 +191,7 @@ class PublicApiController extends Controller
                 if (! $user) {
                     abort(403);
                 } else {
-                    $follows = FollowerService::follows($profile->id, $user->profile_id);
+                    $follows = FollowerService::follows($user->profile_id, $profile->id);
                     if ($follows == false && $profile->id !== $user->profile_id && $user->is_admin == false) {
                         abort(404);
                     }


### PR DESCRIPTION
`The code checks if the status owner (of a private account) follows the viewer, but it should check if the viewer follows the status owner.`