### PR TITLE
Fix PHP syntax errors

### DIFF
--- a/app/Auth/BearerTokenResponse.php
+++ b/app/Auth/BearerTokenResponse.php
@@ -14,7 +14,7 @@ class BearerTokenResponse extends \League\OAuth2\Server\ResponseTypes\BearerToke
      *
      * @return array
      */
-    protected function getExtraParams(AccessTokenEntityInterface $accessToken)
+    protected function getExtraParams(AccessTokenEntityInterface $accessToken): array
     {
         return [
             'scope' => implode(' ', array_map(fn ($scope) => $scope->getIdentifier(), $accessToken->getScopes())),

--- a/app/Jobs/GroupsPipeline/DeleteCommentPipeline.php
+++ b/app/Jobs/GroupsPipeline/DeleteCommentPipeline.php
@@ -46,7 +46,7 @@ class DeleteCommentPipeline implements ShouldQueue
     {
         $groupId = $this->status->group_id;
         $postId = $this->status->id;
-        if($this->status->)
+        // if($this->status->)
         $parent = $this->parent;
         $parent->reply_count = GroupComment::whereStatusId($parent->id)->count();
         $parent->save();


### PR DESCRIPTION
Fix parse error in `DeleteCommentPipeline.php`: incomplete `if($this->status->)` statement — commented out the broken expression.

Add missing `: array` return type to `BearerTokenResponse::getExtraParams()` to match parent class signature, preventing a fatal error at runtime.

### Why tests pass despite these bugs

Neither class is covered by the test suite. PHP only parses files when they're autoloaded — since no test imports `DeleteCommentPipeline` or instantiates `BearerTokenResponse`, the parse error and the return type mismatch are never triggered during `php artisan test`.

### Background on `getExtraParams` return type

The `: array` return type was added to `BearerTokenResponse::getExtraParams()` in `league/oauth2-server` in [commit bca5d67](https://github.com/thephpleague/oauth2-server/commit/bca5d67f6f5e44935dd1f96e507571cf4e6ec60e) (Dec 2, 2022) as part of "Add types to satisfy phpstan". It was fully enforced in v9.0.0 with strict typing. Pixelfed currently uses v9.3.0, so the child class must declare the return type to avoid a fatal error.

---

💡 To catch these issues early on CI, consider adding [php-parallel-lint](https://github.com/php-parallel-lint/PHP-Parallel-Lint):

```bash
composer require --dev php-parallel-lint/php-parallel-lint
vendor/bin/parallel-lint --exclude vendor --exclude node_modules --colors --blame .
```

Or add it directly to the GitHub Actions workflow via `shivammathur/setup-php`:

```yaml
- uses: shivammathur/setup-php@v2
  with:
    php-version: '8.3'
    tools: parallel-lint

- name: Check PHP syntax
  run: parallel-lint --exclude vendor --exclude node_modules --colors --blame .
```


Output:
```

PHP 8.4.19 | 10 parallel jobs
............................................................   60/1774 (  3%)
............................................................  120/1774 (  6%)
............................................................  180/1774 ( 10%)
............................................................  240/1774 ( 13%)
............................................................  300/1774 ( 16%)
............................................................  360/1774 ( 20%)
............................................................  420/1774 ( 23%)
............................................................  480/1774 ( 27%)
............................................................  540/1774 ( 30%)
............................................................  600/1774 ( 33%)
............................................................  660/1774 ( 37%)
...........................................X................  720/1774 ( 40%)
............................................................  780/1774 ( 43%)
............................................................  840/1774 ( 47%)
............................................................  900/1774 ( 50%)
............................................................  960/1774 ( 54%)
............................................................ 1020/1774 ( 57%)
............................................................ 1080/1774 ( 60%)
............................................................ 1140/1774 ( 64%)
............................................................ 1200/1774 ( 67%)
............................................................ 1260/1774 ( 71%)
............................................................ 1320/1774 ( 74%)
............................................................ 1380/1774 ( 77%)
............................................................ 1440/1774 ( 81%)
............................................................ 1500/1774 ( 84%)
............................................................ 1560/1774 ( 87%)
............................................................ 1620/1774 ( 91%)
............................................................ 1680/1774 ( 94%)
............................................................ 1740/1774 ( 98%)
..................................                           1774/1774 (100%)


Checked 1774 files in 8.6 seconds
Syntax error found in 1 file

------------------------------------------------------------
Parse error: ./app/Jobs/GroupsPipeline/DeleteCommentPipeline.php:49
    47|         $groupId = $this->status->group_id;
    48|         $postId = $this->status->id;
  > 49|         if($this->status->)
    50|         $parent = $this->parent;
    51|         $parent->reply_count = GroupComment::whereStatusId($parent->id)->count();
Unexpected token ")", expecting identifier or variable or "{" or "$"
Blame dansup <danielsupernault@gmail.com>, commit '67606eb7' from 2026-03-24T00:35:01-06:00
```

____

Alternative: add Psalm to CI — it will also report report about other issues in the codebase. I can create a new PR for this.