### PR TITLE
Invalidate landing / instance-data cache on write

### DIFF
--- a/app/Console/Commands/InstanceUpdateTotalLocalPosts.php
+++ b/app/Console/Commands/InstanceUpdateTotalLocalPosts.php
@@ -3,7 +3,7 @@
 namespace App\Console\Commands;
 
 use App\Services\ConfigCacheService;
-use Cache;
+use App\Services\LandingCacheService;
 use DB;
 use Illuminate\Console\Command;
 use Storage;
@@ -42,7 +42,7 @@ class InstanceUpdateTotalLocalPosts extends Command
             return;
         }
         $this->updateAndCache();
-        Cache::forget('api:nodeinfo');
+        LandingCacheService::invalidateStats();
 
     }
 

--- a/app/Http/Controllers/Admin/AdminDirectoryController.php
+++ b/app/Http/Controllers/Admin/AdminDirectoryController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\PixelfedDirectoryController;
 use App\Models\ConfigCache;
 use App\Services\AccountService;
 use App\Services\ConfigCacheService;
+use App\Services\LandingCacheService;
 use App\Services\StatusService;
 use App\Status;
 use App\User;
@@ -226,7 +227,7 @@ trait AdminDirectoryController
             $res['banner_image'] = $path;
             ConfigCacheService::put('app.banner_image', url(Storage::url($path)));
 
-            Cache::forget('api:v1:instance-data-response-v1');
+            LandingCacheService::invalidateBanner();
         }
 
         $config->v = json_encode($res);
@@ -322,7 +323,7 @@ trait AdminDirectoryController
         $directory->save();
         $bannerImage->v = url(Storage::url('public/headers/default.jpg'));
         $bannerImage->save();
-        Cache::forget('api:v1:instance-data-response-v1');
+        LandingCacheService::invalidateBanner();
         ConfigCacheService::put('pixelfed.directory', $directory);
 
         return $bannerImage->v;

--- a/app/Http/Controllers/Admin/AdminSettingsController.php
+++ b/app/Http/Controllers/Admin/AdminSettingsController.php
@@ -316,6 +316,13 @@ trait AdminSettingsController
         return view('admin.settings.system', compact('sys'));
     }
 
+    public function settingsClearInstanceCache(Request $request)
+    {
+        LandingCacheService::invalidate();
+
+        return redirect()->route('admin.settings.system')->with('status', 'Instance cache cleared.');
+    }
+
     public function settingsApiFetch(Request $request)
     {
         $cloud_storage = ConfigCacheService::get('pixelfed.cloud_storage');

--- a/app/Http/Controllers/Admin/AdminSettingsController.php
+++ b/app/Http/Controllers/Admin/AdminSettingsController.php
@@ -10,6 +10,7 @@ use App\Services\AccountService;
 use App\Services\AdminSettingsService;
 use App\Services\ConfigCacheService;
 use App\Services\FilesystemService;
+use App\Services\LandingCacheService;
 use App\User;
 use App\Util\Site\Config;
 use Artisan;
@@ -101,8 +102,7 @@ trait AdminSettingsController
 
         if ($request->filled('admin_account_id')) {
             ConfigCacheService::put('instance.admin.pid', $request->admin_account_id);
-            Cache::forget('api:v1:instance-data:contact');
-            Cache::forget('api:v1:instance-data-response-v1');
+            LandingCacheService::invalidateContact();
         }
         if ($request->filled('rule_delete')) {
             $index = (int) $request->input('rule_delete');
@@ -114,8 +114,7 @@ trait AdminSettingsController
             unset($json[$index]);
             $json = json_encode(array_values($json));
             ConfigCacheService::put('app.rules', $json);
-            Cache::forget('api:v1:instance-data:rules');
-            Cache::forget('api:v1:instance-data-response-v1');
+            LandingCacheService::invalidateRules();
 
             return 200;
         }
@@ -220,8 +219,7 @@ trait AdminSettingsController
                 $json[] = $val;
                 ConfigCacheService::put('app.rules', json_encode(array_values($json)));
             }
-            Cache::forget('api:v1:instance-data:rules');
-            Cache::forget('api:v1:instance-data-response-v1');
+            LandingCacheService::invalidateRules();
         }
 
         if ($request->filled('account_autofollow_usernames')) {
@@ -366,9 +364,7 @@ trait AdminSettingsController
             $json[] = $val;
             ConfigCacheService::put('app.rules', json_encode(array_values($json)));
         }
