### PR TITLE
Update FetchCacheService.php - Cache put/get keys.

### DIFF
--- a/app/Services/FetchCacheService.php
+++ b/app/Services/FetchCacheService.php
@@ -18,7 +18,7 @@ class FetchCacheService
         $ar = $allowRedirects ? 'ar1:' : 'ar0';
         $key = self::CACHE_KEY.sha1($url).':'.$vc.$ar.$ttl;
         if (Cache::has($key)) {
-            return false;
+            return Cache::get($key);
         }
 
         if ($verifyCheck) {
@@ -70,10 +70,11 @@ class FetchCacheService
 
         if (! $res->ok()) {
             Cache::put($key, 1, $ttl);
-
             return false;
         }
 
-        return $res->json();
+        $result = $res->json();
+        Cache::put($key, $result, $ttl);
+        return $result;
     }
 }


### PR DESCRIPTION
```
When the cache contains the key (Cache::has($key) is true), the function returns false instead of retrieving the cached value. Therefore, even if a response were cached, callers never receive it.
The function never stores successful responses in the cache. Only failures are cached (as the integer 1).
```