### PR TITLE
Append account_status to the Relationship array.

### DIFF
--- a/app/Http/Controllers/Api/ApiV1Controller.php
+++ b/app/Http/Controllers/Api/ApiV1Controller.php
@@ -1084,6 +1084,7 @@ class ApiV1Controller extends Controller
                         'domain_blocking' => false,
                         'showing_reblogs' => false,
                         'endorsed' => false,
+                        'account_status' => 'active',
                     ];
                 }
 

--- a/app/Services/RelationshipService.php
+++ b/app/Services/RelationshipService.php
@@ -4,6 +4,7 @@ namespace App\Services;
 
 use App\Follower;
 use App\FollowRequest;
+use App\Profile;
 use App\UserFilter;
 use Illuminate\Support\Facades\Cache;
 
@@ -24,6 +25,8 @@ class RelationshipService
         }
 
         return Cache::remember(self::key("a_{$aid}:t_{$tid}"), 1209600, function () use ($aid, $tid) {
+            $targetProfile = Profile::find($tid);
+
             return [
                 'id' => (string) $tid,
                 'following' => Follower::whereProfileId($aid)->whereFollowingId($tid)->exists(),
@@ -45,6 +48,7 @@ class RelationshipService
                 'domain_blocking' => false,
                 'showing_reblogs' => false,
                 'endorsed' => false,
+                'account_status' => $targetProfile && $targetProfile->status ? $targetProfile->status : 'active',
             ];
         });
     }
@@ -88,6 +92,7 @@ class RelationshipService
             'domain_blocking' => false,
             'showing_reblogs' => false,
             'endorsed' => false,
+            'account_status' => 'active',
         ];
     }
 

--- a/app/Transformer/Api/RelationshipTransformer.php
+++ b/app/Transformer/Api/RelationshipTransformer.php
@@ -42,6 +42,7 @@ class RelationshipTransformer extends Fractal\TransformerAbstract
             'domain_blocking' => $domainBlocking,
             'showing_reblogs' => false,
             'endorsed' => false,
+            'account_status' => $profile->status ?? 'active',
         ];
     }
 }


### PR DESCRIPTION
I don't understand why `$profile->status` returns null for active but "deleted/suspended/banned" for those status types.

Why isn't it active?