### PR TITLE
fix: clear bootstrap cache during Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,9 @@ RUN chown -R www-data:www-data /var/www/html \
     && find /var/www/html -type d -exec chmod 755 {} \; \
     && chmod -R ug+rwx /var/www/html/storage /var/www/html/bootstrap/cache
 
-RUN composer install --no-ansi --no-interaction --optimize-autoloader
+RUN composer install --no-ansi --no-interaction --optimize-autoloader \
+    && php artisan optimize:clear \
+    && php artisan package:discover --ansi
 
 USER www-data
 


### PR DESCRIPTION
Adds `optimize:clear` and `package:discover` after `composer install` in the Dockerfile to ensure no stale service provider references persist from previous builds or mounted volumes.