### PR TITLE
bugfix: Update HashtagFollowService.php iswarm logic. Always returns 0

### DIFF
--- a/app/Services/HashtagFollowService.php
+++ b/app/Services/HashtagFollowService.php
@@ -62,7 +62,7 @@ class HashtagFollowService
 
     public static function isWarm($hid)
     {
-        return Redis::zcount(self::CACHE_KEY.$hid, 0, -1) ?? Redis::zscore(self::CACHE_WARMED, $hid) != null;
+        return Redis::zcard(self::CACHE_KEY.$hid) > 0 || Redis::zscore(self::CACHE_WARMED, $hid) !== null;
     }
 
     public static function setWarm($hid)


### PR DESCRIPTION
```
Use zcard to check if the set exists and has elements 

https://redis.io/docs/latest/commands/zcard/
Returns the sorted set cardinality (number of elements) of the sorted set stored at key.

Use a logical OR to fall back to CACHE_WARMED check
```