### PR TITLE
Accept compacted `Note` attachments

### DIFF
--- a/app/Util/ActivityPub/Helpers.php
+++ b/app/Util/ActivityPub/Helpers.php
@@ -77,17 +77,18 @@ class Helpers
             $data = ['object' => $data];
         }
 
-        $activity = $data['object'];
         $mimeTypes = explode(',', config_cache('pixelfed.media_types'));
         $mediaTypes = in_array('video/mp4', $mimeTypes) ?
             ['Document', 'Image', 'Video'] :
             ['Document', 'Image'];
 
-        if (! isset($activity['attachment']) || empty($activity['attachment'])) {
+        $attachments = self::getAttachments($data);
+
+        if (empty($attachments)) {
             return false;
         }
 
-        return Validator::make($activity['attachment'], [
+        return Validator::make($attachments, [
             '*.type' => ['required', 'string', Rule::in($mediaTypes)],
             '*.url' => 'required|url',
             '*.mediaType' => ['required', 'string', Rule::in($mimeTypes)],
@@ -901,9 +902,21 @@ class Helpers
      */
     public static function getAttachments(array $data): array
     {
-        return isset($data['object']) ?
-            $data['object']['attachment'] :
-            $data['attachment'];
+        $object = isset($data['object']) ?
+            $data['object'] :
+            $data;
+
+        if (! is_array($object) ||
+            ! isset($object['attachment']) ||
+            empty($object['attachment']) ||
+            ! is_array($object['attachment'])
+        ) {
+            return [];
+        }
+
+        return array_is_list($object['attachment']) ?
+            $object['attachment'] :
+            [$object['attachment']];
     }
 
     /**

--- a/tests/Unit/ActivityPub/NoteAttachmentTest.php
+++ b/tests/Unit/ActivityPub/NoteAttachmentTest.php
@@ -56,5 +56,56 @@ class NoteAttachmentTest extends TestCase
         $valid = Helpers::verifyAttachments($this->invalidMime);
         $this->assertFalse($valid);
     }
-}
 
+    #[Test]
+    public function compactedCreateNoteAttachment()
+    {
+        $activity = $this->mastodon;
+        $activity['object']['attachment'] = $activity['object']['attachment'][0];
+
+        $valid = Helpers::verifyAttachments($activity);
+        $this->assertTrue($valid);
+    }
+
+    #[Test]
+    public function compactedBareNoteAttachment()
+    {
+        $activity = $this->pixelfed;
+        $activity['attachment'] = $activity['attachment'][0];
+
+        $valid = Helpers::verifyAttachments($activity);
+        $this->assertTrue($valid);
+    }
+
+    #[Test]
+    public function compactedInvalidAttachmentType()
+    {
+        $activity = $this->invalidType;
+        $activity['object']['attachment'] = $activity['object']['attachment'][0];
+
+        $valid = Helpers::verifyAttachments($activity);
+        $this->assertFalse($valid);
+    }
+
+    #[Test]
+    public function compactedInvalidMimeType()
+    {
+        $activity = $this->invalidMime;
+        $activity['object']['attachment'] = $activity['object']['attachment'][0];
+
+        $valid = Helpers::verifyAttachments($activity);
+        $this->assertFalse($valid);
+    }
+
+    #[Test]
+    public function getAttachmentsReturnsListForCompactedAttachment()
+    {
+        $activity = $this->mastodon;
+        $activity['object']['attachment'] = $activity['object']['attachment'][0];
+
+        $attachments = Helpers::getAttachments($activity);
+
+        $this->assertCount(1, $attachments);
+        $this->assertSame('Document', $attachments[0]['type']);
+    }
+}


### PR DESCRIPTION
Fixes incoming ActivityPub `Create(Note)` deliveries where `attachment` is encoded as a single compacted object instead of a one-item array.

Pixelfed now normalizes Note attachments before validation and import, so single JSON-LD compacted attachments are handled the same way as existing array-form attachments.

Fixes #6588.