### PR TITLE
Accept ActivityPub Article type objects

### DIFF
--- a/app/Http/Controllers/SearchController.php
+++ b/app/Http/Controllers/SearchController.php
@@ -88,7 +88,7 @@ class SearchController extends Controller
         ) {
             $remote = Helpers::fetchFromUrl($tag);
             if (isset($remote['type']) &&
-                in_array($remote['type'], ['Note', 'Question'])
+                in_array($remote['type'], ['Note', 'Question', 'Article'])
             ) {
                 $item = Helpers::statusFetch($tag);
                 $this->tokens['posts'] = [[
@@ -343,7 +343,7 @@ class SearchController extends Controller
 
         $remote = Helpers::fetchFromUrl($tag);
 
-        if (isset($remote['type']) && $remote['type'] == 'Note') {
+        if (isset($remote['type']) && in_array($remote['type'], ['Note', 'Article'])) {
             $item = Helpers::statusFetch($tag);
             if (! $item) {
                 return;

--- a/app/Services/SearchApiV2Service.php
+++ b/app/Services/SearchApiV2Service.php
@@ -306,7 +306,7 @@ class SearchApiV2Service
                 if ($res) {
                     $json = json_decode($res, true);
 
-                    if (! $json || ! isset($json['@context']) || ! isset($json['type']) || ! in_array($json['type'], ['Note', 'Person'])) {
+                    if (! $json || ! isset($json['@context']) || ! isset($json['type']) || ! in_array($json['type'], ['Note', 'Person', 'Article'])) {
                         return [
                             'accounts' => [],
                             'hashtags' => [],
@@ -316,6 +316,7 @@ class SearchApiV2Service
 
                     switch ($json['type']) {
                         case 'Note':
+                        case 'Article':
                             $obj = Helpers::statusFetch($query);
                             if (! $obj || ! isset($obj['id'])) {
                                 return $default;

--- a/app/Util/ActivityPub/Helpers.php
+++ b/app/Util/ActivityPub/Helpers.php
@@ -589,7 +589,7 @@ class Helpers
         $url = self::getStatusUrl($activity, $id);
 
         if ((! isset($activity['type']) ||
-             in_array($activity['type'], ['Create', 'Note'])) &&
+             in_array($activity['type'], ['Create', 'Note', 'Article'])) &&
             ! self::validateStatusDomains($id, $url)) {
             throw new \Exception('Invalid status domains');
         }

--- a/app/Util/ActivityPub/Inbox.php
+++ b/app/Util/ActivityPub/Inbox.php
@@ -273,10 +273,10 @@ class Inbox
             return;
         }
 
-        if ($activity['type'] == 'Note' && ! empty($activity['inReplyTo'])) {
+        if (in_array($activity['type'], ['Note', 'Article']) && ! empty($activity['inReplyTo'])) {
             $this->handleNoteReply();
 
-        } elseif ($activity['type'] == 'Note' && ! empty($activity['attachment'])) {
+        } elseif (in_array($activity['type'], ['Note', 'Article']) && ! empty($activity['attachment'])) {
             if (! $this->verifyNoteAttachment()) {
                 return;
             }
@@ -1431,7 +1431,7 @@ class Inbox
             return;
         }
 
-        if ($activity['type'] === 'Note') {
+        if (in_array($activity['type'], ['Note', 'Article'])) {
             if (Status::whereObjectUrl($activity['id'])->exists()) {
                 StatusRemoteUpdatePipeline::dispatch($activity);
             }


### PR DESCRIPTION
## Summary

- Add support for incoming `Article` objects ([FEP-b2b8](https://codeberg.org/fediverse/fep/src/branch/main/fep/b2b8/fep-b2b8.md)) so that blog posts from platforms like WordPress, WriteFreely, and NodeBB appear on Pixelfed when they include image attachments
- Route `Article` through the same create, update, and search pipelines as `Note`
- Apply the same domain validation to `Article` URLs as to `Note` URLs

## Changes

- **`app/Util/ActivityPub/Inbox.php`** — accept `Article` in `handleCreateActivity()` (reply and attachment branches) and `handleUpdateActivity()`
- **`app/Util/ActivityPub/Helpers.php`** — include `Article` in domain validation within `storeStatus()`
- **`app/Http/Controllers/SearchController.php`** — accept `Article` in `getPosts()` and `getByUrl()`
- **`app/Services/SearchApiV2Service.php`** — accept `Article` in API v2 search type checks and route it alongside `Note`

## What this does NOT change

- Articles without attachments are still dropped (same as Notes) — Pixelfed is an image platform
- Outgoing posts still emit `Note` — no change to how Pixelfed publishes
- Attachment limits (`MAX_ALBUM_LENGTH`) still apply

## Test plan

- [ ] Search for an Article URL via Pixelfed search — it should resolve and display
- [ ] Incoming Create activity wrapping an Article with image attachments should create a status
- [ ] Update activity for an existing Article should update the status
- [ ] Articles without attachments should still be dropped