### PR TITLE
Add exif PHP extension to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ RUN apt-get update && apt-get install -y \
 RUN install-php-extensions \
     bcmath \
     curl \
+    exif \
     gd \
     imagick \
     intl \


### PR DESCRIPTION
The exif extension is [part of the prerequisites](https://docs.pixelfed.org/running-pixelfed/prerequisites.html) but is not installed in Docker.