### PR TITLE
bugfix: Remove a unnecessary join from Hashtag fanout

### DIFF
--- a/app/Jobs/HomeFeedPipeline/FeedInsertPipeline.php
+++ b/app/Jobs/HomeFeedPipeline/FeedInsertPipeline.php
@@ -118,8 +118,7 @@ class FeedInsertPipeline implements ShouldBeUniqueUntilProcessing, ShouldQueue
         $filters = UserFilter::whereFilterableType('App\Profile')
             ->whereFilterableId($status['account']['id'])
             ->whereIn('filter_type', ['mute', 'block'])
-            ->join('profiles', 'user_filters.user_id', '=', 'profiles.user_id')
-            ->pluck('profiles.id')
+            ->pluck('user_id')
             ->toArray();
 
         if ($filters && count($filters)) {

--- a/app/Jobs/HomeFeedPipeline/FeedInsertRemotePipeline.php
+++ b/app/Jobs/HomeFeedPipeline/FeedInsertRemotePipeline.php
@@ -116,8 +116,7 @@ class FeedInsertRemotePipeline implements ShouldBeUniqueUntilProcessing, ShouldQ
         $filters = UserFilter::whereFilterableType('App\Profile')
             ->whereFilterableId($status['account']['id'])
             ->whereIn('filter_type', ['mute', 'block'])
-            ->join('profiles', 'user_filters.user_id', '=', 'profiles.user_id')
-            ->pluck('profiles.id')
+            ->pluck('user_id')
             ->toArray();
 
         if ($filters && count($filters)) {

--- a/app/Jobs/HomeFeedPipeline/HashtagInsertFanoutPipeline.php
+++ b/app/Jobs/HomeFeedPipeline/HashtagInsertFanoutPipeline.php
@@ -116,8 +116,7 @@ class HashtagInsertFanoutPipeline implements ShouldBeUniqueUntilProcessing, Shou
         $filters = UserFilter::whereFilterableType('App\Profile')
             ->whereFilterableId($status['account']['id'])
             ->whereIn('filter_type', ['mute', 'block'])
-            ->join('profiles', 'user_filters.user_id', '=', 'profiles.user_id')
-            ->pluck('profiles.id')
+            ->pluck('user_id')
             ->toArray();
 
         if ($filters && count($filters)) {


### PR DESCRIPTION
`Remove the unnecessary join and pluck user_id directly from the user_filters table, as it already contains the required profile_id.`