### PR TITLE
Update symfony/http-foundation requirement due  CVE-2026-48736

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
         "spatie/laravel-image-optimizer": "^1.8.2",
         "stevebauman/purify": "^6.2.0",
         "symfony/http-client": "^7.3",
-        "symfony/http-foundation": "7.3.7",
+        "symfony/http-foundation": "7.4.13",
         "symfony/mailgun-mailer": "^7.3"
     },
     "require-dev": {


### PR DESCRIPTION
Pushing symfony/http-foundation to the newest 7.x version that fixes the CVE (see also https://packagist.org/security-advisories/PKSA-y6py-qpv1-h52p)