### PR TITLE
Refactored StatusDelete jobs that currently skip deletion if the profile is soft-deleted

### DIFF
--- a/app/Jobs/StatusPipeline/StatusDelete.php
+++ b/app/Jobs/StatusPipeline/StatusDelete.php
@@ -181,7 +181,7 @@ class StatusDelete implements ShouldQueue
         $profile = $status->profile()->withTrashed()->first();
 
         if (! $profile) {
-            return
+            return;
         }
 
         $audience = $status->profile->getAudienceInbox();

--- a/app/Jobs/StatusPipeline/StatusDelete.php
+++ b/app/Jobs/StatusPipeline/StatusDelete.php
@@ -77,7 +77,7 @@ class StatusDelete implements ShouldQueue
             return;
         }
 
-        $profile = $status->profile;
+        $profile = $status->profile()->withTrashed()->first();
 
         // Verify profile exists
         if (! $profile) {
@@ -178,10 +178,10 @@ class StatusDelete implements ShouldQueue
 
     public function fanoutDelete($status)
     {
-        $profile = $status->profile;
+        $profile = $status->profile()->withTrashed()->first();
 
         if (! $profile) {
-            return;
+            return $this->unlinkRemoveMedia($status);
         }
 
         $audience = $status->profile->getAudienceInbox();

--- a/app/Jobs/StatusPipeline/StatusDelete.php
+++ b/app/Jobs/StatusPipeline/StatusDelete.php
@@ -181,7 +181,7 @@ class StatusDelete implements ShouldQueue
         $profile = $status->profile()->withTrashed()->first();
 
         if (! $profile) {
-            return $this->unlinkRemoveMedia($status);
+            return
         }
 
         $audience = $status->profile->getAudienceInbox();


### PR DESCRIPTION
Account deletion can leave orphaned statuses/media because the check `if (! $profile)` returns null if profile is soft-deleted

Now it will still delete the 

In `app/Jobs/StatusPipeline/StatusDelete.php:`
```
$profile = $status->profile;

// Verify profile exists
if (! $profile) {
    Log::info("StatusDelete: Profile no longer exists for status {$status->id}, skipping job"); // <-- BUG 🔴 Early return prevents status/media deletion + federation delete fanout

    return;
}
```