### PR TITLE
Accessibility: Mark status avatar images as decorative

### DIFF
--- a/resources/assets/js/components/PostComponent.vue
+++ b/resources/assets/js/components/PostComponent.vue
@@ -16,7 +16,7 @@
 				<div class="d-flex d-md-none align-items-center justify-content-between card-header bg-white w-100">
 					<div class="d-flex">
 						<div class="status-avatar mr-2" @click="redirect(statusProfileUrl)">
-							<img :src="statusAvatar" width="24px" height="24px" style="border-radius:12px;" class="cursor-pointer">
+							<img :src="statusAvatar" width="24px" height="24px" style="border-radius:12px;" class="cursor-pointer" alt="">
 						</div>
 						<div class="username">
 							<span class="username-link font-weight-bold text-dark cursor-pointer" @click="redirect(statusProfileUrl)">{{ statusUsername }}</span>
@@ -82,7 +82,7 @@
 						<div class="d-md-flex d-none align-items-center justify-content-between card-header py-3 bg-white">
 							<div class="d-flex align-items-center status-username text-truncate">
 								<div class="status-avatar mr-2" @click="redirect(statusProfileUrl)">
-									<img :src="statusAvatar" width="24px" height="24px" style="border-radius:12px;" class="cursor-pointer">
+									<img :src="statusAvatar" width="24px" height="24px" style="border-radius:12px;" class="cursor-pointer" alt="">
 								</div>
 								<div class="username">
 									<span class="username-link font-weight-bold text-dark cursor-pointer" @click="redirect(statusProfileUrl)">{{ statusUsername }}</span>


### PR DESCRIPTION
<img width="228" height="87" alt="Accessibility inspector pointing out how a status avatar is missing an alt text tag." src="https://github.com/user-attachments/assets/e6378701-ebaf-4c6f-8736-8ff1c5c75cf6" />

Status avatars are currently missing an alt text tag in their HTML, which is required to pass [Success Criterion 1.1.1 "Non-text Content" of the Web Content Accessibility Guidelines](https://www.w3.org/TR/WCAG22/#non-text-content). Since the avatars are most likely considered "decorative", [the alt text tag should be included with an empty value](https://www.w3.org/WAI/tutorials/images/decorative/) (`alt=""`). Thanks in advance!