### PR TITLE
Fix AccountTransformer.php make sure the acct handle contains the domain suffix for remote users.

### DIFF
--- a/app/Transformer/Api/Mastodon/v1/AccountTransformer.php
+++ b/app/Transformer/Api/Mastodon/v1/AccountTransformer.php
@@ -11,11 +11,12 @@ class AccountTransformer extends Fractal\TransformerAbstract
     {
         $local = $profile->domain == null;
         $username = $local ? $profile->username : explode('@', substr($profile->username, 1))[0];
+        $acct = $local ? $profile->username : substr($profile->username, 1);
 
         return [
             'id' => (string) $profile->id,
             'username' => $username,
-            'acct' => $username,
+            'acct' => $acct,
             'display_name' => $profile->name,
             'locked' => (bool) $profile->is_private,
             'bot' => false,


### PR DESCRIPTION
`the acct handle lacks the domain suffix (e.g., it shows "alice" instead of "alice@example.com") for remote users.`