### PR TITLE
Allow Unicode letters in story text overlays; block invisible chars

### DIFF
--- a/app/Http/Controllers/Stories/StoryApiV1Controller.php
+++ b/app/Http/Controllers/Stories/StoryApiV1Controller.php
@@ -35,6 +35,28 @@ class StoryApiV1Controller extends Controller
 
     const RECENT_TTL = 300;
 
+    /**
+     * Allowed characters in story text overlays.
+     *
+     * Accepts: Unicode letters (\p{L}), combining marks (\p{M}), digits
+     * (\p{N}), space separators (\p{Zs}, including ASCII space and NBSP),
+     * punctuation (\p{P}), and symbols (\p{S}, which includes single-
+     * codepoint emoji and regional-indicator flags).
+     *
+     * Rejects, by omission: control chars (\p{Cc} — incl. tab, newline,
+     * NUL), format chars (\p{Cf} — zero-width space/joiner, BOM, bidi
+     * overrides, tag chars, Mongolian vowel separator), private use
+     * (\p{Co}), unassigned (\p{Cn}), surrogates (\p{Cs}). Uses \p{Zs}
+     * rather than \s because Perl-compat \s also matches some legacy
+     * format characters like U+180E. This blocks the common invisible-
+     * character and bidi-spoofing attack vectors.
+     *
+     * Tradeoff: ZWJ-composed emoji sequences (e.g. 👨‍👩‍👧, 🏳️‍🌈) are rejected
+     * because U+200D ZERO WIDTH JOINER is \p{Cf}. Single-codepoint emoji
+     * and regional-indicator country flags still work.
+     */
+    const TEXT_OVERLAY_PATTERN = '/^[\p{L}\p{M}\p{N}\p{Zs}\p{P}\p{S}]*$/u';
+
     public function carousel(Request $request)
     {
         abort_if(! (bool) config_cache('instance.stories.enabled') || ! $request->user(), 404);
@@ -444,7 +466,7 @@ class StoryApiV1Controller extends Controller
 
                         switch ($type) {
                             case 'text':
-                                if (! preg_match('/^[a-zA-Z0-9\s\p{P}\p{S}]*$/u', $content)) {
+                                if (! preg_match(self::TEXT_OVERLAY_PATTERN, $content)) {
                                     throw ValidationException::withMessages([
                                         "overlays.{$index}.content" => 'Text overlays contain unsupported characters.',
                                     ]);

--- a/tests/Unit/Stories/StoryTextOverlayPatternTest.php
+++ b/tests/Unit/Stories/StoryTextOverlayPatternTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Tests\Unit\Stories;
+
+use App\Http\Controllers\Stories\StoryApiV1Controller;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Guards the text-overlay character whitelist used by
+ * StoryApiV1Controller::publishNext(). Accepts a wide range of
+ * legitimate Unicode (umlauts, accents, CJK, single-codepoint
+ * emoji, regional-indicator flags) while rejecting invisible /
+ * bidi-spoofing characters.
+ */
+class StoryTextOverlayPatternTest extends TestCase
+{
+    public static function acceptedProvider(): array
+    {
+        return [
+            'ascii'            => ['Hello World 123'],
+            'german umlaut'    => ['Hallöchen Müller'],
+            'accent nfc'       => ['café'],
+            'accent nfd'       => ["cafe\u{0301}"],
+            'cyrillic'         => ['Привет'],
+            'arabic'           => ['مرحبا'],
+            'cjk'              => ['你好世界'],
+            'single emoji'     => ['Hi 😀'],
+            'heart vs16'       => ["I\u{2764}\u{FE0F}NY"],
+            'country flag'     => ['Vacation 🇩🇪'],
+            'currency symbols' => ['Price: 100 € or $100'],
+            'math symbols'     => ['x²+y²=z²'],
+            'punctuation'      => ['Hello, world! (test) — "quoted"'],
+            'empty string'     => [''],
+        ];
+    }
+
+    public static function rejectedProvider(): array
+    {
+        return [
+            'zero-width space'   => ["hello\u{200B}admin"],
+            'zero-width nojoin'  => ["a\u{200C}b"],
+            'zero-width joiner'  => ["a\u{200D}b"],
+            'word joiner'        => ["ab\u{2060}cd"],
+            'bom / zwnbsp'       => ["\u{FEFF}leading"],
+            'bidi rlo'           => ["innocent\u{202E}cixot"],
+            'bidi lro'           => ["\u{202D}override"],
+            'ltr isolate'        => ["abc\u{2066}xyz\u{2069}"],
+            'rtl isolate'        => ["abc\u{2067}xyz\u{2069}"],
+            'arabic letter mark' => ["a\u{061C}b"],
+            'mongolian vowel sep'=> ["a\u{180E}b"],
+            'private use area'   => ["abc\u{E000}"],
+            'tag character'      => ["abc\u{E0041}"],
+            'nul byte'           => ["abc\x00def"],
+            'tab'                => ["a\tb"],
+            'newline'            => ["a\nb"],
+            'carriage return'    => ["a\rb"],
+            'line separator'     => ["a\u{2028}b"],
+            'paragraph separator'=> ["a\u{2029}b"],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('acceptedProvider')]
+    public function pattern_accepts_safe_input(string $input): void
+    {
+        $this->assertSame(
+            1,
+            preg_match(StoryApiV1Controller::TEXT_OVERLAY_PATTERN, $input),
+            'Expected pattern to accept input: '.bin2hex($input)
+        );
+    }
+
+    #[Test]
+    #[DataProvider('rejectedProvider')]
+    public function pattern_rejects_invisible_or_bidi_input(string $input): void
+    {
+        $this->assertSame(
+            0,
+            preg_match(StoryApiV1Controller::TEXT_OVERLAY_PATTERN, $input),
+            'Expected pattern to reject input: '.bin2hex($input)
+        );
+    }
+}


### PR DESCRIPTION
## Summary

`StoryApiV1Controller::publishNext()` validates each text overlay's
`content` against `'/^[a-zA-Z0-9\s\p{P}\p{S}]*$/u'`. That whitelist
accepts only ASCII letters, so any overlay containing Unicode letters
fails: German umlauts (ä, ö, ü, ß), accents (é, à, ñ), Cyrillic, Arabic,
CJK, etc. The API returns HTTP 500 with `Text overlays contain
unsupported characters.` and the iOS app shows a generic *"contact
admin"* error.

This PR widens the regex to allow Unicode letters/marks/digits while
explicitly keeping invisible and bidi-spoofing characters out.

## The change

```diff
-                                if (! preg_match('/^[a-zA-Z0-9\s\p{P}\p{S}]*$/u', $content)) {
+                                if (! preg_match(self::TEXT_OVERLAY_PATTERN, $content)) {
```

with

```php
const TEXT_OVERLAY_PATTERN = '/^[\p{L}\p{M}\p{N}\p{Zs}\p{P}\p{S}]*$/u';
```

Extracting to a class constant makes the pattern unit-testable.

## What gets accepted

- Unicode letters (`\p{L}`) and combining marks (`\p{M}`) — covers
  umlauts, accents in NFC and NFD form, non-Latin scripts.
- Digits (`\p{N}`), space separators (`\p{Zs}`), punctuation (`\p{P}`).
- Symbols (`\p{S}`) — single-codepoint emoji, regional-indicator country
  flags (🇩🇪), currency, math.

## What gets rejected (by omission from the whitelist)

| Category | Examples | Why blocked |
|---|---|---|
| `\p{Cc}` control | NUL, tab, newline, CR | injection / string-truncation; story overlay is single-line |
| `\p{Cf}` format | U+200B ZWSP, U+200C ZWNJ, U+200D ZWJ, U+2060 word joiner, U+FEFF BOM, U+202A–U+202E bidi overrides, U+2066–U+2069 directional isolates, U+061C arabic letter mark, U+180E mongolian vowel separator, U+E0000–U+E007F tag chars | invisible-character spoofing, bidi-override exploits, hidden stego data |
| `\p{Co}` private use | U+E000–U+F8FF | font can render as anything; stego risk |
| `\p{Cn}`, `\p{Cs}` | unassigned, surrogates | not valid text |

`\p{Zs}` is used instead of Perl-compatible `\s` because PCRE's `\s`
also matches some legacy format chars (notably U+180E) for backwards
compatibility, even when the Unicode database classifies them as
`\p{Cf}`.

## Known tradeoff

ZWJ-composed emoji sequences (👨‍👩‍👧, 🏳️‍🌈, profession and skin-tone
variants) are rejected because U+200D ZERO WIDTH JOINER is `\p{Cf}`.
This is deliberate — keeping invisible characters out is more valuable
here than supporting composite emoji. The single-codepoint emoji set
and country flags via regional indicators still work.

## Tests

Adds `tests/Unit/Stories/StoryTextOverlayPatternTest.php` covering 33
cases:

- **14 accepted**: ASCII, German umlaut, accent in NFC/NFD, Cyrillic,
  Arabic, CJK, single emoji, heart+VS16, country flag, currency, math,
  punctuation, empty string.
- **19 rejected**: zero-width space, ZWNJ, ZWJ, word joiner, BOM, RLO,
  LRO, LTR/RTL isolates, arabic letter mark, mongolian vowel separator,
  private use area, tag character, NUL byte, tab, newline, CR, line
  separator, paragraph separator.

```
OK (33 tests, 33 assertions)
```

## Test plan

- [x] Reproduced the bug on `v0.12.7`: overlay text `Hallöchen` returns
      500 with `Text overlays contain unsupported characters.`
- [x] After patch, the same overlay publishes successfully.
- [x] `vendor/bin/phpunit tests/Unit/Stories/StoryTextOverlayPatternTest.php` — 33/33 green.
- [ ] Reviewer: confirm the ZWJ-emoji tradeoff is acceptable, or request
      adding `\x{200D}` to the whitelist.

## Notes

- Same bug is present on `dev`, `staging`, and the `v0.12.7` tag.
- No DB migration, no schema change, no API contract change.
- Existing valid ASCII overlays continue to validate.