### PR TITLE
Update logging.php to default to `daily` via stack

### DIFF
--- a/config/logging.php
+++ b/config/logging.php
@@ -36,7 +36,7 @@ return [
     'channels' => [
         'stack' => [
             'driver'   => 'stack',
-            'channels' => ['single'],
+            'channels' => ['daily'],
             'ignore_exceptions' => false,
         ],
 


### PR DESCRIPTION
As you mentioned, the default should be daily.... but the .env.examples and code default to stack that points to single.

Updated to match your expectations.