### PR TITLE
Fix for portfolio with recent images not showing up on PSQL

### DIFF
--- a/app/Http/Controllers/PortfolioController.php
+++ b/app/Http/Controllers/PortfolioController.php
@@ -201,6 +201,7 @@ class PortfolioController extends Controller
             return DB::table('media')
                 ->whereProfileId($id)
                 ->whereNotNull('status_id')
+                ->selectRaw('status_id, MAX(id) as id')
                 ->groupBy('status_id')
                 ->orderByDesc('id')
                 ->take(50)


### PR DESCRIPTION
On instances with PostgreSQL database the portfolio stayed empty when selecting „most recent images“ in the portfolio setting. The following error showed up in the web log: 
`'SQLSTATE[42803]: Grouping error: 7 ERROR: column "media.id" must appear in the GROUP BY clause or be used in an aggregate function\nLINE 1: ...tus_id" is not null group by "status_id" order by "id" desc ...\n ^ (Connection: pgsql, SQL: select "status_id" from "media" where "profile_id" = 810030687742828545 and "status_id" is not null group by "status_id" order by "id" desc limit 50)' `

PR introduces a quick fix for the PSQL group by requirements 

Tested on my instance and working now: https://photos.grossermensch.eu/i/portfolio/severin