### PR TITLE
Fix home timeline rejecting empty max_id/min_id pagination params

### DIFF
--- a/app/Http/Controllers/Api/ApiV1Controller.php
+++ b/app/Http/Controllers/Api/ApiV1Controller.php
@@ -2607,8 +2607,8 @@ class ApiV1Controller extends Controller
 
         $this->validate($request, [
             'page' => 'sometimes|integer|max:40',
-            'min_id' => 'sometimes|integer|min:0|max:'.PHP_INT_MAX,
-            'max_id' => 'sometimes|integer|min:0|max:'.PHP_INT_MAX,
+            'min_id' => 'nullable|integer|min:0|max:'.PHP_INT_MAX,
+            'max_id' => 'nullable|integer|min:0|max:'.PHP_INT_MAX,
             'limit' => 'sometimes|integer|min:1',
             'include_reblogs' => 'sometimes',
         ]);


### PR DESCRIPTION
Fixes #6610

`GET /api/v1/timelines/home?max_id=` (empty value) fails validation with HTTP 422. The global `ConvertEmptyStringsToNull` middleware turns `?max_id=` into `null`; because the field is *present*, the `sometimes` rule doesn't skip it, and `null` fails `integer`.

Every other timeline/listing endpoint in `ApiV1Controller` (e.g. `timelinePublic`) uses `nullable|integer` for these params — `timelineHome` was the lone outlier. Mastodon-API clients such as Pixelfed for iOS send `max_id=` on first page load and can't paginate the home timeline.

This switches `min_id`/`max_id` to `nullable|integer` to match the rest of the controller. `limit`/`page` are intentionally left as-is to keep the change minimal and consistent with `timelinePublic`.

Verified against `illuminate/validation` v12: the `null` input fails under `sometimes|integer` and passes under `nullable|integer`, while real integers still validate and non-numeric input is still rejected.

_Prepared with AI assistance (Claude), reviewed and verified by me._