-        Cache::forget('api:v1:instance-data:rules');
-        Cache::forget('api:v1:instance-data-response-v1');
-        Cache::forget('api:v2:instance-data-response-v2');
+        LandingCacheService::invalidateRules();
         Config::refresh();
 
         return [$val];
@@ -395,9 +391,7 @@ trait AdminSettingsController
             ConfigCacheService::put('app.rules', json_encode(array_values($json)));
         }
 
-        Cache::forget('api:v1:instance-data:rules');
-        Cache::forget('api:v1:instance-data-response-v1');
-        Cache::forget('api:v2:instance-data-response-v2');
+        LandingCacheService::invalidateRules();
         Config::refresh();
 
         return response()->json($json);
@@ -413,9 +407,7 @@ trait AdminSettingsController
             ConfigCacheService::put('app.rules', json_encode([]));
         }
 
-        Cache::forget('api:v1:instance-data:rules');
-        Cache::forget('api:v1:instance-data-response-v1');
-        Cache::forget('api:v2:instance-data-response-v2');
+        LandingCacheService::invalidateRules();
         Config::refresh();
 
         return response()->json([]);
@@ -560,9 +552,7 @@ trait AdminSettingsController
         ConfigCacheService::put('pixelfed.import.instagram.enabled', $request->boolean('instagram_import'));
         ConfigCacheService::put('pixelfed.bouncer.enabled', $request->boolean('autospam_enabled'));
 
-        Cache::forget('api:v1:instance-data-response-v1');
-        Cache::forget('api:v2:instance-data-response-v2');
-        Cache::forget('api:v1:instance-data:contact');
+        LandingCacheService::invalidateContact();
         Config::refresh();
 
         return $request->all();
@@ -580,10 +570,8 @@ trait AdminSettingsController
         ConfigCacheService::put('instance.landing.show_directory', $request->boolean('show_directory'));
         ConfigCacheService::put('instance.landing.show_explore', $request->boolean('show_explore'));
 
-        Cache::forget('api:v1:instance-data:rules');
-        Cache::forget('api:v1:instance-data-response-v1');
-        Cache::forget('api:v2:instance-data-response-v2');
-        Cache::forget('api:v1:instance-data:contact');
+        LandingCacheService::invalidateRules();
+        LandingCacheService::invalidateContact();
         Config::refresh();
 
         return $request->all();
@@ -615,10 +603,8 @@ trait AdminSettingsController
         ConfigCacheService::put('pixelfed.optimize_image', $request->boolean('optimize_image'));
         ConfigCacheService::put('pixelfed.optimize_video', $request->boolean('optimize_video'));
 
-        Cache::forget('api:v1:instance-data:rules');
-        Cache::forget('api:v1:instance-data-response-v1');
-        Cache::forget('api:v2:instance-data-response-v2');
-        Cache::forget('api:v1:instance-data:contact');
+        LandingCacheService::invalidateRules();
+        LandingCacheService::invalidateContact();
         Config::refresh();
 
         return $request->all();
@@ -636,10 +622,8 @@ trait AdminSettingsController
         ConfigCacheService::put('app.short_description', $request->input('short_description'));
         ConfigCacheService::put('app.description', $request->input('long_description'));
 
-        Cache::forget('api:v1:instance-data:rules');
-        Cache::forget('api:v1:instance-data-response-v1');
-        Cache::forget('api:v2:instance-data-response-v2');
-        Cache::forget('api:v1:instance-data:contact');
+        LandingCacheService::invalidateRules();
+        LandingCacheService::invalidateContact();
         Config::refresh();
 
         return $request->all();
@@ -658,9 +642,7 @@ trait AdminSettingsController
             'max_caption_length' => $request->input('max_caption_length'),
             'max_altext_length' => $request->input('max_altext_length'),
         ];
-        Cache::forget('api:v1:instance-data:rules');
-        Cache::forget('api:v1:instance-data-response-v1');
-        Cache::forget('api:v2:instance-data-response-v2');
+        LandingCacheService::invalidateRules();
         Config::refresh();
 
         return $res;
@@ -724,9 +706,7 @@ trait AdminSettingsController
             'captcha_sitekey' => $request->input('captcha_sitekey'),
             'custom_emoji_enabled' => $request->boolean('custom_emoji_enabled'),
         ];
-        Cache::forget('api:v1:instance-data:rules');
-        Cache::forget('api:v1:instance-data-response-v1');
-        Cache::forget('api:v2:instance-data-response-v2');
+        LandingCacheService::invalidateRules();
         Config::refresh();
 
         return $res;
