### PR TITLE
zcard > 0 incorrectly implies the cache is fully warmed

### DIFF
--- a/app/Services/HashtagFollowService.php
+++ b/app/Services/HashtagFollowService.php
@@ -62,7 +62,7 @@ class HashtagFollowService
 
     public static function isWarm($hid)
     {
-        return Redis::zcard(self::CACHE_KEY.$hid) > 0 || Redis::zscore(self::CACHE_WARMED, $hid) !== null;
+        return Redis::zscore(self::CACHE_WARMED, $hid) !== null;
     }
 
     public static function setWarm($hid)


### PR DESCRIPTION
`[zcard > 0 incorrectly implies the cache is fully warmed]` so the check is redundant.