### PR TITLE
Add DB fallback for timeline pagination beyond the Redis cache.

### DIFF
--- a/app/Http/Controllers/Api/ApiV1Controller.php
+++ b/app/Http/Controllers/Api/ApiV1Controller.php
@@ -2651,6 +2651,9 @@ class ApiV1Controller extends Controller
                     $res = HomeTimelineService::getRankedMinId($pid, $min ?? 0, $paddedLimit);
                 } else {
                     $res = HomeTimelineService::getRankedMaxId($pid, $max ?? 0, $paddedLimit);
+                    if (empty($res) && $max) {
+                        $res = HomeTimelineService::fallbackMaxId($pid, $max, $paddedLimit);
+                    }
                 }
             } else {
                 $res = HomeTimelineService::get($pid, 0, $paddedLimit);
@@ -3014,6 +3017,9 @@ class ApiV1Controller extends Controller
 
                 if ($max) {
                     $feed = NetworkTimelineService::getRankedMaxId($max, $limit + 5);
+                    if (empty($feed)) {
+                        $feed = NetworkTimelineService::fallbackMaxId($max, $limit + 5);
+                    }
                 } elseif ($min) {
                     $feed = NetworkTimelineService::getRankedMinId($min, $limit + 5);
                 } else {
@@ -3061,6 +3067,9 @@ class ApiV1Controller extends Controller
 
                 if ($max) {
                     $feed = PublicTimelineService::getRankedMaxId($max, $limit + 5);
+                    if (empty($feed)) {
+                        $feed = PublicTimelineService::fallbackMaxId($max, $limit + 5);
+                    }
                 } elseif ($min) {
                     $feed = PublicTimelineService::getRankedMinId($min, $limit + 5);
                 } else {

--- a/app/Http/Controllers/PublicApiController.php
+++ b/app/Http/Controllers/PublicApiController.php
@@ -328,6 +328,9 @@ class PublicApiController extends Controller
 
             if ($max) {
                 $feed = PublicTimelineService::getRankedMaxId($max, $limit);
+                if (empty($feed)) {
+                    $feed = PublicTimelineService::fallbackMaxId($max, $limit);
+                }
             } elseif ($min) {
                 $feed = PublicTimelineService::getRankedMinId($min, $limit);
             } else {
@@ -603,6 +606,9 @@ class PublicApiController extends Controller
 
             if ($max) {
                 $feed = NetworkTimelineService::getRankedMaxId($max, $limit);
+                if (empty($feed)) {
+                    $feed = NetworkTimelineService::fallbackMaxId($max, $limit);
+                }
             } elseif ($min) {
                 $feed = NetworkTimelineService::getRankedMinId($min, $limit);
             } else {

--- a/app/Services/HomeTimelineService.php
+++ b/app/Services/HomeTimelineService.php
@@ -53,7 +53,14 @@ class HomeTimelineService
             Redis::zpopmin(self::CACHE_KEY.$id);
         }
 
-        return Redis::zadd(self::CACHE_KEY.$id, $val, $val);
+        $result = Redis::zadd(self::CACHE_KEY.$id, $val, $val);
+
+        $ttl = Redis::ttl(self::CACHE_KEY.$id);
+        if ($ttl < 0) {
+            Redis::expire(self::CACHE_KEY.$id, config('instance.timeline.home.cache_ttl', 86400));
+        }
+
+        return $result;
     }
 
     public static function rem($id, $val)

--- a/app/Services/HomeTimelineService.php
+++ b/app/Services/HomeTimelineService.php
@@ -16,8 +16,8 @@ class HomeTimelineService
 
     public static function get($id, $start = 0, $stop = 10)
     {
-        if ($stop > 100) {
-            $stop = 100;
+        if ($stop > 500) {
+            $stop = 500;
         }
 
         return Redis::zrevrange(self::CACHE_KEY.$id, $start, $stop);
@@ -49,7 +49,7 @@ class HomeTimelineService
 
     public static function add($id, $val)
     {
-        if (self::count($id) >= 400) {
+        if (self::count($id) >= config('instance.timeline.home.cache_dropoff', 800)) {
             Redis::zpopmin(self::CACHE_KEY.$id);
         }
 
@@ -64,6 +64,26 @@ class HomeTimelineService
     public static function count($id)
     {
         return Redis::zcard(self::CACHE_KEY.$id);
+    }
+
+    public static function fallbackMaxId($id, $max, $limit = 10)
+    {
+        $following = Cache::remember('profile:following:'.$id, 1209600, function () use ($id) {
+            $following = Follower::whereProfileId($id)->pluck('following_id');
+
+            return $following->push($id)->toArray();
+        });
+
+        return Status::where('id', '<', $max)
+            ->whereIntegerInRaw('profile_id', $following)
+            ->whereNull(['in_reply_to_id', 'reblog_of_id'])
+            ->whereIn('type', ['photo', 'photo:album', 'video', 'video:album', 'photo:video:album'])
+            ->whereIn('visibility', ['public', 'unlisted', 'private'])
+            ->orderByDesc('id')
+            ->limit($limit)
+            ->pluck('id')
+            ->values()
+            ->toArray();
     }
 
     public static function warmCache($id, $force = false, $limit = 100, $returnIds = false)

--- a/app/Services/NetworkTimelineService.php
+++ b/app/Services/NetworkTimelineService.php
@@ -11,8 +11,8 @@ class NetworkTimelineService
 
     public static function get($start = 0, $stop = 10)
     {
-        if ($stop > 100) {
-            $stop = 100;
+        if ($stop > 500) {
+            $stop = 500;
         }
 
         return Redis::zrevrange(self::CACHE_KEY, $start, $stop);
@@ -64,6 +64,27 @@ class NetworkTimelineService
     public static function count()
     {
         return Redis::zcard(self::CACHE_KEY);
+    }
+
+    public static function fallbackMaxId($max, $limit = 10)
+    {
+        $hideNsfw = config('instance.hide_nsfw_on_public_feeds');
+        $maxHoursOld = config('instance.timeline.network.max_hours_old', 2160);
+
+        return Status::where('id', '<', $max)
+            ->whereNotNull('uri')
+            ->whereNull(['in_reply_to_id', 'reblog_of_id'])
+            ->whereIn('type', ['photo', 'photo:album', 'video', 'video:album', 'photo:video:album'])
+            ->whereScope('public')
+            ->where('created_at', '>', now()->subHours($maxHoursOld))
+            ->when($hideNsfw, function ($q) {
+                return $q->where('is_nsfw', false);
+            })
+            ->orderByDesc('id')
+            ->limit($limit)
+            ->pluck('id')
+            ->values()
+            ->toArray();
     }
 
     public static function deleteByProfileId($profileId)

--- a/app/Services/NetworkTimelineService.php
+++ b/app/Services/NetworkTimelineService.php
@@ -48,7 +48,14 @@ class NetworkTimelineService
             Redis::zpopmin(self::CACHE_KEY);
         }
 
-        return Redis::zadd(self::CACHE_KEY, $val, $val);
+        $result = Redis::zadd(self::CACHE_KEY, $val, $val);
+
+        $ttl = Redis::ttl(self::CACHE_KEY);
+        if ($ttl < 0) {
+            Redis::expire(self::CACHE_KEY, config('instance.timeline.network.cache_ttl', 86400));
+        }
+
+        return $result;
     }
 
     public static function rem($val)

--- a/app/Services/PublicTimelineService.php
+++ b/app/Services/PublicTimelineService.php
@@ -48,7 +48,14 @@ class PublicTimelineService
             Redis::zpopmin(self::CACHE_KEY);
         }
 
-        return Redis::zadd(self::CACHE_KEY, $val, $val);
+        $result = Redis::zadd(self::CACHE_KEY, $val, $val);
+
+        $ttl = Redis::ttl(self::CACHE_KEY);
+        if ($ttl < 0) {
+            Redis::expire(self::CACHE_KEY, config('instance.timeline.local.cache_ttl', 86400));
+        }
+
+        return $result;
     }
 
     public static function rem($val)

--- a/app/Services/PublicTimelineService.php
+++ b/app/Services/PublicTimelineService.php
@@ -11,8 +11,8 @@ class PublicTimelineService
 
     public static function get($start = 0, $stop = 10)
     {
-        if ($stop > 100) {
-            $stop = 100;
+        if ($stop > 500) {
+            $stop = 500;
         }
 
         return Redis::zrevrange(self::CACHE_KEY, $start, $stop);
@@ -44,7 +44,7 @@ class PublicTimelineService
 
     public static function add($val)
     {
-        if (self::count() > 400) {
+        if (self::count() > config('instance.timeline.local.cache_dropoff', 10000)) {
             Redis::zpopmin(self::CACHE_KEY);
         }
 
@@ -64,6 +64,24 @@ class PublicTimelineService
     public static function count()
     {
         return Redis::zcard(self::CACHE_KEY);
+    }
+
+    public static function fallbackMaxId($max, $limit = 10)
+    {
+        $hideNsfw = config('instance.hide_nsfw_on_public_feeds');
+
+        return Status::where('id', '<', $max)
+            ->whereNull(['uri', 'in_reply_to_id', 'reblog_of_id'])
+            ->whereIn('type', ['photo', 'photo:album', 'video', 'video:album', 'photo:video:album'])
+            ->whereScope('public')
+            ->when($hideNsfw, function ($q) {
+                return $q->where('is_nsfw', false);
+            })
+            ->orderByDesc('id')
+            ->limit($limit)
+            ->pluck('id')
+            ->values()
+            ->toArray();
     }
 
     public static function deleteByProfileId($profileId)

--- a/config/instance.php
+++ b/config/instance.php
@@ -26,7 +26,7 @@ return [
     'timeline' => [
         'home' => [
             'cached' => env('PF_HOME_TIMELINE_CACHE', false),
-            'cache_ttl' => env('PF_HOME_TIMELINE_CACHE_TTL', 900),
+            'cache_ttl' => env('PF_HOME_TIMELINE_CACHE_TTL', 86400),
             'cache_dropoff' => env('PF_HOME_TIMELINE_CACHE_DROPOFF', 800),
         ],
 
@@ -34,11 +34,13 @@ return [
             'cached' => env('INSTANCE_PUBLIC_TIMELINE_CACHED', false),
             'is_public' => env('INSTANCE_PUBLIC_LOCAL_TIMELINE', false),
             'cache_dropoff' => env('INSTANCE_PUBLIC_TIMELINE_CACHE_DROPOFF', 10000),
+            'cache_ttl' => env('INSTANCE_PUBLIC_TIMELINE_CACHE_TTL', 86400),
         ],
 
         'network' => [
             'cached' => env('PF_NETWORK_TIMELINE') ? env('INSTANCE_NETWORK_TIMELINE_CACHED', false) : false,
             'cache_dropoff' => env('INSTANCE_NETWORK_TIMELINE_CACHE_DROPOFF', 100),
+            'cache_ttl' => env('INSTANCE_NETWORK_TIMELINE_CACHE_TTL', 86400),
             'max_hours_old' => env('INSTANCE_NETWORK_TIMELINE_CACHE_MAX_HOUR_INGEST', 2160),
         ],
     ],

--- a/config/instance.php
+++ b/config/instance.php
@@ -27,11 +27,13 @@ return [
         'home' => [
             'cached' => env('PF_HOME_TIMELINE_CACHE', false),
             'cache_ttl' => env('PF_HOME_TIMELINE_CACHE_TTL', 900),
+            'cache_dropoff' => env('PF_HOME_TIMELINE_CACHE_DROPOFF', 800),
         ],
 
         'local' => [
             'cached' => env('INSTANCE_PUBLIC_TIMELINE_CACHED', false),
             'is_public' => env('INSTANCE_PUBLIC_LOCAL_TIMELINE', false),
+            'cache_dropoff' => env('INSTANCE_PUBLIC_TIMELINE_CACHE_DROPOFF', 10000),
         ],
 
         'network' => [


### PR DESCRIPTION
When users scroll past the Redis cache (dropoff limit), the timeline services now fall back to a direct DB query instead of returning empty. This enables true infinite scroll regardless of cache size.

+ added the unused TTL on the cache for 24 hours