@@ -792,9 +772,7 @@ trait AdminSettingsController
             'max_user_mutes' => $request->input('max_user_mutes'),
             'max_domain_blocks' => $request->input('max_domain_blocks'),
         ];
-        Cache::forget('api:v1:instance-data:rules');
-        Cache::forget('api:v1:instance-data-response-v1');
-        Cache::forget('api:v2:instance-data-response-v2');
+        LandingCacheService::invalidateRules();
         Config::refresh();
 
         return $res;
@@ -880,9 +858,7 @@ trait AdminSettingsController
             }
             $res['changes'] = json_encode($changes);
         }
-        Cache::forget('api:v1:instance-data:rules');
-        Cache::forget('api:v1:instance-data-response-v1');
-        Cache::forget('api:v2:instance-data-response-v2');
+        LandingCacheService::invalidateRules();
         Config::refresh();
 
         return $res;

--- a/app/Http/Controllers/Settings/HomeSettings.php
+++ b/app/Http/Controllers/Settings/HomeSettings.php
@@ -7,6 +7,7 @@ use App\EmailVerification;
 use App\Mail\PasswordChange;
 use App\Media;
 use App\Services\AccountService;
+use App\Services\LandingCacheService;
 use App\Services\PronounService;
 use App\Util\Lexer\Autolink;
 use App\Util\Lexer\PrettyNumber;
@@ -102,6 +103,9 @@ trait HomeSettings
             Cache::forget('user:account:id:'.$user->id);
             AccountService::forgetAccountSettings($profile->id);
             AccountService::del($profile->id);
+            if (LandingCacheService::profileBacksContact((int) $profile->id)) {
+                LandingCacheService::invalidateContact();
+            }
 
             return redirect('/settings/home')->with('status', 'Profile successfully updated!');
         }

--- a/app/Jobs/AvatarPipeline/AvatarOptimize.php
+++ b/app/Jobs/AvatarPipeline/AvatarOptimize.php
@@ -4,6 +4,8 @@ namespace App\Jobs\AvatarPipeline;
 
 use App\Avatar;
 use App\Profile;
+use App\Services\AccountService;
+use App\Services\LandingCacheService;
 use App\Util\Media\ImageDriverManager;
 use Cache;
 use Carbon\Carbon;
@@ -96,6 +98,10 @@ class AvatarOptimize implements ShouldQueue
             $avatar->last_processed_at = Carbon::now();
             $avatar->save();
             Cache::forget('avatar:'.$avatar->profile_id);
+            AccountService::del($avatar->profile_id);
+            if (LandingCacheService::profileBacksContact((int) $avatar->profile_id)) {
+                LandingCacheService::invalidateContact();
+            }
             $this->deleteOldAvatar($avatar->media_path, $this->current);
 
             if ((bool) config_cache('pixelfed.cloud_storage') && (bool) config_cache('instance.avatar.local_to_cloud')) {
@@ -132,5 +138,9 @@ class AvatarOptimize implements ShouldQueue
         $avatar->save();
         Storage::delete($avatar->media_path);
         Cache::forget('avatar:'.$avatar->profile_id);
+        AccountService::del($avatar->profile_id);
+        if (LandingCacheService::profileBacksContact((int) $avatar->profile_id)) {
+            LandingCacheService::invalidateContact();
+        }
     }
 }

