### PR TITLE
Make sure profile saving has a clear error when email is not verified

### DIFF
--- a/app/Http/Controllers/Settings/HomeSettings.php
+++ b/app/Http/Controllers/Settings/HomeSettings.php
@@ -60,7 +60,7 @@ trait HomeSettings
         $enforceEmailVerification = config_cache('pixelfed.enforce_email_verification');
 
         // Only allow email to be updated if not yet verified
-        if (! $enforceEmailVerification || ! $changes && $user->email_verified_at) {
+        if (! $enforceEmailVerification || $user->email_verified_at) {
             if ($profile->name != $name) {
                 $changes = true;
                 $user->name = $name;
@@ -92,6 +92,8 @@ trait HomeSettings
                     PronounService::put($profile->id, $pronouns);
                 }
             }
+        } else {
+            return redirect('/settings/home')->with('status', 'Verify your email address before you can update your profile!');
         }
 
         if ($changes === true) {


### PR DESCRIPTION
Closes #6492

This ensures that a correct error message is shown when a user needs to verify their email address before changing their profile.