### PR TITLE
Fix videos never reaching cloud storage by downscaling in Blurhash (#2652)

### DIFF
--- a/app/Jobs/VideoPipeline/VideoThumbnail.php
+++ b/app/Jobs/VideoPipeline/VideoThumbnail.php
@@ -98,10 +98,20 @@ class VideoThumbnail implements ShouldBeUniqueUntilProcessing, ShouldQueue
             $media->thumbnail_path = $save;
             $media->save();
 
-            $blurhash = Blurhash::generate($media);
-            if ($blurhash) {
-                $media->blurhash = $blurhash;
-                $media->save();
+            // Isolated from the thumbnail work on purpose. The blurhash is decorative;
+            // MediaStoragePipeline at the end of this method is not, and until now any
+            // failure here skipped it, leaving the video on local disk forever with no
+            // failed_jobs row to show for it (pixelfed#2652).
+            try {
+                $blurhash = Blurhash::generate($media);
+                if ($blurhash) {
+                    $media->blurhash = $blurhash;
+                    $media->save();
+                }
+            } catch (\Exception $e) {
+                if (config('app.dev_log')) {
+                    Log::error('Video blurhash generation failed: '.$e->getMessage());
+                }
             }
 
             if (config('media.hls.enabled')) {

--- a/app/Jobs/VideoPipeline/VideoThumbnail.php
+++ b/app/Jobs/VideoPipeline/VideoThumbnail.php
@@ -108,7 +108,12 @@ class VideoThumbnail implements ShouldBeUniqueUntilProcessing, ShouldQueue
                     $media->blurhash = $blurhash;
                     $media->save();
                 }
-            } catch (\Exception $e) {
+            } catch (\Throwable $e) {
+                // \Throwable, not \Exception: the failure this guard exists for is a
+                // memory_limit exhaustion, which surfaces as \Error (or a fatal), not
+                // \Exception. Catching only \Exception here would let the very case
+                // that strands the video (pixelfed#2652) slip through and skip the
+                // MediaStoragePipeline dispatch below.
                 if (config('app.dev_log')) {
                     Log::error('Video blurhash generation failed: '.$e->getMessage());
                 }

--- a/app/Util/Media/Blurhash.php
+++ b/app/Util/Media/Blurhash.php
@@ -37,6 +37,40 @@ class Blurhash
         $width = imagesx($image);
         $height = imagesy($image);
 
+        // The loop below allocates one PHP array per pixel, which costs a few hundred
+        // bytes each once the hashtable is counted: a 720x1280 frame measured at 224 MB
+        // peak, i.e. ~255 bytes per pixel, which puts 1920x1080 near half a gigabyte
+        // (#2652 reports over a gigabyte on an older PHP). Image thumbnails are capped
+        // at 640x640 and run under Image::__construct()'s ini_set('memory_limit',
+        // '1024M'), so they stay inside it. Video thumbnails come straight out of
+        // FFmpeg at source resolution with no
+        // such raise, and blow memory_limit outright — a PHP fatal, which is not an
+        // \Exception, so it kills the worker instead of being caught (pixelfed#2652).
+        //
+        // The output is a 4x4-component DCT, so sampling the source at full resolution
+        // buys almost nothing. Downscaling first removes the ceiling for every caller
+        // rather than moving it, which is all raising memory_limit would have done.
+        //
+        // 128px on the long edge measured as the point of diminishing returns: against
+        // the full-resolution hash, mean per-channel deviation of the decoded 24x24
+        // preview is ~7.5/255 at a 32px sample, ~4.5/255 at 64px, ~2.5/255 at 128px,
+        // and no better at 256px. At 128px a 1920x1080 frame samples 9,216 pixels
+        // instead of 2,073,600.
+        $sampleMax = 128;
+        if ($width > $sampleMax || $height > $sampleMax) {
+            $scale = $sampleMax / max($width, $height);
+            $sampleWidth = max(1, (int) round($width * $scale));
+            $sampleHeight = max(1, (int) round($height * $scale));
+
+            $resized = imagescale($image, $sampleWidth, $sampleHeight);
+            if ($resized !== false) {
+                imagedestroy($image);
+                $image = $resized;
+                $width = $sampleWidth;
+                $height = $sampleHeight;
+            }
+        }
+
         $pixels = [];
         for ($y = 0; $y < $height; $y++) {
             $row = [];


### PR DESCRIPTION
Fixes #2652.

## The bug

`Blurhash::generate()` builds a PHP array holding every pixel of the source as a 3-element array. At roughly 255 bytes per pixel — measured at **224 MB peak for a 720x1280 frame** — a 1920x1080 frame approaches half a gigabyte.

Images survive this. Videos do not, and the asymmetry is the whole bug:

| | thumbnail size | memory_limit while hashing |
|---|---|---|
| images | capped at 640x640 by `Image::__construct()` | raised to 1024M by the same constructor |
| videos | whatever FFmpeg saved, i.e. source resolution | untouched, so the php.ini value |

So any video whose frame is 1080p or larger exhausts `memory_limit`. That is a PHP **fatal**, not an `\Exception`, and three things follow:

- the `catch (\Exception $e)` in `VideoThumbnail::handle()` does not catch it
- the job never reaches `failed_jobs`, so nothing anywhere reports a problem
- `MediaStoragePipeline::dispatch()`, the **last line** of `handle()`, never runs

The video stays on local disk permanently while images uploaded beside it replicate normally. On the instance where I found this, every local video ever uploaded was still on the app host and absent from the bucket; every image was in the bucket. Nothing looked broken to a viewer, because the media is still served — just from the app server rather than the CDN, and outside whatever backup policy the bucket has.

This matches the report in #2652 (2021-02-13) and the diagnosis `@jimmybrancaccio` posted in that thread on 2021-11-04.

## The fix

**1. Downscale before sampling.** The output is a 4x4-component DCT, so sampling the source at full resolution buys almost nothing. Measured against the full-resolution hash, mean per-channel deviation of the decoded 24x24 preview:

| sample | deviation |
|---|---|
| 32px | ~7.5/255 |
| 64px | ~4.5/255 |
| **128px** | **~2.5/255** |
| 256px | no better |

128px on the long edge is the point of diminishing returns. Peak memory for the frame above drops **224 MB → 6 MB**. A 1920x1080 frame now samples 9,216 pixels instead of 2,073,600.

This removes the ceiling for every caller rather than moving it, which is all raising `memory_limit` would have done — the next larger frame would find the new wall.

**2. Isolate the blurhash in `VideoThumbnail`.** The blurhash is decorative; the replication dispatch is not, and a decorative step should not be able to skip it. Change 1 covers the fatal, this covers any ordinary exception.

## Compatibility

- **Existing hashes are not recomputed**, so nothing already published changes appearance. Only newly generated hashes use the new sampling.
- `imagescale()` is GD, available since PHP 5.5, and this file already depends on GD (`imagecreatefromstring`, `imagecolorat`). If it fails it returns `false` and the code falls through to the original full-resolution path.
- No config, schema or API change.

## Verification

On a live instance with S3 cloud storage:

- a 1920x1080 video that previously stranded now generates a blurhash, uploads original and thumbnail to the bucket, sets `cdn_url` / `thumbnail_url` / `replicated_at`, and removes the local copies
- ten existing images re-hashed from their stored thumbnails decode to visually identical previews (~1% mean deviation)
- previously stranded videos replicate correctly when the pipeline is re-run against them

Note that a fix alone does not backfill media already stranded by this bug — those need `MediaStoragePipeline` re-dispatched against rows where `cdn_url IS NULL`.