--- a/app/Services/LandingCacheService.php
+++ b/app/Services/LandingCacheService.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace App\Services;
+
+use App\User;
+use Illuminate\Support\Facades\Cache;
+
+/**
+ * Single source of truth for the cache keys that back the landing page,
+ * /api/v1/instance, /api/v2/instance, and nodeinfo.
+ *
+ * These keys are otherwise duplicated across several controllers and a
+ * background job; gathering them here makes it impossible to add a new
+ * read site without also updating the bust paths.
+ */
+class LandingCacheService
+{
+    public const INSTANCE_RESPONSE_V1 = 'api:v1:instance-data-response-v1';
+
+    public const INSTANCE_RESPONSE_V2 = 'api:v2:instance-data-response-v2';
+
+    public const INSTANCE_CONTACT = 'api:v1:instance-data:contact';
+
+    public const INSTANCE_RULES = 'api:v1:instance-data:rules';
+
+    public const INSTANCE_STATS_V0 = 'api:v1:instance-data:stats:v0';
+
+    public const NODEINFO = 'api:nodeinfo';
+
+    public const NODEINFO_USERS = 'api:nodeinfo:users';
+
+    public const NODEINFO_ACTIVE_MONTHLY = 'api:nodeinfo:active-users-monthly';
+
+    public const NODEINFO_ACTIVE_HALFYEAR = 'api:nodeinfo:active-users-half-year';
+
+    public const INSTANCE_TOTAL_POSTS = 'pf:services:instances:self:total-posts';
+
+    public const INSTANCE_BANNER_BLURHASH = 'pf:services:instance:header-blurhash:v1';
+
+    /**
+     * Forget every key that backs the landing page and /api/v(1|2)/instance.
+     *
+     * Use this for explicit admin "clear cache" actions; prefer the more
+     * targeted invalidateContact / invalidateRules / invalidateBanner /
+     * invalidateStats methods when you know which subset changed.
+     */
+    public static function invalidate(): void
+    {
+        self::invalidateContact();
+        self::invalidateRules();
+        self::invalidateBanner();
+        self::invalidateStats();
+    }
+
+    /**
+     * Forget the contact-account-derived cache entries.
+     *
+     * Call this when the admin profile, avatar, bio, or display name changes.
+     */
+    public static function invalidateContact(): void
+    {
+        Cache::forget(self::INSTANCE_CONTACT);
+        Cache::forget(self::INSTANCE_RESPONSE_V1);
+        Cache::forget(self::INSTANCE_RESPONSE_V2);
+    }
+
+    /**
+     * Forget the instance-rules-derived cache entries.
+     *
+     * Call this when app.rules changes.
+     */
+    public static function invalidateRules(): void
+    {
+        Cache::forget(self::INSTANCE_RULES);
+        Cache::forget(self::INSTANCE_RESPONSE_V1);
+        Cache::forget(self::INSTANCE_RESPONSE_V2);
+    }
+
+    /**
+     * Forget the banner-image-derived cache entries.
+     *
+     * The header blurhash is cached with rememberForever AND short-circuited
+     * by a config_cache value, so both layers must be cleared together —
+     * otherwise the next render will return the stale blurhash from the
+     * config_cache fallback path inside InstanceService::headerBlurhash().
+     */
+    public static function invalidateBanner(): void
+    {
+        Cache::forget(self::INSTANCE_BANNER_BLURHASH);
+        Cache::forget(self::INSTANCE_RESPONSE_V1);
+        Cache::forget(self::INSTANCE_RESPONSE_V2);
+        ConfigCacheService::put('instance.banner.blurhash', '');
+    }
+
+    /**
+     * Forget the counts/stats cache entries.
+     *
+     * These are time-driven (12h / 1h) under normal operation; explicit
+     * invalidation is rarely necessary, but exposed here for the admin
+     * "clear cache" action.
+     */
+    public static function invalidateStats(): void
+    {
+        Cache::forget(self::INSTANCE_STATS_V0);
+        Cache::forget(self::NODEINFO);
+        Cache::forget(self::NODEINFO_USERS);
+        Cache::forget(self::NODEINFO_ACTIVE_MONTHLY);
+        Cache::forget(self::NODEINFO_ACTIVE_HALFYEAR);
+        Cache::forget(self::INSTANCE_TOTAL_POSTS);
+        Cache::forget(self::INSTANCE_RESPONSE_V1);
+        Cache::forget(self::INSTANCE_RESPONSE_V2);
+    }
+
+    /**
+     * Does this profile back the configured contact account?
+     *
+     * Mirrors the resolution logic in LandingService::get() / the V1+V2
+     * instance endpoints: prefer the explicitly-configured admin profile
+     * id, otherwise fall back to the first is_admin user.
+     */
+    public static function profileBacksContact(int $profileId): bool
+    {
+        $configured = config_cache('instance.admin.pid');
+        if ($configured) {
+            return (int) $configured === $profileId;
+        }
+
+        $admin = User::whereIsAdmin(true)->first();
+
+        return $admin && (int) $admin->profile_id === $profileId;
+    }
+
+    /**
+     * @return string[]
+     */
+    public static function all(): array
+    {
+        return [
+            self::INSTANCE_RESPONSE_V1,
+            self::INSTANCE_RESPONSE_V2,
+            self::INSTANCE_CONTACT,
+            self::INSTANCE_RULES,
+            self::INSTANCE_STATS_V0,
+            self::NODEINFO,
+            self::NODEINFO_USERS,
+            self::NODEINFO_ACTIVE_MONTHLY,
+            self::NODEINFO_ACTIVE_HALFYEAR,
+            self::INSTANCE_TOTAL_POSTS,
+            self::INSTANCE_BANNER_BLURHASH,
+        ];
+    }
+}

