### PR TITLE
fix: replace deprecated str_ helpers in Blade templates and tests

### DIFF
--- a/resources/views/admin/apps/home.blade.php
+++ b/resources/views/admin/apps/home.blade.php
@@ -39,7 +39,7 @@
         </td>
         <td class="font-weight-bold"><a href="{{$app->user->url()}}">{{$app->user->username}}</a></td>
         <td class="font-weight-bold">{{$app->name}}</td>
-        <td class="font-weight-bold">{{str_limit($app->redirect, 30)}}</td>
+        <td class="font-weight-bold">{{Str::limit($app->redirect, 30)}}</td>
         <td class="font-weight-bold">{{$app->revoked ? 'true' : 'false'}}</td>
         <td class="font-weight-bold">{{now()->parse($app->created_at)->diffForHumans()}}</td>
       </tr>

--- a/resources/views/admin/curated-register/index.blade.php
+++ b/resources/views/admin/curated-register/index.blade.php
@@ -81,11 +81,11 @@
                         </td>
                         @endif
                         <td class="align-middle">
-                            {{ str_limit($record->reason_to_join, 100) }}
+                            {{ Str::limit($record->reason_to_join, 100) }}
                         </td>
                         <td class="align-middle">
                             <p class="mb-0">
-                                {{ str_limit(\Illuminate\Support\Str::mask($record->email, '*', 5, 10), 10) }}
+                                {{ Str::limit(\Illuminate\Support\Str::mask($record->email, '*', 5, 10), 10) }}
                             </p>
                         </td>
                         <td class="align-middle">{{ $record->created_at->diffForHumans() }}</td>

--- a/resources/views/admin/curated-register/templates.blade.php
+++ b/resources/views/admin/curated-register/templates.blade.php
@@ -65,7 +65,7 @@
                                     {{ $template->name }}
                                 </td>
                                 <td class="align-middle">
-                                    {{ str_limit($template->content, 80) }}
+                                    {{ Str::limit($template->content, 80) }}
                                 </td>
                                 <td class="align-middle">
                                     {{ $template->is_active ? '✅' : '❌' }}

--- a/resources/views/admin/messages/home.blade.php
+++ b/resources/views/admin/messages/home.blade.php
@@ -65,7 +65,7 @@
                       </a>
                     </td>
                     <td class="font-weight-bold"><a href="{{$msg->user->url()}}">{{$msg->user->username}}</a></td>
-                    <td class="font-weight-bold">{{str_limit($msg->message, 40)}}</td>
+                    <td class="font-weight-bold">{{Str::limit($msg->message, 40)}}</td>
                     <td class="font-weight-bold">{{$msg->created_at->diffForHumans()}}</td>
                   </tr>
                   @endforeach

--- a/resources/views/admin/newsroom/home.blade.php
+++ b/resources/views/admin/newsroom/home.blade.php
@@ -47,8 +47,8 @@
                             </td>
                             <td class="font-weight-bold">
                                 <div>
-                                  <p class="mb-0 font-weight-bold">{{str_limit($news->title, 50)}}</p>
-                                  {{-- <p class="mb-0 small">{{str_limit($news->summary, 80)}}</p> --}}
+                                  <p class="mb-0 font-weight-bold">{{Str::limit($news->title, 50)}}</p>
+                                  {{-- <p class="mb-0 small">{{Str::limit($news->summary, 80)}}</p> --}}
                                 </div>
                             </td>
                             <td class="text-muted">

--- a/resources/views/admin/users/home.blade.php
+++ b/resources/views/admin/users/home.blade.php
@@ -211,7 +211,7 @@
 
 
                                             <small class="text-muted">
-                                                {{ str_limit(strip_tags($user->profile->bio))}}
+                                                {{ Str::limit(strip_tags($user->profile->bio))}}
                                             </small>
                                             <small class="text-warning">
                                                 {{ parse_url($user->profile->website, PHP_URL_HOST) }}

