### PR TITLE
Allow Create activites' 'to' and 'cc' properties to be JSON-LD compliant

### DIFF
--- a/app/Util/ActivityPub/Inbox.php
+++ b/app/Util/ActivityPub/Inbox.php
@@ -252,6 +252,10 @@ class Inbox
         $to = isset($activity['to']) ? $activity['to'] : [];
         $cc = isset($activity['cc']) ? $activity['cc'] : [];
 
+        // JSON-LD allows for arrays with one element to be represented with just the value alone
+        if (is_string($to)) $to = [$to];
+        if (is_string($cc)) $cc = [$cc];
+
         if ($activity['type'] == 'Question') {
             // $this->handlePollCreate();
 


### PR DESCRIPTION
Allows Create activities' `to` and `cc` properties to be individual array values to comply with JSON-LD specification

*From a [similar contribution](https://codeberg.org/rimu/pyfedi/pulls/1531):*
> JSON-LD allows for arrays to be specified by just their first value
>
> I cannot find the specification at the moment, but the [json-ld.org playground](https://json-ld.org/playground/next/) (linked from w3.org) shows this
>
> [Activity with solo To object (playground)](https://json-ld.org/playground/next/#json-ld=%7B%22%40context%22%3A%22https%3A%2F%2Fwww.w3.org%2Fns%2Factivitystreams%22%2C%22to%22%3A%22https%3A%2F%2Fexample.com%22%7D&startTab=tab-expanded) vs [Activity with array of a single To value (playground)](https://json-ld.org/playground/next/#json-ld=%7B%22%40context%22%3A%22https%3A%2F%2Fwww.w3.org%2Fns%2Factivitystreams%22%2C%22to%22%3A%5B%22https%3A%2F%2Fexample.com%22%5D%7D&startTab=tab-expanded)
>
> This change will allow for implementations that use [npm jsonld](https://www.npmjs.com/package/jsonld) (like [fedify](https://fedify.dev)) to correctly interact with Piefed