--- a/resources/views/admin/settings/system.blade.php
+++ b/resources/views/admin/settings/system.blade.php
@@ -77,6 +77,22 @@
       </div>
     </div>
   </div>
+  <hr>
+  <p class="h6 text-uppercase text-center">INSTANCE CACHE</p>
+  @if(session('status'))
+  <div class="alert alert-success">{{ session('status') }}</div>
+  @endif
+  <div class="card shadow-none border">
+    <div class="card-body">
+      <p class="mb-2">
+        Clears the cached payloads behind the landing page, <code>/api/v1/instance</code>, <code>/api/v2/instance</code>, and nodeinfo (admin profile, rules, banner blurhash, user and post counts). Safe to run at any time; the values will repopulate on the next request.
+      </p>
+      <form method="POST" action="{{ route('admin.settings.system.clear-instance-cache') }}" class="mb-0">
+        @csrf
+        <button type="submit" class="btn btn-outline-danger font-weight-bold">Clear Instance Cache</button>
+      </form>
+    </div>
+  </div>
 @endsection
 
 @push('styles')

--- a/routes/web-admin.php
+++ b/routes/web-admin.php
@@ -64,6 +64,7 @@ Route::domain(config('pixelfed.domain.admin'))->prefix('i/admin')->group(functio
     Route::get('settings/backups', 'AdminController@settingsBackups')->name('admin.settings.backups');
     Route::get('settings/storage', 'AdminController@settingsStorage')->name('admin.settings.storage');
     Route::get('settings/system', 'AdminController@settingsSystem')->name('admin.settings.system');
+    Route::post('settings/system/clear-instance-cache', 'AdminController@settingsClearInstanceCache')->name('admin.settings.system.clear-instance-cache');
 
     Route::get('instances', 'AdminController@instances')->name('admin.instances');
     Route::post('instances', 'AdminController@instanceScan');


### PR DESCRIPTION
## Motivation

I recently set up my own self-hosted Pixelfed instance. While most of it went smoothly enough, the part I wasted the most time on turned out to be **cache invalidation**. So this PR attempts to wrangle a lot of hard-coded defaults spread throughout the codebase into admin-configurable variables.

The landing page, `/api/v1/instance`, `/api/v2/instance`, and nodeinfo are backed by 11 distinct cache keys with TTLs ranging from 1 hour to 7 days (some are `rememberForever`). Several mutation sites don't invalidate on write, so admin profile changes, banner uploads, and instance-config edits can remain invisible on public surfaces for up to a week.

Two concrete symptoms I hit on my own instance:

- Updating the admin avatar or bio via the regular `/settings/home`  UI (not the admin panel) left the old values on the landing page and `/api/v(1|2)/instance` until `api:v1:instance-data:contact` naturally expired 7 days later.
- Uploading a new instance banner via the admin panel invalidated the V1 wrapper key but not the `rememberForever` header-blurhash cache or the `instance.banner.blurhash` config-cache short-circuit, so the old blurhash persisted indefinitely.

## Approach

1. **Centralize the keys.** New `App\Services\LandingCacheService` is a single source of truth for the 11 keys behind these surfaces, with granular invalidation helpers (`invalidateContact`, `invalidateRules`, `invalidateBanner`, `invalidateStats`) plus an aggregate `invalidate()`.
2. **Route existing invalidation sites through the service.** 14 duplicated `Cache::forget` blocks across `AdminSettingsController`, `AdminDirectoryController`, and the `app:instance-update-total-local-posts` command now call the service. This closes three pre-existing invalidation gaps (see commit 2 for the specifics).
3. **Add missing invalidation sites.** `AvatarOptimize` and `HomeSettings::homeUpdate` now invalidate the contact cache when the profile being updated backs the configured contact account (via a `profileBacksContact` helper that mirrors `LandingService::get()`'s resolution logic). `AvatarOptimize` also picks up an `AccountService::del()` call for the per-profile account cache that was previously left stale.
4. **Add a manual override.** A new "Clear Instance Cache" button on `/i/admin/settings/system` calls `LandingCacheService::invalidate()` for the rare cases where operators mutate `ConfigCache` directly or need to debug stale-cache symptoms (or are setting up a new instance and need to know their changes stuck).

(those are basically the four commits in this PR)

## Testing

`php -l` clean on all 7 modified PHP files under `php:8.3-cli`. I've not yet tested end-to-end against a running Pixelfed instance, but I'm  happy to add tests or run through a manual verification checklist if that would help review.