### PR TITLE
Bugfix: TypeError: can't access property "avatar", s.account is null in notification components

### DIFF
--- a/app/Http/Controllers/Api/ApiV1Controller.php
+++ b/app/Http/Controllers/Api/ApiV1Controller.php
@@ -2534,6 +2534,10 @@ class ApiV1Controller extends Controller
                 return $n;
             })
             ->filter(function ($n) use ($pe) {
+                if (! isset($n['account']) || ! is_array($n['account']) || ! isset($n['account']['id'])) {
+                    return false;
+                }
+
                 if (in_array($n['type'], ['mention', 'reblog', 'favourite'])) {
                     return isset($n['status'], $n['status']['id']);
                 }

--- a/app/Services/AccountService.php
+++ b/app/Services/AccountService.php
@@ -27,7 +27,7 @@ class AccountService
             $fractal = new Fractal\Manager;
             $fractal->setSerializer(new ArraySerializer);
             $profile = Profile::find($id);
-            if (! $profile || $profile->status === 'delete') {
+            if (! $profile || in_array($profile->status, ['delete', 'suspended', 'banned'])) {
                 return null;
             }
             $resource = new Fractal\Resource\Item($profile, new AccountTransformer);

--- a/app/Services/NotificationService.php
+++ b/app/Services/NotificationService.php
@@ -126,7 +126,10 @@ class NotificationService
             $n = self::rewriteMastodonTypes(self::getNotification($id));
             if ($n != null && in_array($n['type'], self::MASTODON_TYPES)) {
                 if (isset($n['account'])) {
-                    $n['account'] = AccountService::getMastodon($n['account']['id']);
+                    $n['account'] = AccountService::getMastodon($n['account']['id'], true);
+                    if (! $n['account']) {
+                        continue;
+                    }
                 }
 
                 if (isset($n['relationship'])) {
@@ -162,7 +165,10 @@ class NotificationService
             $n = self::rewriteMastodonTypes(self::getNotification($id));
             if ($n != null && in_array($n['type'], self::MASTODON_TYPES)) {
                 if (isset($n['account'])) {
-                    $n['account'] = AccountService::getMastodon($n['account']['id']);
+                    $n['account'] = AccountService::getMastodon($n['account']['id'], true);
+                    if (! $n['account']) {
+                        continue;
+                    }
                 }
 
                 if (isset($n['relationship'])) {

--- a/resources/assets/components/partials/TimelineStatus.vue
+++ b/resources/assets/components/partials/TimelineStatus.vue
@@ -257,6 +257,9 @@
             },
 
             getStatusAvatar() {
+                if(!this.status.account) {
+                    return '/storage/avatars/default.png?v=0';
+                }
                 if (window._sharedData.user.id == this.status.account.id) {
                     return window._sharedData.user.avatar;
                 }
@@ -310,7 +313,7 @@
                     .filter(m => m.hasOwnProperty("license") && m.license && m.license.hasOwnProperty("id"))
                     .map(m => m.license)[0] : false;
             this.admin = window._sharedData.user.is_admin;
-            this.owner = this.shadowStatus.account.id == window._sharedData.user.id;
+            this.owner = this.shadowStatus.account && this.shadowStatus.account.id == window._sharedData.user.id;
             if (this.shadowStatus.reply_count && this.autoloadComments && this.shadowStatus.comments_disabled === false) {
                 setTimeout(() => {
                     this.showCommentDrawer = true;

--- a/resources/assets/components/partials/post/PostHeader.vue
+++ b/resources/assets/components/partials/post/PostHeader.vue
@@ -11,7 +11,7 @@
             </div>
         </div>
         <div class="card-header border-0" style="border-top-left-radius: 15px;border-top-right-radius: 15px;">
-            <div class="media align-items-center">
+            <div class="media align-items-center" v-if="status && status.account">
                 <a :href="status.account.url" @click.prevent="goToProfile()" style="margin-right: 10px;">
                     <img :src="getStatusAvatar()" style="border-radius:15px;" width="44" height="44" onerror="this.onerror=null;this.src='/storage/avatars/default.png?v=0';">
                 </a>
@@ -363,6 +363,9 @@
             },
 
             getStatusAvatar() {
+                if(!this.status.account) {
+                    return '/storage/avatars/default.png?v=0';
+                }
                 if(window._sharedData.user.id == this.status.account.id) {
                     return window._sharedData.user.avatar;
                 }

--- a/resources/assets/components/partials/post/PostReactions.vue
+++ b/resources/assets/components/partials/post/PostReactions.vue
@@ -236,6 +236,9 @@
 			},
 
 			getStatusAvatar() {
+				if(!this.status.account) {
+					return '/storage/avatars/default.png?v=0';
+				}
 				if(window._sharedData.user.id == this.status.account.id) {
 					return window._sharedData.user.avatar;
 				}

--- a/resources/assets/components/sections/Notifications.vue
+++ b/resources/assets/components/sections/Notifications.vue
@@ -35,7 +35,7 @@
 
 					<template v-else>
 						<div v-for="(n, index) in feed" class="mb-2">
-							<div class="media align-items-center">
+							<div v-if="n.account" class="media align-items-center">
 								<img
 									v-if="n.type === 'autospam.warning'"
 									class="mr-2 rounded-circle shadow-sm p-1"

--- a/resources/assets/components/sections/Timeline.vue
+++ b/resources/assets/components/sections/Timeline.vue
@@ -297,7 +297,7 @@
                     }
                     this.ids = ids;
                     this.max_id = Math.min(...ids);
-                    this.feed = res.data;
+                    this.feed = res.data.filter(p => p && p.account && (!p.reblog || p.reblog.account));
 
                     if(res.data.length < 4) {
                         this.canLoadMore = false;
@@ -358,7 +358,7 @@
                     }
                     setTimeout(() => {
                         res.data.forEach(p => {
-                            if(this.ids.indexOf(p.id) == -1) {
+                            if(this.ids.indexOf(p.id) == -1 && p && p.account && (!p.reblog || p.reblog.account)) {
                                 if(this.max_id > p.id) {
                                     this.max_id = p.id;
                                 }

--- a/resources/assets/components/sections/Timeline.vue
+++ b/resources/assets/components/sections/Timeline.vue
@@ -297,7 +297,7 @@
                     }
                     this.ids = ids;
                     this.max_id = Math.min(...ids);
-                    this.feed = res.data.filter(p => p && p.account && (!p.reblog || p.reblog.account));
+                    this.feed = res.data;
 
                     if(res.data.length < 4) {
                         this.canLoadMore = false;
@@ -358,7 +358,7 @@
                     }
                     setTimeout(() => {
                         res.data.forEach(p => {
-                            if(this.ids.indexOf(p.id) == -1 && p && p.account && (!p.reblog || p.reblog.account)) {
+                            if(this.ids.indexOf(p.id) == -1) {
                                 if(this.max_id > p.id) {
                                     this.max_id = p.id;
                                 }

--- a/resources/assets/js/components/NotificationCard.vue
+++ b/resources/assets/js/components/NotificationCard.vue
@@ -15,7 +15,8 @@
 						<p class="mb-0 text-lighter"><i class="fas fa-chevron-right"></i></p>
 					</div>
 				</div>
-				<div v-if="notifications.length > 0" class="media align-items-center px-3 py-2 border-bottom border-light" v-for="(n, index) in notifications">
+				<div v-if="notifications.length > 0" class="media align-items-center px-3 py-2 border-bottom border-light" v-for="(n, index) in notifications" :key="'notif-'+index">
+					<template v-if="n.account">
 					<img class="mr-2 rounded-circle" style="border:1px solid #ccc" :src="n.account.avatar" alt="" width="32px" height="32px" onerror="this.onerror=null;this.src='/storage/avatars/default.png';">
 					<div class="media-body font-weight-light small">
 						<div v-if="n.type == 'favourite'">
@@ -126,6 +127,7 @@
 						</div>
 					</div>
 					<div class="small text-muted font-weight-bold" :title="n.created_at">{{timeAgo(n.created_at)}}</div>
+					</template>
 				</div>
 				<div v-if="notifications.length">
 					<infinite-loading @infinite="infiniteNotifications">
@@ -186,6 +188,9 @@
 				axios.get('/api/pixelfed/v1/notifications?pg=true')
 				.then(res => {
 					let data = res.data.filter(n => {
+						if(!n.account) {
+							return false;
+						}
 						if(n.type == 'share' && !n.status) {
 							return false;
 						}
@@ -226,6 +231,9 @@
 				}).then(res => {
 					if(res.data.length) {
 						let data = res.data.filter(n => {
+							if(!n.account) {
+								return false;
+							}
 							if(n.type == 'share' && !n.status) {
 								return false;
 							}


### PR DESCRIPTION
Problem: 
The notification list crashes and just shows an infinite spinning notification card.
<img width="352" height="203" alt="image" src="https://github.com/user-attachments/assets/4d1f52ea-50a7-4780-87a5-4cfe98da2a1d" />


Trying to fix type error for account avatar.

root cause was discovered.. I got a spam DM, reported it and then deleted the account using the moderation portal.

This resulted in null account follow/direct type notifications. 

<img width="507" height="708" alt="image" src="https://github.com/user-attachments/assets/2833b095-67dc-4fe5-a769-5866bf668537" />


```
TypeError: can't access property "avatar", s.account is null

    a https://pixelfed.au/js/home.chunk.f0d8948dbe6b4132.js:2
```