### PR TITLE
refactor: split AppServiceProvider into focused providers

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -6,7 +6,6 @@ use App\Avatar;
 use App\Follower;
 use App\HashtagFollow;
 use App\Like;
-use App\Models\OAuthToken;
 use App\ModLog;
 use App\Notification;
 use App\Observers\AvatarObserver;
@@ -29,17 +28,10 @@ use App\User;
 use App\UserFilter;
 use Auth;
 use Horizon;
-use Illuminate\Cache\RateLimiting\Limit;
-use Illuminate\Database\Eloquent\Model;
-use Illuminate\Http\Request;
-use Illuminate\Pagination\Paginator;
 use Illuminate\Support\Facades\Gate;
-use Illuminate\Support\Facades\RateLimiter;
-use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Facades\URL;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\ServiceProvider;
-use Laravel\Passport\Passport;
 use Laravel\Pulse\Facades\Pulse;
 
 class AppServiceProvider extends ServiceProvider
@@ -55,11 +47,8 @@ class AppServiceProvider extends ServiceProvider
             URL::forceScheme('https');
         }
 
-        Passport::$clientUuids = false;
-        Passport::authorizationView('auth.oauth.authorize');
+        URL::forceRootUrl(config('app.url'));
 
-        Schema::defaultStringLength(191);
-        Paginator::useBootstrap();
         Avatar::observe(AvatarObserver::class);
         Follower::observe(FollowerObserver::class);
         HashtagFollow::observe(HashtagFollowObserver::class);
@@ -71,9 +60,11 @@ class AppServiceProvider extends ServiceProvider
         User::observe(UserObserver::class);
         Status::observe(StatusObserver::class);
         UserFilter::observe(UserFilterObserver::class);
+
         Horizon::auth(function ($request) {
             return Auth::check() && $request->user()->is_admin;
         });
+
         Validator::includeUnvalidatedArrayKeys();
 
         Gate::define('viewPulse', function (User $user) {
@@ -95,90 +86,6 @@ class AppServiceProvider extends ServiceProvider
                 ];
             });
         }
-
-        RateLimiter::for('app-signup', function (Request $request) {
-            return Limit::perDay(100)->by($request->ip());
-        });
-
-        RateLimiter::for('app-code-verify', function (Request $request) {
-            $email = strtolower(trim((string) $request->input('email')));
-
-            $emailKey = $email !== ''
-                ? hash('sha256', $email)
-                : 'missing';
-
-            return [
-                Limit::perHour(20)->by('app-code-verify:ip:' . $request->ip()),
-                Limit::perHour(10)->by('app-code-verify:email:' . $emailKey),
-            ];
-        });
-
-        RateLimiter::for('app-code-resend', function (Request $request) {
-            return Limit::perHour(10)->by($request->ip());
-        });
-
-        RateLimiter::for('account-lookup', function (Request $request) {
-            return Limit::perDay(50)->by($request->ip());
-        });
-
-        RateLimiter::for('oauth-pat', function (Request $request) {
-            $user = $request->user('web');
-
-            $actor = $user
-                ? 'u:' . $user->getAuthIdentifier()
-                : 'ip:' . $request->ip();
-
-            $tooMany = function (Request $request, array $headers) {
-                return response()->json([
-                    'message' => 'Too many requests',
-                    'retry_after' => isset($headers['Retry-After'])
-                        ? (int) $headers['Retry-After']
-                        : null,
-                    'debug' => 'oauth-pat limiter hit',
-                    'headers' => $headers,
-                ], 429)->withHeaders($headers)->header('X-Debug-Limiter', 'oauth-pat');
-            };
-
-            return [
-                Limit::perMinute(3)
-                    ->by("minute:{$actor}"),
-
-                Limit::perHour(15)
-                    ->by("hour:{$actor}"),
-
-                Limit::perDay(20)
-                    ->by("day:{$actor}"),
-            ];
-        });
-
-        Passport::useTokenModel(OAuthToken::class);
-        Passport::tokensExpireIn(now()->addDays(config('instance.oauth.token_expiration', 356)));
-        Passport::refreshTokensExpireIn(now()->addDays(config('instance.oauth.refresh_expiration', 400)));
-        Passport::enableImplicitGrant();
-        if (config('instance.oauth.pat.enabled')) {
-            Passport::personalAccessClientId(config('instance.oauth.pat.id'));
-        }
-
-        Passport::tokensCan([
-            'read' => 'Full read access to your account',
-            'write' => 'Full write access to your account',
-            'follow' => 'Ability to follow other profiles',
-            'admin:read' => 'Read all data on the server',
-            'admin:read:domain_blocks' => 'Read sensitive information of all domain blocks',
-            'admin:write' => 'Modify all data on the server',
-            'admin:write:domain_blocks' => 'Perform moderation actions on domain blocks',
-            'push' => 'Receive your push notifications',
-        ]);
-
-        Passport::setDefaultScope([
-            'read',
-            'write',
-            'follow',
-        ]);
-
-        URL::forceRootUrl(config('app.url'));
-
-        // Model::preventLazyLoading(true);
     }
 
     /**
@@ -188,8 +95,6 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        Passport::ignoreRoutes();
-
         $this->app->bind(UserOidcService::class, function () {
             return UserOidcService::build();
         });

--- a/app/Providers/PassportServiceProvider.php
+++ b/app/Providers/PassportServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers;
 
+use App\Models\OAuthToken;
 use App\Passport\CachedPersonalAccessClientRepository;
 use Laravel\Passport\Bridge;
 use Laravel\Passport\ClientRepository;
@@ -15,7 +16,43 @@ class PassportServiceProvider extends \Laravel\Passport\PassportServiceProvider
     {
         parent::register();
 
+        Passport::ignoreRoutes();
+
         $this->app->singleton(ClientRepository::class, CachedPersonalAccessClientRepository::class);
+    }
+
+    public function boot(): void
+    {
+        parent::boot();
+
+        Passport::$clientUuids = false;
+        Passport::authorizationView('auth.oauth.authorize');
+
+        Passport::useTokenModel(OAuthToken::class);
+        Passport::tokensExpireIn(now()->addDays(config('instance.oauth.token_expiration', 356)));
+        Passport::refreshTokensExpireIn(now()->addDays(config('instance.oauth.refresh_expiration', 400)));
+        Passport::enableImplicitGrant();
+
+        if (config('instance.oauth.pat.enabled')) {
+            Passport::personalAccessClientId(config('instance.oauth.pat.id'));
+        }
+
+        Passport::tokensCan([
+            'read' => 'Full read access to your account',
+            'write' => 'Full write access to your account',
+            'follow' => 'Ability to follow other profiles',
+            'admin:read' => 'Read all data on the server',
+            'admin:read:domain_blocks' => 'Read sensitive information of all domain blocks',
+            'admin:write' => 'Modify all data on the server',
+            'admin:write:domain_blocks' => 'Perform moderation actions on domain blocks',
+            'push' => 'Receive your push notifications',
+        ]);
+
+        Passport::setDefaultScope([
+            'read',
+            'write',
+            'follow',
+        ]);
     }
 
     /**

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -2,7 +2,10 @@
 
 namespace App\Providers;
 
+use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Foundation\Support\Providers\RouteServiceProvider as ServiceProvider;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\Facades\Route;
 
 class RouteServiceProvider extends ServiceProvider
@@ -14,6 +17,8 @@ class RouteServiceProvider extends ServiceProvider
      */
     public function boot()
     {
+        $this->configureRateLimiting();
+
         parent::boot();
     }
 
