### PR TITLE
Federation: Valid ActivityPub Content-Type variants are rejected, causing remote fetch failures

### DIFF
--- a/app/Services/ActivityPubFetchService.php
+++ b/app/Services/ActivityPubFetchService.php
@@ -117,20 +117,41 @@ class ActivityPubFetchService
             return;
         }
 
-        $acceptedTypes = [
-            'application/activity+json; charset=utf-8',
-            'application/activity+json',
-            'application/ld+json; profile="https://www.w3.org/ns/activitystreams"',
-        ];
-
         $contentType = $res->getHeader('Content-Type')[0];
 
         if (! $contentType) {
             return;
         }
 
-        if (! in_array($contentType, $acceptedTypes)) {
+        // Parse Content-Type: extract media type (case-insensitive) and parameters
+        $contentTypeParts = array_map('trim', explode(';', $contentType));
+        $mediaType = strtolower($contentTypeParts[0]);
+
+        $acceptedMediaTypes = [
+            'application/activity+json',
+            'application/ld+json',
+        ];
+
+        if (! in_array($mediaType, $acceptedMediaTypes)) {
             return;
+        }
+
+        // For application/ld+json, verify the ActivityStreams profile parameter
+        if ($mediaType === 'application/ld+json') {
+            $hasActivityStreamsProfile = false;
+            foreach (array_slice($contentTypeParts, 1) as $param) {
+                $param = trim($param);
+                if (stripos($param, 'profile=') === 0) {
+                    $profile = trim(substr($param, strlen('profile=')), ' "\'');
+                    if ($profile === 'https://www.w3.org/ns/activitystreams') {
+                        $hasActivityStreamsProfile = true;
+                        break;
+                    }
+                }
+            }
+            if (! $hasActivityStreamsProfile) {
+                return;
+            }
         }
 
         return $returnJsonFormat ? $res->json() : $res->body();

--- a/app/Services/ActivityPubFetchService.php
+++ b/app/Services/ActivityPubFetchService.php
@@ -136,23 +136,24 @@ class ActivityPubFetchService
             return;
         }
 
-        // For application/ld+json, verify the ActivityStreams profile parameter
-        if ($mediaType === 'application/ld+json') {
-            $hasActivityStreamsProfile = false;
-            foreach (array_slice($contentTypeParts, 1) as $param) {
-                $param = trim($param);
-                if (stripos($param, 'profile=') === 0) {
-                    $profile = trim(substr($param, strlen('profile=')), ' "\'');
-                    if ($profile === 'https://www.w3.org/ns/activitystreams') {
-                        $hasActivityStreamsProfile = true;
-                        break;
-                    }
-                }
-            }
-            if (! $hasActivityStreamsProfile) {
-                return;
-            }
-        }
+        //// For application/ld+json, verify the ActivityStreams profile parameter
+        // TODO: Validate if this check is required
+        // if ($mediaType === 'application/ld+json') {
+        //     $hasActivityStreamsProfile = false;
+        //     foreach (array_slice($contentTypeParts, 1) as $param) {
+        //         $param = trim($param);
+        //         if (stripos($param, 'profile=') === 0) {
+        //             $profile = trim(substr($param, strlen('profile=')), ' "\'');
+        //             if ($profile === 'https://www.w3.org/ns/activitystreams') {
+        //                 $hasActivityStreamsProfile = true;
+        //                 break;
+        //             }
+        //         }
+        //     }
+        //     if (! $hasActivityStreamsProfile) {
+        //         return;
+        //     }
+        // }
 
         return $returnJsonFormat ? $res->json() : $res->body();
     }

--- a/app/Services/ActivityPubFetchService.php
+++ b/app/Services/ActivityPubFetchService.php
@@ -137,23 +137,22 @@ class ActivityPubFetchService
         }
 
         //// For application/ld+json, verify the ActivityStreams profile parameter
-        // TODO: Validate if this check is required
-        // if ($mediaType === 'application/ld+json') {
-        //     $hasActivityStreamsProfile = false;
-        //     foreach (array_slice($contentTypeParts, 1) as $param) {
-        //         $param = trim($param);
-        //         if (stripos($param, 'profile=') === 0) {
-        //             $profile = trim(substr($param, strlen('profile=')), ' "\'');
-        //             if ($profile === 'https://www.w3.org/ns/activitystreams') {
-        //                 $hasActivityStreamsProfile = true;
-        //                 break;
-        //             }
-        //         }
-        //     }
-        //     if (! $hasActivityStreamsProfile) {
-        //         return;
-        //     }
-        // }
+        if ($mediaType === 'application/ld+json') {
+            $hasActivityStreamsProfile = false;
+            foreach (array_slice($contentTypeParts, 1) as $param) {
+                $param = trim($param);
+                if (stripos($param, 'profile=') === 0) {
+                    $profile = trim(substr($param, strlen('profile=')), ' "\'');
+                    if ($profile === 'https://www.w3.org/ns/activitystreams') {
+                        $hasActivityStreamsProfile = true;
+                        break;
+                    }
+                }
+            }
+            if (! $hasActivityStreamsProfile) {
+                return;
+            }
+        }
 
         return $returnJsonFormat ? $res->json() : $res->body();
     }


### PR DESCRIPTION
The original fails unless those strings match exactly. Updated to check the MediaType, ignore the charset and confirm the profile value for `ld+json`. 

```
false alarms from valid headers:
* application/activity+json; charset=UTF-8
* application/activity+json;charset=utf-8
* application/activity+json; charset="utf-8"
* application/ld+json; profile="https://www.w3.org/ns/activitystreams"; charset=utf-8
```