### PR TITLE
OAuth: Token endpoint response loses required no-store/no-cache headers 

### DIFF
--- a/app/Http/Controllers/OAuth/ApiTokenController.php
+++ b/app/Http/Controllers/OAuth/ApiTokenController.php
@@ -24,11 +24,12 @@ class ApiTokenController extends AccessTokenController
 
                 if ($token) {
                     $data['created_at'] = $token->created_at->toIso8601String();
+                    $response->setContent(json_encode($data));
                 }
             }
         }
 
-        return response()->json($data, $response->getStatusCode());
+        return $response;
     }
 
     private function getTokenIdFromJwt(string $jwt): ?string


### PR DESCRIPTION
The response has Cache-Control: no-cache, private instead of Cache-Control: no-store, and the Pragma: no-cache header is completely missing.

Result is OAuth2 access tokens may be cached by browsers or intermediate proxies, violating RFC 6749 Section 5.1 security requirements and potentially exposing access tokens.