@@ -61,5 +66,57 @@ class RouteServiceProvider extends ServiceProvider
     {
         Route::middleware('api')
             ->group(base_path('routes/api.php'));
+    }
+
+    /**
+     * Configure the rate limiters for the application.
+     *
+     * @return void
+     */
+    protected function configureRateLimiting()
+    {
+        RateLimiter::for('app-signup', function (Request $request) {
+            return Limit::perDay(100)->by($request->ip());
+        });
+
+        RateLimiter::for('app-code-verify', function (Request $request) {
+            $email = strtolower(trim((string) $request->input('email')));
+
+            $emailKey = $email !== ''
+                ? hash('sha256', $email)
+                : 'missing';
+
+            return [
+                Limit::perHour(20)->by('app-code-verify:ip:'.$request->ip()),
+                Limit::perHour(10)->by('app-code-verify:email:'.$emailKey),
+            ];
+        });
+
+        RateLimiter::for('app-code-resend', function (Request $request) {
+            return Limit::perHour(10)->by($request->ip());
+        });
+
+        RateLimiter::for('account-lookup', function (Request $request) {
+            return Limit::perDay(50)->by($request->ip());
+        });
+
+        RateLimiter::for('oauth-pat', function (Request $request) {
+            $user = $request->user('web');
+
+            $actor = $user
+                ? 'u:'.$user->getAuthIdentifier()
+                : 'ip:'.$request->ip();
+
+            return [
+                Limit::perMinute(3)
+                    ->by("minute:{$actor}"),
+
+                Limit::perHour(15)
+                    ->by("hour:{$actor}"),
+
+                Limit::perDay(20)
+                    ->by("day:{$actor}"),
+            ];
+        });
     }
 }


### PR DESCRIPTION
Move responsibilities out of the bloated AppServiceProvider into their proper homes:

- **Passport config** (scopes, tokens, expiration, auth view) → `PassportServiceProvider`
- **Rate limiters** (5 definitions) → `RouteServiceProvider::configureRateLimiting()`
- **Removed** `Schema::defaultStringLength(191)` — unnecessary with utf8mb4 on MySQL 5.7.7+
- **Removed** `Paginator::useBootstrap()` — frontend will be replaced

AppServiceProvider now contains only: observers, Horizon/Pulse auth gates, URL configuration, and validator settings.

**Merge order:** Merge after #6816 (deprecated helpers) to avoid conflicts.