### PR TITLE
Fix bug: skipping monthly trending pictures if not enough daily for the Explore view

### DIFF
--- a/resources/assets/components/landing/Explore.vue
+++ b/resources/assets/components/landing/Explore.vue
@@ -99,7 +99,7 @@
 				})
 				.then(res => {
 					if(res && res.data.length) {
-						if(this.rangeIndex == 2 && res.data.length > 3) {
+						if(res.data.length > 3) {
 							this.feed = res.data;
 							this.loading = false;
 						} else {


### PR DESCRIPTION
The intention with the code is that if there are not enough trending pictures on the daily view, we will zoom out and look at monthly trends and pick pictures from those. If it still is missing pictures, zoom out yet again to look for yearly trending pictures. However, the if-statement was written in a way where it would ask for monthly trends and immediately ask for yearly trends. On our server yearly returns no images, so the Explore page would be empty.

This change makes it so that it looks for the monthly trending pictures and evaluates whether to use those or look for yearly trending pictures.