### PR TITLE
Bugfix: Update DeleteRemoteProfilePipeline.php - reported_profile_id IS NULL condition deleting unrelated reports

### DIFF
--- a/app/Jobs/DeletePipeline/DeleteRemoteProfilePipeline.php
+++ b/app/Jobs/DeletePipeline/DeleteRemoteProfilePipeline.php
@@ -134,7 +134,7 @@ class DeleteRemoteProfilePipeline implements ShouldQueue
             });
 
         // Delete reports
-        Report::whereProfileId($profile->id)->orWhere('reported_profile_id')->forceDelete();
+        Report::whereProfileId($pid)->orWhere('reported_profile_id', $pid)->forceDelete();
 
         // Delete profile
         Profile::findOrFail($profile->id)->delete();


### PR DESCRIPTION
`DeleteRemoteProfilePipeline deletes unrelated reports (reported_profile_id IS NULL)`