### PR TITLE
Add github workflow to build containers to ghcr.io

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -1,0 +1,52 @@
+name: Container building for ghcr.io
+
+on:
+  push:
+    branches: ["dev", "staging"]
+    tags:
+      - v*
+
+jobs:
+  build:
+    uses: docker/github-builder/.github/workflows/build.yml@v1
+    permissions:
+      contents: read # for checkout
+      packages: write # to upload build to GHCR
+      id-token: write # signing attestations with github oidc token
+    with:
+      output: image
+      push: true
+      context: .
+      platforms: linux/amd64,linux/arm64
+      cache: true
+      cache-mode: max
+      fail-fast: true
+      sbom: true
+      sign: false
+      cache-scope: pixelfed
+      meta-images: ghcr.io/${{ github.repository_owner }}/pixelfed
+      meta-tags: |
+        type=semver,pattern=v{{version}}
+        type=ref,event=branch
+      meta-flavor: |
+        latest=${{ startsWith(github.ref, 'refs/tags/') }}
+      set-meta-labels: true
+      set-meta-annotations: true
+    secrets:
+      registry-auths: |
+        - registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+  cleanup:
+    needs: build
+    if: ${{ github.ref_type == 'branch' }}
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+
+    steps:
+      - uses: dataaxiom/ghcr-cleanup-action@v1
+        with:
+          package: pixelfed
+          delete-untagged: true
+          older-than: 1 hour


### PR DESCRIPTION
Builds arm64 and amd64 containers and stores those into ghcr.io registry.

Builds dev and staging branches and tags

Uses docker builder that spaws matrix of jobs in native hosts in parallel build instead qemu approach.

Repository package visibility need to be checked to be public to allow people to use build containers.