### PR TITLE
Confirm: CreateNote array_merge will push to top of json instead of appending as an array.

### DIFF
--- a/app/Transformer/ActivityPub/Verb/CreateNote.php
+++ b/app/Transformer/ActivityPub/Verb/CreateNote.php
@@ -38,7 +38,7 @@ class CreateNote extends Fractal\TransformerAbstract
                     'href' => $parent->permalink(),
                     'name' => $name,
                 ];
-                $mentions = array_merge($reply, $mentions);
+                array_push($mentions, $reply);
             }
         }
 

--- a/app/Transformer/ActivityPub/Verb/UpdateNote.php
+++ b/app/Transformer/ActivityPub/Verb/UpdateNote.php
@@ -38,7 +38,7 @@ class UpdateNote extends Fractal\TransformerAbstract
                     'href' => $parent->permalink(),
                     'name' => $name,
                 ];
-                $mentions = array_merge($reply, $mentions);
+                array_push($mentions, $reply);
             }
         }
 


### PR DESCRIPTION
```
$current = array_merge($reply, $mentions);
// [
//   'type' => 'Mention',
//   'href' => 'https://pixelfed.social/users/parent',
//   'name' => '@parent',
//   0 => [...alice...],
//   1 => [...bob...],
// ]

$updated = $mentions;
array_push($correct, $reply);
// [
//   0 => [...alice...],
//   1 => [...bob...],
//   2 => ['type' => 'Mention', 'href' => 'https://pixelfed.social/users/parent', 'name' => '@parent'],
// ]
```