### PR TITLE
Update PublicApiController.php for findOrFail($username)

### DIFF
--- a/app/Http/Controllers/PublicApiController.php
+++ b/app/Http/Controllers/PublicApiController.php
@@ -130,7 +130,7 @@ class PublicApiController extends Controller
         ]);
 
         $limit = $request->limit ?? 10;
-        $profile = Profile::whereNull('status')->findOrFail($username);
+        $profile = Profile::whereUsername($username)->whereNull('status')->firstOrFail();
         $status = Status::whereProfileId($profile->id)->whereCommentsDisabled(false)->findOrFail($postId);
         $this->scopeCheck($profile, $status);
 


### PR DESCRIPTION
`The findOrFail() method expects an integer ID as its parameter, but $username is a string.`

took `$profile = Profile::whereUsername($username)->whereNull('status')->firstOrFail();` from line 93