### PR TITLE
Remove deprecated EXP_LC (hidden like counts) config

### DIFF
--- a/config/exp.php
+++ b/config/exp.php
@@ -7,9 +7,6 @@
  */
 
 return [
-	// Hidden like counts (deprecated)
-	'lc' => env('EXP_LC', false),
-
 	// Recommendations (deprecated)
 	'rec' => false,
 

--- a/resources/views/admin/diagnostics/home.blade.php
+++ b/resources/views/admin/diagnostics/home.blade.php
@@ -298,11 +298,6 @@
 
                                 	<tr>
                                 		<td><span class="badge badge-primary">EXP</span></td>
-                                		<td><strong>EXP_LC</strong></td>
-                                		<td><span>{{config_cache('exp.lc') ? '✅ true' : '❌ false' }}</span></td>
-                                	</tr>
-                                	<tr>
-                                		<td><span class="badge badge-primary">EXP</span></td>
                                 		<td><strong>EXP_TOP</strong></td>
                                 		<td><span>{{config_cache('exp.top') ? '✅ true' : '❌ false' }}</span></td>
                                 	</tr>


### PR DESCRIPTION
Remove the EXP_LC env var from config/exp.php and its diagnostic row from the admin diagnostics page. 

This feature was already marked as deprecated and unused.