### PR TITLE
Fix API status editing: use auth:api guard

### DIFF
--- a/app/Http/Controllers/StatusEditController.php
+++ b/app/Http/Controllers/StatusEditController.php
@@ -15,7 +15,7 @@ class StatusEditController extends Controller
 {
     public function __construct()
     {
-        $this->middleware('auth');
+        $this->middleware('auth:api');
         abort_if(! config('exp.pue'), 404, 'Post editing is not enabled on this server.');
     }
 


### PR DESCRIPTION
## Problem

`StatusEditController::__construct()` applies the web `auth` guard:

```php
$this->middleware('auth');
```

Bearer/OAuth clients cannot satisfy that guard, so both endpoints this controller serves fail for every third-party API client:

- `PUT /api/v1/statuses/{id}` — edit a status
- `GET /api/v1/statuses/{id}/history` — edit history

Status create and delete keep working, because those live in `ApiV1Controller`, which has no controller-level web auth. That asymmetry is what makes the symptom look like "post editing is broken" rather than "auth is misconfigured".

## Fix

Switch the constructor to the API guard so it matches the routes.

## Why this is safe

`StatusEditController` is routed only from `routes/api.php`, where the group already applies the API guard:

```php
$middleware = ['auth:api', 'validemail'];                            // routes/api.php:5
Route::get('statuses/{id}/history', 'StatusEditController@history')  // :175
    ->middleware($middleware);
Route::put('statuses/{id}', 'StatusEditController@store')            // :176
    ->middleware($middleware);
```

It is not referenced in `routes/web.php`, so there is no session-based route that depends on the old guard.

Authorization is unchanged. Ownership is enforced in `StoreStatusEditRequest::authorize()`:

```php
return $status && $this->user()->profile_id === $status->profile_id;
```

Because `auth:api` calls `Auth::shouldUse('api')`, `$request->user()` resolves to the token's user exactly as it did under the web guard.

## Alternative

Since the route group already applies `auth:api`, the constructor line could simply be **deleted** rather than corrected. I kept a controller-level guard for defence in depth, but I'm happy to switch to removing it if you prefer — arguably the duplication is what let the two drift apart in the first place.

## Relationship to #6582

#6582 touches this same constructor (dropping the `exp.pue` `abort_if`) but leaves the guard as `auth`, so the two changes are independent. They will overlap textually if both land.

## Testing

Applied to two live v0.12.7 instances. Before the patch, `PUT /api/v1/statuses/{id}` failed for Bearer/OAuth clients; after it, editing from a third-party client succeeds. Unauthenticated requests return `401` as expected.
