### PR TITLE
Bugfix: Update CustomEmojiService.php to validate emoji downloads before commiting to the DB.

### DIFF
--- a/app/Services/CustomEmojiService.php
+++ b/app/Services/CustomEmojiService.php
@@ -80,10 +80,31 @@ class CustomEmojiService
             }
 
             $ext = '.'.last(explode('/', $json['icon']['mediaType']));
-            $dest = storage_path('app/public/emoji/').$emoji->id.$ext;
-            copy($json['icon']['url'], $dest);
-            $emoji->media_path = 'emoji/'.$emoji->id.$ext;
-            $emoji->save();
+            $mediaPath = 'emoji/'.$emoji->id.$ext;
+            
+            try {
+                $response = Http::timeout(30)
+                    ->withOptions(['max_redirects' => 0])
+                    ->get($json['icon']['url']);
+            
+                if (!$response->successful()) {
+                    return;
+                }
+            
+                // Validate actual content type from response
+                $contentType = $response->header('Content-Type');
+                if (!in_array($contentType, ['image/jpeg', 'image/png', 'image/jpg'])) {
+                    return;
+                }
+            
+                Storage::put('public/'.$mediaPath, $response->body());
+            
+                $emoji->media_path = $mediaPath;
+                $emoji->save();
+            } catch (\Exception $e) {
+                // Download failed
+                return;
+            }
 
             $name = str_replace(':', '', $json['name']);
             Cache::forget('pf:custom_emoji');


### PR DESCRIPTION
`When copy() fails to download an emoji image, the code saves a database record with a media_path pointing to a non-existent file instead of handling the error or rolling back the transaction.`