### PR TITLE
refactor: replace str_limit() with Str::limit()

### DIFF
--- a/app/Jobs/RemoteFollowPipeline/RemoteFollowImportRecent.php
+++ b/app/Jobs/RemoteFollowPipeline/RemoteFollowImportRecent.php
@@ -170,7 +170,7 @@ class RemoteFollowImportRecent implements ShouldQueue
         $profile = $this->profile;
         $supported = $this->supported;
         $attachments = $activity['object']['attachment'];
-        $caption = str_limit($activity['object']['content'], 125);
+        $caption = Str::limit($activity['object']['content'], 125);
 
         if (Status::whereUrl($activity['id'])->count() !== 0) {
             return true;

--- a/app/Listeners/AuthLogin.php
+++ b/app/Listeners/AuthLogin.php
@@ -7,6 +7,7 @@ use App\Profile;
 use App\UserDevice;
 use App\UserSetting;
 use DB;
+use Illuminate\Support\Str;
 
 class AuthLogin
 {
@@ -117,7 +118,7 @@ class AuthLogin
             return UserDevice::firstOrCreate([
                 'user_id' => $user->id,
                 'ip' => request()->ip(),
-                'user_agent' => str_limit(request()->userAgent(), 180),
+                'user_agent' => Str::limit(request()->userAgent(), 180),
             ]);
         });
     }

--- a/app/Services/GroupService.php
+++ b/app/Services/GroupService.php
@@ -11,6 +11,7 @@ use App\Models\GroupPost;
 use App\Profile;
 use App\Util\ActivityPub\Helpers;
 use Cache;
+use Illuminate\Support\Str;
 use Purify;
 
 class GroupService
@@ -40,7 +41,7 @@ class GroupService
                     'id' => (string) $group->id,
                     'name' => $group->name,
                     'description' => $group->description,
-                    'short_description' => str_limit(strip_tags($group->description), 120),
+                    'short_description' => Str::limit(strip_tags($group->description), 120),
                     'category' => self::categoryById($group->category_id),
                     'local' => (bool) $group->local,
                     'url' => $group->url(),


### PR DESCRIPTION
Replace the last 3 deprecated `str_limit()` calls with `Str::limit()`.

No deprecated `str_*` helper functions remain in the codebase after this.