### PR TITLE
Fix profile cache not clearing when updating only pronouns

### DIFF
--- a/app/Http/Controllers/Settings/HomeSettings.php
+++ b/app/Http/Controllers/Settings/HomeSettings.php
@@ -86,6 +86,7 @@ trait HomeSettings
             }
 
             if ($existingPronouns != $pronouns) {
+                $changes = true;
                 if ($pronouns && in_array('Select Pronoun(s)', $pronouns)) {
                     PronounService::clear($profile->id);
                 } else {

--- a/resources/assets/components/partials/profile/ProfileSidebar.vue
+++ b/resources/assets/components/partials/profile/ProfileSidebar.vue
@@ -8,7 +8,8 @@
                              onerror="this.onerror=null;this.src='/storage/avatars/default.png?v=0';">
                     </div>
                     <div class="media-body">
-                        <p class="display-name" v-html="getDisplayName()"></p>
+                        <p class="display-name mb-0" v-html="getDisplayName()"></p>
+                        <p v-if="profile.pronouns && profile.pronouns.length" class="text-muted small mb-1">{{profile.pronouns.join('/')}}</p>
                         <p class="username" :class="{ remote: !profile.local }">
                             <a v-if="!profile.local" :href="profile.url" class="primary">&commat;{{ profile.acct }}</a>
                             <span v-else>&commat;{{ profile.acct }}</span>
@@ -109,7 +110,8 @@
             </div>
 
             <div class="d-none d-md-block text-center">
-                <p v-html="getDisplayName()" class="display-name"></p>
+                <p v-html="getDisplayName()" class="display-name mb-0"></p>
+                <p v-if="profile.pronouns && profile.pronouns.length" class="text-muted small mb-1">{{profile.pronouns.join('/')}}</p>
 
                 <p class="username" :class="{ remote: !profile.local }">
                     <a v-if="!profile.local" :href="profile.url" class="primary">&commat;{{ profile.acct }}</a>


### PR DESCRIPTION
### What does this PR do?
Fixes an issue where a user's profile cache is not cleared if they only update their pronouns in settings. 

### Why is this needed?
When a user updates their pronouns without modifying any other profile fields (like name, bio, or website), the `$changes` flag in `HomeSettings.php` remains `false`. As a result, the backend correctly saves the new pronouns to the database via `PronounService::put()`, but it skips clearing the profile cache. This causes the old pronouns to persist on the frontend until the cache expires or another field is updated.

This PR sets `$changes = true` when pronouns are modified, ensuring the cache is properly invalidated.

### How to test
1. Go to Account Settings > Profile.
2. Update your pronouns, leaving all other fields unchanged.
3. Save changes.
4. Verify that the new pronouns are immediately visible on your profile page.