### PR TITLE
Media: support .mov uploads via on-ingest transcode to mp4

### DIFF
--- a/app/Http/Controllers/Admin/AdminSettingsController.php
+++ b/app/Http/Controllers/Admin/AdminSettingsController.php
@@ -603,7 +603,7 @@ trait AdminSettingsController
         $mediaTypes = $request->input('media_types');
         $mediaArray = explode(',', $mediaTypes);
         foreach ($mediaArray as $mediaType) {
-            if (! in_array($mediaType, ['image/jpeg', 'image/png', 'image/gif', 'image/webp', 'image/avif', 'image/heic', 'video/mp4', 'video/mov'])) {
+            if (! in_array($mediaType, ['image/jpeg', 'image/png', 'image/gif', 'image/webp', 'image/avif', 'image/heic', 'video/mp4', 'video/quicktime', 'video/x-m4v'])) {
                 return redirect()->back()->withErrors(['media_types' => 'Invalid media type']);
             }
         }

--- a/app/Http/Controllers/Api/ApiV2Controller.php
+++ b/app/Http/Controllers/Api/ApiV2Controller.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Jobs\ImageOptimizePipeline\ImageOptimize;
 use App\Jobs\MediaPipeline\MediaDeletePipeline;
 use App\Jobs\VideoPipeline\VideoThumbnail;
+use App\Jobs\VideoPipeline\VideoTranscode;
 use App\Media;
 use App\Services\AccountService;
 use App\Services\InstanceService;
@@ -320,6 +321,13 @@ class ApiV2Controller extends Controller
 
             case 'video/mp4':
                 VideoThumbnail::dispatch($media)->onQueue('mmo');
+                $preview_url = '/storage/no-preview.png';
+                $url = '/storage/no-preview.png';
+                break;
+
+            case 'video/quicktime':
+            case 'video/x-m4v':
+                VideoTranscode::dispatch($media)->onQueue('mmo');
                 $preview_url = '/storage/no-preview.png';
                 $url = '/storage/no-preview.png';
                 break;

--- a/app/Http/Controllers/ComposeController.php
+++ b/app/Http/Controllers/ComposeController.php
@@ -8,6 +8,7 @@ use App\Hashtag;
 use App\Jobs\ImageOptimizePipeline\ImageOptimize;
 use App\Jobs\StatusPipeline\NewStatusPipeline;
 use App\Jobs\VideoPipeline\VideoThumbnail;
+use App\Jobs\VideoPipeline\VideoTranscode;
 use App\Media;
 use App\MediaTag;
 use App\Models\Poll;
@@ -140,6 +141,13 @@ class ComposeController extends Controller
 
             case 'video/mp4':
                 VideoThumbnail::dispatch($media)->onQueue('mmo');
+                $preview_url = '/storage/no-preview.png';
+                $url = '/storage/no-preview.png';
+                break;
+
+            case 'video/quicktime':
+            case 'video/x-m4v':
+                VideoTranscode::dispatch($media)->onQueue('mmo');
                 $preview_url = '/storage/no-preview.png';
                 $url = '/storage/no-preview.png';
                 break;

--- a/app/Jobs/StoryPipeline/StoryFetch.php
+++ b/app/Jobs/StoryPipeline/StoryFetch.php
@@ -685,8 +685,8 @@ class StoryFetch implements ShouldQueue
             'image/avif' => ['avif'],
             'video/mp4' => ['mp4'],
             'video/webm' => ['webm'],
-            'video/mov' => ['mov'],
             'video/quicktime' => ['mov', 'qt'],
+            'video/x-m4v' => ['m4v'],
         ];
 
         foreach ($mimeTypes as $mimeType) {

--- a/app/Jobs/VideoPipeline/VideoTranscode.php
+++ b/app/Jobs/VideoPipeline/VideoTranscode.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace App\Jobs\VideoPipeline;
+
+use App\Media;
+use App\Services\MediaService;
+use App\Services\StatusService;
+use Cache;
+use FFMpeg;
+use FFMpeg\Format\Video\X264;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldBeUniqueUntilProcessing;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\Middleware\WithoutOverlapping;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Storage;
+use Log;
+
+class VideoTranscode implements ShouldBeUniqueUntilProcessing, ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    const TRANSCODABLE_MIMES = ['video/quicktime', 'video/x-m4v'];
+
+    protected $media;
+
+    public $timeout = 1800;
+
+    public $tries = 2;
+
+    public $maxExceptions = 1;
+
+    public $failOnTimeout = true;
+
+    public $deleteWhenMissingModels = true;
+
+    public $uniqueFor = 7200;
+
+    public function uniqueId(): string
+    {
+        return 'media:video-transcode:id-'.$this->media->id;
+    }
+
+    public function middleware(): array
+    {
+        return [(new WithoutOverlapping("media:video-transcode:id-{$this->media->id}"))->shared()->dontRelease()];
+    }
+
+    public function __construct(Media $media)
+    {
+        $this->media = $media;
+    }
+
+    public function handle()
+    {
+        $media = $this->media;
+
+        if ($media->mime === 'video/mp4') {
+            VideoThumbnail::dispatch($media)->onQueue('mmo');
+
+            return;
+        }
+
+        if (! in_array($media->mime, self::TRANSCODABLE_MIMES, true)) {
+            return;
+        }
+
+        $sourcePath = $media->media_path;
+        $info = pathinfo($sourcePath);
+        $targetPath = ($info['dirname'] === '.' ? '' : $info['dirname'].'/').$info['filename'].'.mp4';
+
+        if ($targetPath === $sourcePath) {
+            $targetPath = ($info['dirname'] === '.' ? '' : $info['dirname'].'/').$info['filename'].'_pf.mp4';
+        }
+
+        try {
+            $format = new X264('aac', 'libx264');
+            $format->setAdditionalParameters(['-movflags', '+faststart']);
+
+            FFMpeg::open($sourcePath)
+                ->export()
+                ->toDisk('local')
+                ->inFormat($format)
+                ->save($targetPath);
+
+            $originalPath = $media->media_path;
+            $media->media_path = $targetPath;
+            $media->mime = 'video/mp4';
+
+            if (Storage::disk('local')->exists($targetPath)) {
+                $media->size = Storage::disk('local')->size($targetPath);
+            }
+
+            $media->save();
+
+            try {
+                if (Storage::disk('local')->exists($originalPath)) {
+                    Storage::disk('local')->delete($originalPath);
+                }
+            } catch (\Exception $cleanupException) {
+                if (config('app.dev_log')) {
+                    Log::warning('Video transcode cleanup failed: '.$cleanupException->getMessage());
+                }
+            }
+
+            if ($media->status_id) {
+                Cache::forget('status:transformer:media:attachments:'.$media->status_id);
+                MediaService::del($media->status_id);
+                StatusService::del($media->status_id);
+            }
+
+            VideoThumbnail::dispatch($media)->onQueue('mmo');
+        } catch (\Exception $e) {
+            if (config('app.dev_log')) {
+                Log::error('Video transcode failed for media '.$media->id.': '.$e->getMessage());
+            }
+
+            throw $e;
+        }
+    }
+}