--- a/resources/views/auth/curated-register/partials/step-1.blade.php
+++ b/resources/views/auth/curated-register/partials/step-1.blade.php
@@ -1,5 +1,5 @@
 @php
-$id = str_random(14);
+$id = Str::random(14);
 @endphp
 <h1 class="text-center">Before you continue.</h1>
 @if(config_cache('app.rules') && strlen(config_cache('app.rules')) > 5)

--- a/resources/views/components/collapse.blade.php
+++ b/resources/views/components/collapse.blade.php
@@ -1,5 +1,5 @@
 @php
-$cid = 'col' . str_random(6);
+$cid = 'col' . Str::random(6);
 @endphp
 <p>
   <a class="text-dark font-weight-bold" data-toggle="collapse" href="#{{$cid}}" role="button" aria-expanded="false" aria-controls="{{$cid}}">

--- a/resources/views/emails/contact/admin-response.blade.php
+++ b/resources/views/emails/contact/admin-response.blade.php
@@ -4,7 +4,7 @@ Hello **&commat;{{$contact->user->username}}**,
 You contacted the admin team of {{config('pixelfed.domain.app')}} with the following inquiry:
 
 <x-mail::panel>
-<i>{{str_limit($contact->message, 80)}}</i>
+<i>{{Str::limit($contact->message, 80)}}</i>
 </x-mail::panel>
 
 <x-mail::button :url="$url" color="primary">

--- a/resources/views/emails/curated-register/admin_notify.blade.php
+++ b/resources/views/emails/curated-register/admin_notify.blade.php
@@ -19,7 +19,7 @@ Email: <strong>{{ $verify->email }}</strong>
 <hr>
 
 <small><strong>*The user provided the following reason to join:*</strong></small>
-<p style="font-size:9pt;">{!!str_limit(nl2br($verify->reason_to_join), 300)!!}</p>
+<p style="font-size:9pt;">{!!Str::limit(nl2br($verify->reason_to_join), 300)!!}</p>
 </x-mail::panel>
 
 <x-mail::button :url="$verify->adminReviewUrl()" color="success">

--- a/resources/views/settings/parental-controls/checkbox.blade.php
+++ b/resources/views/settings/parental-controls/checkbox.blade.php
@@ -1,5 +1,5 @@
 @php
-$id = str_random(6) . '_' . str_slug($name);
+$id = Str::random(6) . '_' . Str::slug($name);
 $defaultChecked = isset($checked) && $checked ? 'checked=""' : '';
 @endphp<div class="custom-control custom-checkbox">
                 <input type="checkbox" class="custom-control-input" id="{{$id}}" name="{{$name}}" {!!$defaultChecked!!}>

--- a/tests/Feature/RemoteOidcTest.php
+++ b/tests/Feature/RemoteOidcTest.php
@@ -6,6 +6,7 @@ use App\Models\UserOidcMapping;
 use App\Services\UserOidcService;
 use App\User;
 use Auth;
+use Illuminate\Support\Str;
 use League\OAuth2\Client\Provider\GenericResourceOwner;
 use League\OAuth2\Client\Token\AccessToken;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
@@ -42,7 +43,7 @@ class RemoteOidcTest extends TestCase
         config(['remote-auth.oidc.enabled' => true]);
 
         $oauthData = [
-            'sub' => str_random(10),
+            'sub' => Str::random(10),
             'preferred_username' => fake()->unique()->userName,
             'email' => fake()->unique()->freeEmail,
         ];
@@ -83,7 +84,7 @@ class RemoteOidcTest extends TestCase
         config(['remote-auth.oidc.enabled' => true]);
 
         $oauthData = [
-            'sub' => str_random(10),
+            'sub' => Str::random(10),
             'preferred_username' => $user->username,
             'email' => $user->email,
         ];


### PR DESCRIPTION
Replace remaining `str_random()`, `str_limit()`, and `str_slug()` calls in Blade templates and test files with `Str::random()`, `Str::limit()`, and `Str::slug()`.

These will throw runtime errors since `laravel/helpers` was removed in #6816.