### PR TITLE
refactor: use ::class syntax in EventServiceProvider

### DIFF
--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -2,8 +2,11 @@
 
 namespace App\Providers;
 
+use App\Listeners\AuthLogin;
+use App\Listeners\LogFailedLogin;
+use Illuminate\Auth\Events\Failed;
+use Illuminate\Auth\Events\Login;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
-use Illuminate\Support\Facades\Event;
 
 class EventServiceProvider extends ServiceProvider
 {
@@ -13,11 +16,11 @@ class EventServiceProvider extends ServiceProvider
      * @var array
      */
     protected $listen = [
-        'Illuminate\Auth\Events\Login' => [
-            \App\Listeners\AuthLogin::class,
+        Login::class => [
+            AuthLogin::class,
         ],
-        'Illuminate\Auth\Events\Failed' => [
-            \App\Listeners\LogFailedLogin::class,
+        Failed::class => [
+            LogFailedLogin::class,
         ],
     ];
 
@@ -29,7 +32,5 @@ class EventServiceProvider extends ServiceProvider
     public function boot()
     {
         parent::boot();
-
-        //
     }
 }


### PR DESCRIPTION
Replace string-based event class references with proper `::class` imports for IDE navigation and static analysis compatibility.

Trivial 2-line fix, no behavior change.