### PR TITLE
Remove EXP_EMC flag, Mastodon API compatibility is always enforced

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -61,9 +61,6 @@ AP_INBOX="true"
 AP_OUTBOX="true"
 AP_SHAREDINBOX="true"
 
-# Experimental Configuration
-EXP_EMC="true"
-
 # Mail Configuration
 # Configure after initial setup
 MAIL_DRIVER="smtp"

--- a/.env.example
+++ b/.env.example
@@ -55,9 +55,6 @@ AP_INBOX="false"
 AP_OUTBOX="false"
 AP_SHAREDINBOX="false"
 
-# Experimental Configuration
-EXP_EMC="true"
-
 ## Mail Configuration (Post-Installer)
 MAIL_DRIVER=log
 MAIL_HOST=smtp.mailtrap.io

--- a/app/Console/Commands/Installer.php
+++ b/app/Console/Commands/Installer.php
@@ -393,7 +393,6 @@ class Installer extends Command
         $this->updateEnvFile('OPEN_REGISTRATION', $open_registration);
         $this->updateEnvFile('ENFORCE_EMAIL_VERIFICATION', $enforce_email_verification);
         $this->updateEnvFile('OAUTH_ENABLED', $enable_mobile_apis);
-        $this->updateEnvFile('EXP_EMC', $enable_mobile_apis);
     }
 
     protected function mediaSettings()

--- a/app/Services/AccountService.php
+++ b/app/Services/AccountService.php
@@ -49,10 +49,6 @@ class AccountService
             return null;
         }
 
-        if (config('exp.emc') == false) {
-            return $account;
-        }
-
         unset(
             $account['header_bg'],
             $account['is_admin'],

--- a/app/Services/StatusService.php
+++ b/app/Services/StatusService.php
@@ -64,10 +64,6 @@ class StatusService
 
         $status['replies_count'] = $status['reply_count'];
 
-        if (config('exp.emc') == false) {
-            return $status;
-        }
-
         unset(
             $status['_v'],
             $status['comments_disabled'],

--- a/config/exp.php
+++ b/config/exp.php
@@ -33,9 +33,6 @@ return [
 	// Single page application (beta)
 	'spa' => true,
 
-	// Enforce Mastoapi Compatibility (alpha)
-	'emc' => env('EXP_EMC', true),
-
 	// HLS Live Streaming
 	'hls' => env('HLS_LIVE', false),
 

--- a/resources/views/admin/diagnostics/home.blade.php
+++ b/resources/views/admin/diagnostics/home.blade.php
@@ -322,12 +322,6 @@
                                 		<td><span>{{config_cache('exp.gps') ? '✅ true' : '❌ false' }}</span></td>
                                 	</tr>
                                 	<tr>
-                                		<td><span class="badge badge-primary">EXP</span></td>
-                                		<td><strong>EXP_EMC</strong></td>
-                                		<td><span>{{config_cache('exp.emc') ? '✅ true' : '❌ false' }}</span></td>
-                                	</tr>
-
-                                	<tr>
                                 		<td><span class="badge badge-primary">FEDERATION</span></td>
                                 		<td><strong>ACTIVITY_PUB</strong></td>
                                 		<td><span>{{(bool) config_cache('federation.activitypub.enabled') ? '✅ true' : '❌ false' }}</span></td>


### PR DESCRIPTION
The Mastodon API compatibility stripping in StatusService and AccountService is now default.

I have no idea what this actually does.