### PR TITLE
Add email verification banner to homepage

### DIFF
--- a/app/Services/AccountService.php
+++ b/app/Services/AccountService.php
@@ -8,6 +8,7 @@ use App\Status;
 use App\Transformer\Api\AccountTransformer;
 use App\User;
 use App\UserSetting;
+use Auth;
 use Cache;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
@@ -37,6 +38,10 @@ class AccountService
 
         if (! $res) {
             return $softFail ? null : abort(404);
+        }
+
+        if (Auth::check() && $res['id'] == Auth::user()->profile_id) {
+            $res['email_verified_at'] = Auth::user()->email_verified_at ? Auth::user()->email_verified_at->toJSON() : null;
         }
 
         return $res;

--- a/app/Transformer/Api/AccountTransformer.php
+++ b/app/Transformer/Api/AccountTransformer.php
@@ -6,6 +6,7 @@ use App\Profile;
 use App\Services\PronounService;
 use App\User;
 use App\UserSetting;
+use Auth;
 use Cache;
 use League\Fractal;
 
@@ -72,6 +73,7 @@ class AccountTransformer extends Fractal\TransformerAbstract
             'last_fetched_at' => optional($profile->last_fetched_at)->toJSON(),
             'pronouns' => PronounService::get($profile->id),
             'location' => $profile->location,
+            'email_verified_at' => ($local && Auth::check() && $profile->user_id == Auth::id()) ? Auth::user()->email_verified_at : null,
         ];
 
         return $res;

--- a/app/Transformer/Api/AccountTransformer.php
+++ b/app/Transformer/Api/AccountTransformer.php
@@ -6,7 +6,6 @@ use App\Profile;
 use App\Services\PronounService;
 use App\User;
 use App\UserSetting;
-use Auth;
 use Cache;
 use League\Fractal;
 
@@ -73,7 +72,6 @@ class AccountTransformer extends Fractal\TransformerAbstract
             'last_fetched_at' => optional($profile->last_fetched_at)->toJSON(),
             'pronouns' => PronounService::get($profile->id),
             'location' => $profile->location,
-            'email_verified_at' => ($local && Auth::check() && $profile->user_id == Auth::id()) ? Auth::user()->email_verified_at : null,
         ];
 
         return $res;

--- a/app/Util/Site/Config.php
+++ b/app/Util/Site/Config.php
@@ -29,6 +29,7 @@ class Config
             return [
                 'version' => config('pixelfed.version'),
                 'open_registration' => (bool) config_cache('pixelfed.open_registration'),
+                'enforce_email_verification' => (bool) config_cache('pixelfed.enforce_email_verification'),
                 'show_legal_notice_link' => (bool) config('instance.has_legal_notice'),
                 'uploader' => [
                     'max_photo_size' => (int) config_cache('pixelfed.max_photo_size'),

--- a/resources/assets/components/Home.vue
+++ b/resources/assets/components/Home.vue
@@ -9,6 +9,22 @@
                 </div>
 
                 <div class="col-md-8 col-lg-6 px-0">
+                    <template v-if="enforceEmailVerification && !profile.email_verified_at">
+                        <div class="card rounded-lg mb-4 ft-std" style="background: #f59e0b;">
+                            <div class="card-body">
+                                <div class="d-flex justify-content-between align-items-center" style="gap:1rem">
+                                    <div class="d-flex align-items-center" style="gap:1rem">
+                                        <i class="far fa-envelope-open fa-3x text-white"></i>
+                                        <div>
+                                            <h1 class="h4 font-weight-bold text-light mb-0">Verify your email address</h1>
+                                            <p class="mb-0 text-white" style="font-size:16px;">Please check your inbox to verify your account and unlock all features.</p>
+                                        </div>
+                                    </div>
+                                    <a class="btn btn-light font-weight-bold" href="/i/verify-email">Verify Now</a>
+                                </div>
+                            </div>
+                        </div>
+                    </template>
                     <template v-if="showUpdateWarning && updateInfo && updateInfo.hasOwnProperty('running_latest')">
                         <div class="card rounded-lg mb-4 ft-std" style="background: #e11d48;border: 3px dashed #fff">
                             <div class="card-body">
@@ -108,6 +124,7 @@
                 recommended: [],
                 trending: [],
                 storiesEnabled: false,
+                enforceEmailVerification: false,
                 shouldRefresh: false,
                 showUpdateWarning: false,
                 showUpdateConnectionWarning: false,
@@ -128,6 +145,7 @@
                 this.profile = window._sharedData.user;
                 this.isLoaded = true;
                 this.storiesEnabled = window.App?.config?.features?.hasOwnProperty('stories') ? window.App.config.features.stories : false;
+                this.enforceEmailVerification = window.App?.config?.enforce_email_verification ?? false;
 
                 if(this.profile.is_admin) {
                     this.softwareUpdateCheck();


### PR DESCRIPTION
### What does this PR do?
Adds a prominent warning banner to the homepage for users who have not yet verified their email address.

### Why is this needed?
When `ENFORCE_EMAIL_VERIFICATION` is enabled, unverified users are restricted from certain actions (like updating their profile or uploading media) but often receive no clear feedback on *why* these actions are failing. This PR ensures that unverified users see a clear call-to-action banner on their home feed, guiding them to the verification page.

### Technical Details
- Added `email_verified_at` to the `AccountTransformer` (only for the authenticated user).
- Added `enforce_email_verification` to the global site configuration.
- Added a responsive banner to the `Home.vue` component.

### How to test
1. Enable `ENFORCE_EMAIL_VERIFICATION` in your `.env`.
2. Log in as a user with an unverified email.
3. Observe the orange verification banner at the top of the home feed.
4. Verify your email and confirm that the banner disappears.