### PR TITLE
Provide feedback when profile update is blocked by email verification

### DIFF
--- a/app/Http/Controllers/Settings/HomeSettings.php
+++ b/app/Http/Controllers/Settings/HomeSettings.php
@@ -59,6 +59,10 @@ trait HomeSettings
 
         $enforceEmailVerification = config_cache('pixelfed.enforce_email_verification');
 
+        if ($enforceEmailVerification && ! $user->email_verified_at) {
+            return redirect('/settings/home')->with('error', 'You must verify your email before you can update your profile.');
+        }
+
         // Only allow email to be updated if not yet verified
         if (! $enforceEmailVerification || ! $changes && $user->email_verified_at) {
             if ($profile->name != $name) {


### PR DESCRIPTION
### What does this PR do?
Adds an error message when a user attempts to update their profile settings but is blocked by the `enforce_email_verification` policy.

### Why is this needed?
Currently, if `enforce_email_verification` is enabled and a user has not yet verified their email, profile updates (name, bio, website, etc.) are silently ignored in `HomeSettings@homeUpdate`. The page simply redirects back without any indication of why the changes were not saved. This PR provides a clear error message to the user.

### How to test
1. Enable `ENFORCE_EMAIL_VERIFICATION` in your `.env`.
2. Create a new user but do not verify their email.
3. Attempt to update the user's bio in settings.
4. Verify that an error message is now displayed instead of the changes being silently dropped.