### PR TITLE
Revert passport v13 change to uuid from bigint 

### DIFF
--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -27,6 +27,7 @@ class AuthServiceProvider extends ServiceProvider
     public function boot()
     {
         if (config('pixelfed.oauth_enabled') == true) {
+            Passport::$clientUuids = false;
             Passport::ignoreRoutes();
             Passport::tokensExpireIn(now()->addDays(config('instance.oauth.token_expiration', 356)));
             Passport::refreshTokensExpireIn(now()->addDays(config('instance.oauth.refresh_expiration', 400)));


### PR DESCRIPTION
Revert change to uuid from bigint as described in upgrade.md for passport v13.x (https://github.com/laravel/passport/blob/13.x/UPGRADE.md) to fix passport issues 