### PR TITLE
Keep valid URLs intact and therefore clickable

### DIFF
--- a/app/Util/ActivityPub/Helpers.php
+++ b/app/Util/ActivityPub/Helpers.php
@@ -180,7 +180,7 @@ class Helpers
                 return false;
             }
 
-            return $uri->toString();
+            return $uri;
 
         } catch (UriException $e) {
             return false;


### PR DESCRIPTION
Links in DMs are stripped at the moment by the validateUrl function. This small change stops valid links from getting transformed into strings without any options to click on them. 