### PR TITLE
Add missing french translations (on the auth pages)

### DIFF
--- a/resources/lang/fr/auth.php
+++ b/resources/lang/fr/auth.php
@@ -12,7 +12,31 @@ return [
     |
      */
 
-    'failed'      =>    'Ces informations d\'identification ne correspondent à aucune se trouvant dans notre base de données.',
+    'failed'      =>    'Ces informations d’identification ne correspondent à aucune se trouvant dans notre base de données.',
     'throttle'    =>    'Trop de tentatives de connexion ont été effectuées. Veuillez réessayer dans :seconds secondes.',
     'verifyYourEmailAddress' => ' - Vérifiez votre adresse de courrier électronique',
+    'loginTitle'       =>   'Connexion à mon compte',
+    'password'         =>   'Mot de passe' ,
+    'remember'         =>   'Se souvenir de moi',
+    'forgot'           =>   'Mot de passe oublié',
+    'login'            =>   'Se connecter',
+
+    'register'         =>   'S’inscrire',
+    'reset'            =>   'Réinitialiser le mot de passe',
+
+    'name'             =>   'Nom public',
+    'username'         =>   'Identifiant',
+    'confirm-password' =>   'Confirmer le mot de passe',
+
+    'age'              =>   'J’ai 16 ans ou plus',
+    'terms'            =>   "En vous inscrivant, vous acceptez nos <a href=\"".route('site.terms')."\" class=\"font-weight-bold text-dark\">conditions d’utilisation</a> et <a href=\"".route('site.privacy')."\" class=\"font-weight-bold text-dark\">politique de confidentialité</a>.",
+
+    'emailAddress'     =>   "Adresse de courriel",
+
+    'registerTitle'    =>   'Créer un nouveau profil',
+
+    'sendReset'        =>   'Envoyer le lien de réinitialisation de mot de passe',
+    'backLogin'        =>   'Retour à l’identification',
+
+    'signInMastodon'  => 'S’inscrire avec Mastodon',
 ];


### PR DESCRIPTION
Hello,
This merge request adds missing french translations for the auth / login pages.
It has been validated on the test instance of our (french speaking) association.
Thanks in advance!