--- a/resources/assets/components/admin/AdminSettings.vue
+++ b/resources/assets/components/admin/AdminSettings.vue
@@ -1034,7 +1034,7 @@
                     }
 
                     if(this.mediaTypes.mov) {
-                        res += 'video/mov,'
+                        res += 'video/quicktime,'
                     }
 
                     if(res.endsWith(',')) {
@@ -1096,12 +1096,24 @@
             },
 
             setMediaTypes() {
+                const mimeToKey = {
+                    'image/jpeg': 'jpeg',
+                    'image/png': 'png',
+                    'image/gif': 'gif',
+                    'image/webp': 'webp',
+                    'image/avif': 'avif',
+                    'image/heic': 'heic',
+                    'video/mp4': 'mp4',
+                    'video/quicktime': 'mov',
+                    'video/x-m4v': 'mov',
+                    'video/mov': 'mov',
+                };
                 const types = this.media.media_types.split(',');
                 if(types && types.length) {
                     types.forEach((type) => {
-                        let mime = type.split('/')[1];
-                        if(['jpeg', 'png', 'gif', 'webp', 'avif', 'heic', 'mp4', 'mov'].includes(mime)) {
-                            this.mediaTypes[mime] = true;
+                        const key = mimeToKey[type];
+                        if(key) {
+                            this.mediaTypes[key] = true;
                         }
                     })
                 }


### PR DESCRIPTION
## Problem

The admin Media settings UI exposes a "MOV" checkbox that adds the string `video/mov` to `pixelfed.media_types`. `video/mov` is not a registered IANA mime type — PHP's `finfo` (which is what `UploadedFile::getMimeType()` calls) returns `video/quicktime` for actual `.mov` files. So when an admin enables MOV support, every real `.mov` upload arrives with mime `video/quicktime`, fails the `mimetypes:` validator at `ComposeController.php:106` / `ApiV2Controller.php:259`, and is rejected with 400/403 “Invalid media format.”

Even if the validation were patched to accept `video/quicktime`, the post-upload switch in both controllers only dispatches `VideoThumbnail` for `video/mp4` — quicktime media would land in the DB without a thumbnail and fail to publish.

## Fix

Two halves:

1. **Use the correct mime strings.** Replace `video/mov` with `video/quicktime` in the admin allowlist (`AdminSettingsController` validator + `AdminSettings.vue` writer), and add `video/x-m4v` for `.m4v`. The Vue `setMediaTypes` parser is rewritten as an explicit mime→key map so existing cached `video/mov` values still toggle the MOV checkbox correctly (backwards compat). `StoryFetch` mime→extension table updated similarly.

2. **New `App\Jobs\VideoPipeline\VideoTranscode` job.** Opens the source via the existing `pbmedia/laravel-ffmpeg` integration, exports H.264/AAC mp4 with `-movflags +faststart`, swaps `media_path`/`mime`/`size`, deletes the original, then chains into `VideoThumbnail`. `ComposeController` and `Api\ApiV2Controller` route `video/quicktime` and `video/x-m4v` uploads to it.

No migrations, no config changes required. Existing instances with `video/mov` in their cached `media_types` keep working at the admin UI parser level until rewritten.

## Verified

Deployed and tested on a self-hosted instance: an iPhone HEVC `.mov` upload now succeeds end-to-end — transcode runs on the `mmo` queue, thumbnail and blurhash generate, and the post publishes and plays in the timeline.

## Files changed

- `app/Jobs/VideoPipeline/VideoTranscode.php` (new)
- `app/Http/Controllers/ComposeController.php` (case for quicktime/x-m4v)
- `app/Http/Controllers/Api/ApiV2Controller.php` (case for quicktime/x-m4v)
- `app/Http/Controllers/Admin/AdminSettingsController.php` (allowlist)
- `resources/assets/components/admin/AdminSettings.vue` (writer + parser)
- `app/Jobs/StoryPipeline/StoryFetch.php` (mime→ext table)