### PR TITLE
refactor: replace deprecated str_random() with Str::random()

### DIFF
--- a/app/Console/Commands/FixUsernames.php
+++ b/app/Console/Commands/FixUsernames.php
@@ -7,6 +7,7 @@ use App\User;
 use App\Util\Lexer\RestrictedNames;
 use DB;
 use Illuminate\Console\Command;
+use Illuminate\Support\Str;
 
 class FixUsernames extends Command
 {
@@ -86,14 +87,14 @@ class FixUsernames extends Command
 
                 switch ($opt) {
                     case $opts[0]:
-                        $new = 'user_'.str_random(6);
+                        $new = 'user_'.Str::random(6);
                         $this->info('New username: '.$new);
                         break;
 
                     case $opts[1]:
                         $new = htmlspecialchars($old, ENT_QUOTES, 'UTF-8');
                         if (strlen($new) < 6) {
-                            $new = $new.'_'.str_random(4);
+                            $new = $new.'_'.Str::random(4);
                         }
                         $this->info('New username: '.$new);
                         break;
@@ -108,7 +109,7 @@ class FixUsernames extends Command
                         break;
 
                     default:
-                        $new = 'user_'.str_random(6);
+                        $new = 'user_'.Str::random(6);
                         break;
                 }
 

--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -374,7 +374,7 @@ class AdminController extends Controller
         $changedFields = [];
         $slug = Str::slug($request->input('title'));
         if (Newsroom::whereSlug($slug)->exists()) {
-            $slug = $slug.'-'.str_random(4);
+            $slug = $slug.'-'.Str::random(4);
         }
         $news = Newsroom::findOrFail($id);
         $fields = [
@@ -441,7 +441,7 @@ class AdminController extends Controller
         $changedFields = [];
         $slug = Str::slug($request->input('title'));
         if (Newsroom::whereSlug($slug)->exists()) {
-            $slug = $slug.'-'.str_random(4);
+            $slug = $slug.'-'.Str::random(4);
         }
         $news = new Newsroom;
         $fields = [

--- a/app/Http/Controllers/Api/ApiV1Controller.php
+++ b/app/Http/Controllers/Api/ApiV1Controller.php
@@ -322,7 +322,7 @@ class ApiV1Controller extends Controller
                 $currentAvatar = storage_path('app/'.$av->media_path);
                 $file = $request->file('avatar');
                 $path = "public/avatars/{$profile->id}";
-                $name = strtolower(str_random(6)).'.'.$file->guessExtension();
+                $name = strtolower(Str::random(6)).'.'.$file->guessExtension();
                 $request->file('avatar')->storePubliclyAs($path, $name);
                 $av->media_path = "{$path}/{$name}";
                 $av->save();

--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -13,6 +13,7 @@ use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Validator;
+use Illuminate\Support\Str;
 use Purify;
 
 class RegisterController extends Controller
@@ -50,7 +51,7 @@ class RegisterController extends Controller
     public function getRegisterToken()
     {
         return \Cache::remember('pf:register:rt', 900, function () {
-            return str_random(40);
+            return Str::random(40);
         });
     }
 

--- a/app/Http/Controllers/AvatarController.php
+++ b/app/Http/Controllers/AvatarController.php
@@ -7,6 +7,7 @@ use App\Jobs\AvatarPipeline\AvatarOptimize;
 use Auth;
 use Cache;
 use Illuminate\Http\Request;
+use Illuminate\Support\Str;
 
 class AvatarController extends Controller
 {
@@ -56,7 +57,7 @@ class AvatarController extends Controller
         $path = $this->buildPath($id);
         $dir = storage_path('app/'.$path);
         $this->checkDir($dir);
-        $name = str_random(20).'_avatar.'.$file->guessExtension();
+        $name = Str::random(20).'_avatar.'.$file->guessExtension();
         $res = ['root' => 'storage/app/'.$path, 'name' => $name, 'storage' => $path];
 
         return $res;

--- a/app/Http/Controllers/GroupController.php
+++ b/app/Http/Controllers/GroupController.php
@@ -20,6 +20,7 @@ use App\Services\StatusService;
 use App\Status;
 use App\User;
 use Illuminate\Http\Request;
+use Illuminate\Support\Str;
 use Storage;
 
 class GroupController extends GroupFederationController
@@ -198,7 +199,7 @@ class GroupController extends GroupFederationController
                     Storage::delete($metadata['avatar']['path']);
                 }
 
-                $fileName = 'avatar_'.strtolower(str_random($len)).'.'.$avatar->extension();
+                $fileName = 'avatar_'.strtolower(Str::random($len)).'.'.$avatar->extension();
                 $path = $avatar->storePubliclyAs('public/g/'.$group->id.'/meta', $fileName);
                 $url = url(Storage::url($path));
                 $metadata['avatar'] = [
@@ -220,7 +221,7 @@ class GroupController extends GroupFederationController
                     Storage::delete($metadata['header']['path']);
                 }
 
-                $fileName = 'header_'.strtolower(str_random($len)).'.'.$header->extension();
+                $fileName = 'header_'.strtolower(Str::random($len)).'.'.$header->extension();
                 $path = $header->storePubliclyAs('public/g/'.$group->id.'/meta', $fileName);
                 $url = url(Storage::url($path));
                 $metadata['header'] = [

--- a/app/Http/Controllers/ParentalControlsController.php
+++ b/app/Http/Controllers/ParentalControlsController.php
@@ -12,6 +12,7 @@ use App\User;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Str;
 
 class ParentalControlsController extends Controller
 {
@@ -94,7 +95,7 @@ class ParentalControlsController extends Controller
         $pc = new ParentalControls;
         $pc->parent_id = $request->user()->id;
         $pc->email = $request->input('email');
-        $pc->verify_code = str_random(32);
+        $pc->verify_code = Str::random(32);
         $pc->permissions = $state;
         $pc->save();
 

--- a/app/Http/Controllers/Settings/SecuritySettings.php
+++ b/app/Http/Controllers/Settings/SecuritySettings.php
@@ -11,6 +11,7 @@ use BaconQrCode\Renderer\RendererStyle\RendererStyle;
 use BaconQrCode\Writer;
 use Carbon\Carbon;
 use Illuminate\Http\Request;
+use Illuminate\Support\Str;
 use PragmaRX\Google2FA\Google2FA;
 
 trait SecuritySettings
@@ -67,7 +68,7 @@ trait SecuritySettings
     {
         $keys = [];
         for ($i = 0; $i < 11; $i++) {
-            $key = str_random(24);
+            $key = Str::random(24);
             $keys[] = $key;
         }
 

--- a/app/Http/Controllers/Stories/StoryApiV1Controller.php
+++ b/app/Http/Controllers/Stories/StoryApiV1Controller.php
@@ -41,7 +41,7 @@ class StoryApiV1Controller extends Controller
         $pid = $request->user()->profile_id;
 
         if (config('database.default') == 'pgsql') {
-            $s = Cache::remember(self::RECENT_KEY . $pid, self::RECENT_TTL, function () use ($pid) {
+            $s = Cache::remember(self::RECENT_KEY.$pid, self::RECENT_TTL, function () use ($pid) {
                 return Story::select('stories.*', 'followers.following_id')
                     ->leftJoin('followers', 'followers.following_id', 'stories.profile_id')
                     ->where('followers.profile_id', $pid)
@@ -59,7 +59,7 @@ class StoryApiV1Controller extends Controller
                     ->unique('profile_id');
             });
         } else {
-            $s = Cache::remember(self::RECENT_KEY . $pid, self::RECENT_TTL, function () use ($pid) {
+            $s = Cache::remember(self::RECENT_KEY.$pid, self::RECENT_TTL, function () use ($pid) {
                 return Story::select('stories.*', 'followers.following_id')
                     ->leftJoin('followers', 'followers.following_id', 'stories.profile_id')
                     ->where('followers.profile_id', $pid)
@@ -93,7 +93,7 @@ class StoryApiV1Controller extends Controller
                     url("/i/rs/{$profile['id']}");
 
                 return [
-                    'id' => 'pfs:' . $profile['id'],
+                    'id' => 'pfs:'.$profile['id'],
                     'user' => [
                         'id' => (string) $profile['id'],
                         'username' => $profile['username'],
@@ -154,7 +154,7 @@ class StoryApiV1Controller extends Controller
         $pid = $request->user()->profile_id;
 
         if (config('database.default') == 'pgsql') {
-            $s = Cache::remember(self::RECENT_KEY . $pid, self::RECENT_TTL, function () use ($pid) {
+            $s = Cache::remember(self::RECENT_KEY.$pid, self::RECENT_TTL, function () use ($pid) {
                 return Story::select('stories.*', 'followers.following_id')
                     ->leftJoin('followers', 'followers.following_id', 'stories.profile_id')
                     ->where('followers.profile_id', $pid)
@@ -172,7 +172,7 @@ class StoryApiV1Controller extends Controller
                     ->unique('profile_id');
             });
         } else {
-            $s = Cache::remember(self::RECENT_KEY . $pid, self::RECENT_TTL, function () use ($pid) {
+            $s = Cache::remember(self::RECENT_KEY.$pid, self::RECENT_TTL, function () use ($pid) {
                 return Story::select('stories.*', 'followers.following_id')
                     ->leftJoin('followers', 'followers.following_id', 'stories.profile_id')
                     ->where('followers.profile_id', $pid)
@@ -206,7 +206,7 @@ class StoryApiV1Controller extends Controller
                     url("/i/rs/{$profile['id']}");
 
                 return [
-                    'id' => 'pfs:' . $profile['id'],
+                    'id' => 'pfs:'.$profile['id'],
                     'user' => [
                         'id' => (string) $profile['id'],
                         'username' => $profile['username'],
@@ -269,7 +269,7 @@ class StoryApiV1Controller extends Controller
             'file' => [
                 'required',
                 'mimetypes:image/jpeg,image/jpg,image/png,video/mp4',
-                'max:' . config_cache('pixelfed.max_photo_size'),
+                'max:'.config_cache('pixelfed.max_photo_size'),
             ],
             'duration' => 'sometimes|integer|min:0|max:30',
         ]);
@@ -296,7 +296,7 @@ class StoryApiV1Controller extends Controller
         $story->path = $path;
         $story->local = true;
         $story->size = $photo->getSize();
-        $story->bearcap_token = str_random(64);
+        $story->bearcap_token = Str::random(64);
         $story->expires_at = now()->addMinutes(1440);
         $story->save();
 
@@ -306,7 +306,7 @@ class StoryApiV1Controller extends Controller
             'code' => 200,
             'msg' => 'Successfully added',
             'media_id' => (string) $story->id,
-            'media_url' => url(Storage::url($url)) . '?v=' . time(),
+            'media_url' => url(Storage::url($url)).'?v='.time(),
             'media_type' => $story->type,
         ];
 
@@ -420,7 +420,7 @@ class StoryApiV1Controller extends Controller
         if ($count >= Story::MAX_PER_DAY) {
             return response()->json([
                 'code' => 418,
-                'error' => 'You’ve reached your daily limit of ' . Story::MAX_PER_DAY . ' Stories.',
+                'error' => 'You’ve reached your daily limit of '.Story::MAX_PER_DAY.' Stories.',
             ], 418, [], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
         }
 
@@ -578,7 +578,7 @@ class StoryApiV1Controller extends Controller
 
         $rows = DB::table('profiles as p')
             ->select('p.id', 'p.username')
-            ->where('p.username', 'like', $q . '%')
+            ->where('p.username', 'like', $q.'%')
             ->whereExists(function ($sub) use ($pid) {
                 $sub->select(DB::raw(1))
                     ->from('followers as f')
@@ -658,7 +658,7 @@ class StoryApiV1Controller extends Controller
             if ($story->local == false) {
                 StoryViewDeliver::dispatch($story, $authed)->onQueue('story');
             }
-            Cache::forget('stories:recent:by_id:' . $pid);
+            Cache::forget('stories:recent:by_id:'.$pid);
             StoryService::addSeen($pid, $story->id);
         }
 
@@ -726,7 +726,7 @@ class StoryApiV1Controller extends Controller
             $n->profile_id = $dm->to_id;
             $n->actor_id = $dm->from_id;
             $n->item_id = $dm->id;
-            $n->item_type = \App\DirectMessage::class;
+            $n->item_type = DirectMessage::class;
             $n->action = 'story:comment';
             $n->save();
         } else {
@@ -753,7 +753,7 @@ class StoryApiV1Controller extends Controller
         }
 
         $storagePath = MediaPathService::story($user->profile);
-        $path = $photo->storePubliclyAs($storagePath, Str::random(random_int(2, 12)) . '_' . Str::random(random_int(32, 35)) . '_' . Str::random(random_int(1, 14)) . '.' . $photo->extension());
+        $path = $photo->storePubliclyAs($storagePath, Str::random(random_int(2, 12)).'_'.Str::random(random_int(32, 35)).'_'.Str::random(random_int(1, 14)).'.'.$photo->extension());
 
         return $path;
     }

--- a/app/Http/Controllers/StoryComposeController.php
+++ b/app/Http/Controllers/StoryComposeController.php
@@ -73,7 +73,7 @@ class StoryComposeController extends Controller
         $story->path = $path;
         $story->local = true;
         $story->size = $photo->getSize();
-        $story->bearcap_token = str_random(64);
+        $story->bearcap_token = Str::random(64);
         $story->expires_at = now()->addMinutes(1440);
         $story->save();
 
@@ -460,7 +460,7 @@ class StoryComposeController extends Controller
         abort_if(! FollowerService::follows($pid, $story->profile_id), 422, 'Cannot report a story from an account you do not follow');
 
         if (Report::whereProfileId($pid)
-            ->whereObjectType(\App\Story::class)
+            ->whereObjectType(Story::class)
             ->whereObjectId($story->id)
             ->exists()
         ) {
@@ -474,7 +474,7 @@ class StoryComposeController extends Controller
         $report->profile_id = $pid;
         $report->user_id = $request->user()->id;
         $report->object_id = $story->id;
-        $report->object_type = \App\Story::class;
+        $report->object_type = Story::class;
         $report->reported_profile_id = $story->profile_id;
         $report->type = $type;
         $report->message = null;
@@ -550,7 +550,7 @@ class StoryComposeController extends Controller
             $n->profile_id = $dm->to_id;
             $n->actor_id = $dm->from_id;
             $n->item_id = $dm->id;
-            $n->item_type = \App\DirectMessage::class;
+            $n->item_type = DirectMessage::class;
             $n->action = 'story:react';
             $n->save();
         } else {
@@ -627,7 +627,7 @@ class StoryComposeController extends Controller
             $n->profile_id = $dm->to_id;
             $n->actor_id = $dm->from_id;
             $n->item_id = $dm->id;
-            $n->item_type = \App\DirectMessage::class;
+            $n->item_type = DirectMessage::class;
             $n->action = 'story:comment';
             $n->save();
         } else {

--- a/app/Http/Controllers/UserInviteController.php
+++ b/app/Http/Controllers/UserInviteController.php
@@ -9,6 +9,7 @@ use App\UserInvite;
 use Auth;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Str;
 
 class UserInviteController extends Controller
 {
@@ -55,8 +56,8 @@ class UserInviteController extends Controller
         $invite->profile_id = Auth::user()->profile_id;
         $invite->email = $email;
         $invite->message = $request->input('message');
-        $invite->key = str_random(random_int(6, 9)).'_'.str_random(random_int(14, 20)).'_'.str_random(random_int(32, 64));
-        $invite->token = str_random(random_int(32, 69));
+        $invite->key = Str::random(random_int(6, 9)).'_'.Str::random(random_int(14, 20)).'_'.Str::random(random_int(32, 64));
+        $invite->token = Str::random(random_int(32, 69));
         $invite->save();
 
         // Mail::to($email)->send(new UserInviteMail($invite));

--- a/app/Jobs/RemoteFollowPipeline/RemoteFollowImportRecent.php
+++ b/app/Jobs/RemoteFollowPipeline/RemoteFollowImportRecent.php
@@ -16,6 +16,7 @@ use Illuminate\Http\File;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Str;
 use Log;
 use Storage;
 
@@ -222,7 +223,7 @@ class RemoteFollowImportRecent implements ShouldQueue
             $info = pathinfo($url);
             $url = str_replace(' ', '%20', $url);
             $img = file_get_contents($url);
-            $file = '/tmp/'.str_random(64);
+            $file = '/tmp/'.Str::random(64);
             file_put_contents($file, $img);
             $path = Storage::putFile($storagePath, new File($file), 'public');
 

--- a/app/Models/CuratedRegister.php
+++ b/app/Models/CuratedRegister.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Str;
 
 class CuratedRegister extends Model
 {
@@ -60,7 +61,7 @@ class CuratedRegister extends Model
 
     public function emailReplyUrl()
     {
-        return url('/auth/sign_up/concierge?sid='.$this->id.'&code='.$this->verify_code.'&sc='.str_random(8));
+        return url('/auth/sign_up/concierge?sid='.$this->id.'&code='.$this->verify_code.'&sc='.Str::random(8));
     }
 
     public function adminReviewUrl()


### PR DESCRIPTION
Replace all 18 remaining `str_random()` calls with `Str::random()` across 13 files. This was missed in the initial laravel/helpers removal.