### PR TITLE
Update BaseApiController.php - Fix #6478

### DIFF
--- a/app/Http/Controllers/Api/BaseApiController.php
+++ b/app/Http/Controllers/Api/BaseApiController.php
@@ -69,6 +69,12 @@ class BaseApiController extends Controller
             NotificationWarmUserCache::dispatch($pid);
         }
 
+        $res = collect($res)
+            ->filter(function ($n) {
+                return isset($n['account'], $n['account']['id']);
+            })
+            ->values();
+
         return response()->json($res);
     }
 


### PR DESCRIPTION
Fix #6478

Removes the notifications if the account is null (suspended/deleted/banned)

<img width="507" height="708" alt="image" src="https://github.com/user-attachments/assets/8989d4d4-d08b-436b-bd7a-ba7633f83a3c" />
