### PR TITLE
Resizing of the comment field is not working - PR for Issue 6485 

### DIFF
--- a/resources/assets/components/groups/partials/GroupCompose.vue
+++ b/resources/assets/components/groups/partials/GroupCompose.vue
@@ -24,7 +24,6 @@
 								}"
 								:rows="!composeText || composeText.length < 40 ? 1 : 5"
 								:placeholder="placeholder"
-								style="resize: none;"
 								v-model="composeText"
 								></textarea>
 

--- a/resources/assets/components/partials/post/CommentDrawer.vue
+++ b/resources/assets/components/partials/post/CommentDrawer.vue
@@ -311,8 +311,8 @@
 					<textarea
                         class="form-control bg-light rounded-sm shadow-sm rounded-pill"
                         placeholder="Write a comment...."
-                        style="resize: none;padding-right:140px;"
-                        rows="1"
+                        style="padding-right:140px;"
+                        rows="2"
                         v-model="replyContent"
                         :disabled="isPostingReply"></textarea>
 				</vue-tribute>

--- a/resources/assets/components/partials/post/CommentReplyForm.vue
+++ b/resources/assets/components/partials/post/CommentReplyForm.vue
@@ -5,7 +5,8 @@
 
             <div style="display: flex;flex-grow: 1;position: relative;">
         		<textarea
-        			class="form-control bg-light rounded-lg shadow-sm" style="resize: none;padding-right: 60px;"
+        			class="form-control bg-light rounded-lg shadow-sm rounded-pill" style="padding-right: 60px;"
+              rows="2"
         			placeholder="Write a comment...."
         			v-model="replyContent"
         			:disabled="isPostingReply" />


### PR DESCRIPTION
Commit for bug https://github.com/pixelfed/pixelfed/issues/6485

- it uses 2 rows for textarea
- it removes the resize:none
- makes the textarea also rounded

Fixes pixelfed/pixelfed#6485