### PR TITLE
refactor: replace deprecated laravel/helpers with native alternatives

### DIFF
--- a/app/Console/Commands/FixHashtags.php
+++ b/app/Console/Commands/FixHashtags.php
@@ -5,6 +5,7 @@ namespace App\Console\Commands;
 use App\Hashtag;
 use App\StatusHashtag;
 use Illuminate\Console\Command;
+use Illuminate\Support\Str;
 
 class FixHashtags extends Command
 {
@@ -55,7 +56,7 @@ class FixHashtags extends Command
         $this->info('Found '.Hashtag::count().' total hashtags!');
         $count = 0;
         foreach (Hashtag::lazyById(100, 'id') as $tag) {
-            $slug = str_slug($tag->name, '-', false);
+            $slug = Str::slug($tag->name, '-', false);
             if ($slug === $tag->slug) {
                 continue;
             }
@@ -63,7 +64,7 @@ class FixHashtags extends Command
             if (! $count) {
                 continue;
             }
-            $this->info($count.':'.$tag->slug.' : '.str_slug($tag->name, '-', false));
+            $this->info($count.':'.$tag->slug.' : '.Str::slug($tag->name, '-', false));
 
         }
 

--- a/app/Console/Commands/FixUsernames.php
+++ b/app/Console/Commands/FixUsernames.php
@@ -7,6 +7,7 @@ use App\User;
 use App\Util\Lexer\RestrictedNames;
 use DB;
 use Illuminate\Console\Command;
+use Illuminate\Support\Str;
 
 class FixUsernames extends Command
 {
@@ -86,14 +87,14 @@ class FixUsernames extends Command
 
                 switch ($opt) {
                     case $opts[0]:
-                        $new = 'user_'.str_random(6);
+                        $new = 'user_'.Str::random(6);
                         $this->info('New username: '.$new);
                         break;
 
                     case $opts[1]:
                         $new = htmlspecialchars($old, ENT_QUOTES, 'UTF-8');
                         if (strlen($new) < 6) {
-                            $new = $new.'_'.str_random(4);
+                            $new = $new.'_'.Str::random(4);
                         }
                         $this->info('New username: '.$new);
                         break;
@@ -108,7 +109,7 @@ class FixUsernames extends Command
                         break;
 
                     default:
-                        $new = 'user_'.str_random(6);
+                        $new = 'user_'.Str::random(6);
                         break;
                 }
 

--- a/app/Http/Controllers/AccountController.php
+++ b/app/Http/Controllers/AccountController.php
@@ -23,6 +23,7 @@ use Auth;
 use Cache;
 use Carbon\Carbon;
 use Illuminate\Http\Request;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use League\Fractal;
 use League\Fractal\Serializer\ArraySerializer;
@@ -569,7 +570,7 @@ class AccountController extends Controller
             $codes = json_decode($backupCodes, true);
             foreach ($codes as $c) {
                 if (hash_equals($c, $code)) {
-                    $codes = array_flatten(array_diff($codes, [$code]));
+                    $codes = Arr::flatten(array_diff($codes, [$code]));
                     $user->{'2fa_backup_codes'} = json_encode($codes);
                     $user->save();
                     $request->session()->push('2fa.session.active', true);
@@ -598,7 +599,7 @@ class AccountController extends Controller
         $limit = $request->input('limit') ?? 40;
 
         $mutes = UserFilter::whereUserId($user->profile_id)
-            ->whereFilterableType(\App\Profile::class)
+            ->whereFilterableType(Profile::class)
             ->whereFilterType('mute')
             ->simplePaginate($limit)
             ->pluck('filterable_id');
@@ -631,7 +632,7 @@ class AccountController extends Controller
 
         $blocked = UserFilter::select('filterable_id', 'filterable_type', 'filter_type', 'user_id')
             ->whereUserId($user->profile_id)
-            ->whereFilterableType(\App\Profile::class)
+            ->whereFilterableType(Profile::class)
             ->whereFilterType('block')
             ->simplePaginate($limit)
             ->pluck('filterable_id');

--- a/app/Http/Controllers/Admin/AdminDiscoverController.php
+++ b/app/Http/Controllers/Admin/AdminDiscoverController.php
@@ -7,6 +7,7 @@ use App\DiscoverCategoryHashtag;
 use App\Hashtag;
 use App\Media;
 use Illuminate\Http\Request;
+use Illuminate\Support\Str;
 
 trait AdminDiscoverController
 {
@@ -31,7 +32,7 @@ trait AdminDiscoverController
         ]);
 
         $name = $request->input('name');
-        $slug = str_slug($name);
+        $slug = Str::slug($name);
         $active = $request->input('active');
         $media = (int) $request->input('media');
 
@@ -62,7 +63,7 @@ trait AdminDiscoverController
             'hashtags' => 'nullable|string',
         ]);
         $name = $request->input('name');
-        $slug = str_slug($name);
+        $slug = Str::slug($name);
         $active = $request->input('active');
         $media = (int) $request->input('media');
         $media = Media::findOrFail($media);

--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -30,6 +30,7 @@ use App\User;
 use Cache;
 use DB;
 use Illuminate\Http\Request;
+use Illuminate\Support\Str;
 use Illuminate\Validation\Rule;
 use Mail;
 use Storage;
@@ -371,9 +372,9 @@ class AdminController extends Controller
         ]);
         $changed = false;
         $changedFields = [];
-        $slug = str_slug($request->input('title'));
+        $slug = Str::slug($request->input('title'));
         if (Newsroom::whereSlug($slug)->exists()) {
-            $slug = $slug.'-'.str_random(4);
+            $slug = $slug.'-'.Str::random(4);
         }
         $news = Newsroom::findOrFail($id);
         $fields = [
@@ -438,9 +439,9 @@ class AdminController extends Controller
         ]);
         $changed = false;
         $changedFields = [];
-        $slug = str_slug($request->input('title'));
+        $slug = Str::slug($request->input('title'));
         if (Newsroom::whereSlug($slug)->exists()) {
-            $slug = $slug.'-'.str_random(4);
+            $slug = $slug.'-'.Str::random(4);
         }
         $news = new Newsroom;
         $fields = [
@@ -510,7 +511,7 @@ class AdminController extends Controller
         $key = 'exception_report:';
         $decrypted = decrypt($request->input('payload'));
 
-        if (! starts_with($decrypted, $key)) {
+        if (! str_starts_with($decrypted, $key)) {
             abort(403, 'Can only decrypt error diagnostics');
         }
 

--- a/app/Http/Controllers/AdminInviteController.php
+++ b/app/Http/Controllers/AdminInviteController.php
@@ -70,7 +70,7 @@ class AdminInviteController extends Controller
                 $underscore = substr_count($value, '_');
                 $period = substr_count($value, '.');
 
-                if (ends_with($value, ['.php', '.js', '.css'])) {
+                if (str_ends_with($value, ['.php', '.js', '.css'])) {
                     return $fail('Username is invalid.');
                 }
 
@@ -158,7 +158,7 @@ class AdminInviteController extends Controller
                     $underscore = substr_count($value, '_');
                     $period = substr_count($value, '.');
 
-                    if (ends_with($value, ['.php', '.js', '.css'])) {
+                    if (str_ends_with($value, ['.php', '.js', '.css'])) {
                         return $fail('Username is invalid.');
                     }
 

--- a/app/Http/Controllers/Api/ApiV1Controller.php
+++ b/app/Http/Controllers/Api/ApiV1Controller.php
@@ -322,7 +322,7 @@ class ApiV1Controller extends Controller
                 $currentAvatar = storage_path('app/'.$av->media_path);
                 $file = $request->file('avatar');
                 $path = "public/avatars/{$profile->id}";
-                $name = strtolower(str_random(6)).'.'.$file->guessExtension();
+                $name = strtolower(Str::random(6)).'.'.$file->guessExtension();
                 $request->file('avatar')->storePubliclyAs($path, $name);
                 $av->media_path = "{$path}/{$name}";
                 $av->save();

--- a/app/Http/Controllers/Api/ApiV1Dot1Controller.php
+++ b/app/Http/Controllers/Api/ApiV1Dot1Controller.php
@@ -34,11 +34,13 @@ use App\Services\PublicTimelineService;
 use App\Services\PushNotificationService;
 use App\Services\SanitizeService;
 use App\Services\StatusService;
+use App\Services\UserAgentService;
 use App\Services\UserRoleService;
 use App\Services\UserStorageService;
 use App\Status;
 use App\StatusArchived;
 use App\Story;
+use App\Transformer\Api\AccountTransformer;
 use App\User;
 use App\UserSetting;
 use App\Util\Lexer\RestrictedNames;
@@ -48,7 +50,6 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\Str;
-use App\Services\UserAgentService;
 use League\Fractal;
 use League\Fractal\Serializer\ArraySerializer;
 use Mail;
@@ -126,10 +127,10 @@ class ApiV1Dot1Controller extends Controller
                 if (! $object) {
                     return $this->error('Invalid object id', 400, ['error_code' => 'ERROR_INVALID_OBJECT_ID']);
                 }
-                $object_type = \App\Status::class;
+                $object_type = Status::class;
                 $exists = Report::whereUserId($user->id)
                     ->whereObjectId($object->id)
-                    ->whereObjectType(\App\Status::class)
+                    ->whereObjectType(Status::class)
                     ->count();
 
                 $rpid = $object->profile_id;
@@ -140,10 +141,10 @@ class ApiV1Dot1Controller extends Controller
                 if (! $object) {
                     return $this->error('Invalid object id', 400, ['error_code' => 'ERROR_INVALID_OBJECT_ID']);
                 }
-                $object_type = \App\Profile::class;
+                $object_type = Profile::class;
                 $exists = Report::whereUserId($user->id)
                     ->whereObjectId($object->id)
-                    ->whereObjectType(\App\Profile::class)
+                    ->whereObjectType(Profile::class)
                     ->count();
                 $rpid = $object->id;
                 break;
@@ -159,10 +160,10 @@ class ApiV1Dot1Controller extends Controller
                 if (! Follower::whereProfileId($user->profile_id)->whereFollowingId($object->profile_id)->exists()) {
                     return $this->error('Invalid object id', 400, ['error_code' => 'ERROR_INVALID_OBJECT_ID']);
                 }
-                $object_type = \App\Story::class;
+                $object_type = Story::class;
                 $exists = Report::whereUserId($user->id)
                     ->whereObjectId($object->id)
-                    ->whereObjectType(\App\Story::class)
+                    ->whereObjectType(Story::class)
                     ->count();
 
                 $rpid = $object->profile_id;
@@ -204,7 +205,7 @@ class ApiV1Dot1Controller extends Controller
     /**
      * DELETE /api/v1.1/accounts/avatar
      *
-     * @return \App\Transformer\Api\AccountTransformer
+     * @return AccountTransformer
      */
     public function deleteAvatar(Request $request)
     {
@@ -286,7 +287,7 @@ class ApiV1Dot1Controller extends Controller
     /**
      * POST /api/v1.1/accounts/change-password
      *
-     * @return \App\Transformer\Api\AccountTransformer
+     * @return AccountTransformer
      */
     public function accountChangePassword(Request $request)
     {
@@ -313,7 +314,7 @@ class ApiV1Dot1Controller extends Controller
         $log = new AccountLog;
         $log->user_id = $user->id;
         $log->item_id = $user->id;
-        $log->item_type = \App\User::class;
+        $log->item_type = User::class;
         $log->action = 'account.edit.password';
         $log->message = 'Password changed';
         $log->link = null;
@@ -548,7 +549,7 @@ class ApiV1Dot1Controller extends Controller
                     $underscore = substr_count($value, '_');
                     $period = substr_count($value, '.');
 
-                    if (ends_with($value, ['.php', '.js', '.css'])) {
+                    if (str_ends_with($value, ['.php', '.js', '.css'])) {
                         return $fail('Username is invalid.');
                     }
 

--- a/app/Http/Controllers/AppRegisterController.php
+++ b/app/Http/Controllers/AppRegisterController.php
@@ -305,7 +305,7 @@ class AppRegisterController extends Controller
                 $underscore = substr_count($value, '_');
                 $period = substr_count($value, '.');
 
-                if (ends_with($value, ['.php', '.js', '.css'])) {
+                if (str_ends_with($value, ['.php', '.js', '.css'])) {
                     return $fail('Username is invalid.');
                 }
 

--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -10,8 +10,10 @@ use App\Util\Lexer\RestrictedNames;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Foundation\Auth\RegistersUsers;
 use Illuminate\Http\Request;
+use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Validator;
+use Illuminate\Support\Str;
 use Purify;
 
 class RegisterController extends Controller
@@ -49,7 +51,7 @@ class RegisterController extends Controller
     public function getRegisterToken()
     {
         return \Cache::remember('pf:register:rt', 900, function () {
-            return str_random(40);
+            return Str::random(40);
         });
     }
 
@@ -76,7 +78,7 @@ class RegisterController extends Controller
                 $underscore = substr_count($value, '_');
                 $period = substr_count($value, '.');
 
-                if (ends_with($value, ['.php', '.js', '.css'])) {
+                if (str_ends_with($value, ['.php', '.js', '.css'])) {
                     return $fail('Username is invalid.');
                 }
 
@@ -151,7 +153,7 @@ class RegisterController extends Controller
      * Create a new user instance after a valid registration.
      *
      *
-     * @return \App\User
+     * @return User
      */
     public function create(array $data)
     {
@@ -172,7 +174,7 @@ class RegisterController extends Controller
     /**
      * Show the application registration form.
      *
-     * @return \Illuminate\Http\Response
+     * @return Response
      */
     public function showRegistrationForm()
     {
@@ -207,7 +209,7 @@ class RegisterController extends Controller
     /**
      * Handle a registration request for the application.
      *
-     * @return \Illuminate\Http\Response
+     * @return Response
      */
     public function register(Request $request)
     {

--- a/app/Http/Controllers/AvatarController.php
+++ b/app/Http/Controllers/AvatarController.php
@@ -7,6 +7,7 @@ use App\Jobs\AvatarPipeline\AvatarOptimize;
 use Auth;
 use Cache;
 use Illuminate\Http\Request;
+use Illuminate\Support\Str;
 
 class AvatarController extends Controller
 {
@@ -56,7 +57,7 @@ class AvatarController extends Controller
         $path = $this->buildPath($id);
         $dir = storage_path('app/'.$path);
         $this->checkDir($dir);
-        $name = str_random(20).'_avatar.'.$file->guessExtension();
+        $name = Str::random(20).'_avatar.'.$file->guessExtension();
         $res = ['root' => 'storage/app/'.$path, 'name' => $name, 'storage' => $path];
 
         return $res;

--- a/app/Http/Controllers/CuratedRegisterController.php
+++ b/app/Http/Controllers/CuratedRegisterController.php
@@ -357,7 +357,7 @@ class CuratedRegisterController extends Controller
                     $underscore = substr_count($value, '_');
                     $period = substr_count($value, '.');
 
-                    if (ends_with($value, ['.php', '.js', '.css'])) {
+                    if (str_ends_with($value, ['.php', '.js', '.css'])) {
                         return $fail('Username is invalid.');
                     }
 

--- a/app/Http/Controllers/DirectMessageController.php
+++ b/app/Http/Controllers/DirectMessageController.php
@@ -25,6 +25,7 @@ use App\UserFilter;
 use App\Util\ActivityPub\Helpers;
 use App\Util\Lexer\Autolink;
 use Illuminate\Http\Request;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 
 class DirectMessageController extends Controller
@@ -208,7 +209,7 @@ class DirectMessageController extends Controller
 
         $nf = UserFilter::whereUserId($recipient->id)
             ->whereFilterableId($profile->id)
-            ->whereFilterableType(\App\Profile::class)
+            ->whereFilterableType(Profile::class)
             ->whereFilterType('dm.mute')
             ->exists();
 
@@ -218,7 +219,7 @@ class DirectMessageController extends Controller
             $notification->actor_id = $profile->id;
             $notification->action = 'dm';
             $notification->item_id = $dm->id;
-            $notification->item_type = \App\DirectMessage::class;
+            $notification->item_type = DirectMessage::class;
             $notification->save();
         }
 
@@ -508,7 +509,7 @@ class DirectMessageController extends Controller
         $dm->to_id = $recipient->id;
         $dm->from_id = $profile->id;
         $dm->status_id = $status->id;
-        $dm->type = array_first(explode('/', $media->mime)) == 'video' ? 'video' : 'photo';
+        $dm->type = Arr::first(explode('/', $media->mime)) == 'video' ? 'video' : 'photo';
         $dm->is_hidden = $hidden;
         $dm->save();
 
@@ -574,7 +575,7 @@ class DirectMessageController extends Controller
             $q = mb_substr($q, 1);
         }
 
-        $blocked = UserFilter::whereFilterableType(\App\Profile::class)
+        $blocked = UserFilter::whereFilterableType(Profile::class)
             ->whereFilterType('block')
             ->whereFilterableId($request->user()->profile_id)
             ->pluck('user_id');
@@ -654,7 +655,7 @@ class DirectMessageController extends Controller
             [
                 'user_id' => $pid,
                 'filterable_id' => $fid,
-                'filterable_type' => \App\Profile::class,
+                'filterable_type' => Profile::class,
                 'filter_type' => 'dm.mute',
             ]
         );
@@ -676,7 +677,7 @@ class DirectMessageController extends Controller
 
         $f = UserFilter::whereUserId($pid)
             ->whereFilterableId($fid)
-            ->whereFilterableType(\App\Profile::class)
+            ->whereFilterableType(Profile::class)
             ->whereFilterType('dm.mute')
             ->firstOrFail();
 

--- a/app/Http/Controllers/GroupController.php
+++ b/app/Http/Controllers/GroupController.php
@@ -20,6 +20,7 @@ use App\Services\StatusService;
 use App\Status;
 use App\User;
 use Illuminate\Http\Request;
+use Illuminate\Support\Str;
 use Storage;
 
 class GroupController extends GroupFederationController
@@ -198,7 +199,7 @@ class GroupController extends GroupFederationController
                     Storage::delete($metadata['avatar']['path']);
                 }
 
-                $fileName = 'avatar_'.strtolower(str_random($len)).'.'.$avatar->extension();
+                $fileName = 'avatar_'.strtolower(Str::random($len)).'.'.$avatar->extension();
                 $path = $avatar->storePubliclyAs('public/g/'.$group->id.'/meta', $fileName);
                 $url = url(Storage::url($path));
                 $metadata['avatar'] = [
@@ -220,7 +221,7 @@ class GroupController extends GroupFederationController
                     Storage::delete($metadata['header']['path']);
                 }
 
-                $fileName = 'header_'.strtolower(str_random($len)).'.'.$header->extension();
+                $fileName = 'header_'.strtolower(Str::random($len)).'.'.$header->extension();
                 $path = $header->storePubliclyAs('public/g/'.$group->id.'/meta', $fileName);
                 $url = url(Storage::url($path));
                 $metadata['header'] = [

--- a/app/Http/Controllers/ParentalControlsController.php
+++ b/app/Http/Controllers/ParentalControlsController.php
@@ -12,6 +12,7 @@ use App\User;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Str;
 
 class ParentalControlsController extends Controller
 {
@@ -94,7 +95,7 @@ class ParentalControlsController extends Controller
         $pc = new ParentalControls;
         $pc->parent_id = $request->user()->id;
         $pc->email = $request->input('email');
-        $pc->verify_code = str_random(32);
+        $pc->verify_code = Str::random(32);
         $pc->permissions = $state;
         $pc->save();
 

--- a/app/Http/Controllers/RemoteAuthController.php
+++ b/app/Http/Controllers/RemoteAuthController.php
@@ -11,6 +11,7 @@ use App\Services\SanitizeService;
 use App\User;
 use App\Util\ActivityPub\Helpers;
 use App\Util\Lexer\RestrictedNames;
+use GuzzleHttp\Exception\RequestException;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
@@ -468,7 +469,7 @@ class RemoteAuthController extends Controller
                     $underscore = substr_count($value, '_');
                     $period = substr_count($value, '.');
 
-                    if (ends_with($value, ['.php', '.js', '.css'])) {
+                    if (str_ends_with($value, ['.php', '.js', '.css'])) {
                         return $fail('Username is invalid.');
                     }
 
@@ -591,7 +592,7 @@ class RemoteAuthController extends Controller
                 } else {
                     return [];
                 }
-            } catch (\GuzzleHttp\Exception\RequestException $e) {
+            } catch (RequestException $e) {
                 return;
             } catch (\Exception $e) {
                 return [];

--- a/app/Http/Controllers/Settings/SecuritySettings.php
+++ b/app/Http/Controllers/Settings/SecuritySettings.php
@@ -11,6 +11,7 @@ use BaconQrCode\Renderer\RendererStyle\RendererStyle;
 use BaconQrCode\Writer;
 use Carbon\Carbon;
 use Illuminate\Http\Request;
+use Illuminate\Support\Str;
 use PragmaRX\Google2FA\Google2FA;
 
 trait SecuritySettings
@@ -67,7 +68,7 @@ trait SecuritySettings
     {
         $keys = [];
         for ($i = 0; $i < 11; $i++) {
-            $key = str_random(24);
+            $key = Str::random(24);
             $keys[] = $key;
         }
 

--- a/app/Http/Controllers/StatusController.php
+++ b/app/Http/Controllers/StatusController.php
@@ -31,7 +31,7 @@ class StatusController extends Controller
         if ($request->user()) {
             // unless they force static view
             if (! $request->has('fs') || $request->input('fs') != '1') {
-                return redirect('/i/web/post/' . $id);
+                return redirect('/i/web/post/'.$id);
             }
         }
 
@@ -94,7 +94,7 @@ class StatusController extends Controller
         if ($status->uri || $status->url) {
             $url = $status->uri ?? $status->url;
 
-            if (ends_with($url, '/activity')) {
+            if (str_ends_with($url, '/activity')) {
                 $url = str_replace('/activity', '', $url);
             }
 
@@ -113,7 +113,7 @@ class StatusController extends Controller
         $hid = HashidService::decode($id);
         abort_if(! $hid, 404);
 
-        return redirect('/i/web/post/' . $hid);
+        return redirect('/i/web/post/'.$hid);
     }
 
     public function showId(int $id)
@@ -164,7 +164,7 @@ class StatusController extends Controller
             return response($content)->header('X-Frame-Options', 'ALLOWALL');
         }
 
-        $aiCheck = Cache::remember('profile:ai-check:spam-login:' . $profile['id'], 3600, function () use ($profile) {
+        $aiCheck = Cache::remember('profile:ai-check:spam-login:'.$profile['id'], 3600, function () use ($profile) {
             $user = Profile::find($profile['id']);
             if (! $user) {
                 return true;
@@ -265,7 +265,7 @@ class StatusController extends Controller
             $ai->user_id = $status->profile->user_id;
             $ai->type = 'post.removed';
             $ai->view = 'account.moderation.post.removed';
-            $ai->item_type = \App\Status::class;
+            $ai->item_type = Status::class;
             $ai->item_id = $status->id;
             $ai->has_media = (bool) $media->count();
             $ai->blurhash = $media->count() ? $media->first()->blurhash : null;
@@ -290,19 +290,19 @@ class StatusController extends Controller
         if ($status->in_reply_to_id) {
             $parent = Status::find($status->in_reply_to_id);
             if ($parent && ($parent->profile_id == $user->profile_id) || ($status->profile_id == $user->profile_id) || $user->is_admin) {
-                Cache::forget('_api:statuses:recent_9:' . $status->profile_id);
-                Cache::forget('profile:status_count:' . $status->profile_id);
-                Cache::forget('profile:embed:' . $status->profile_id);
+                Cache::forget('_api:statuses:recent_9:'.$status->profile_id);
+                Cache::forget('profile:status_count:'.$status->profile_id);
+                Cache::forget('profile:embed:'.$status->profile_id);
                 StatusService::del($status->id, true);
-                Cache::forget('profile:status_count:' . $status->profile_id);
+                Cache::forget('profile:status_count:'.$status->profile_id);
                 $status->uri ? RemoteStatusDelete::dispatch($status) : StatusDelete::dispatch($status);
             }
         } elseif ($status->profile_id == $user->profile_id || $user->is_admin == true) {
-            Cache::forget('_api:statuses:recent_9:' . $status->profile_id);
-            Cache::forget('profile:status_count:' . $status->profile_id);
-            Cache::forget('profile:embed:' . $status->profile_id);
+            Cache::forget('_api:statuses:recent_9:'.$status->profile_id);
+            Cache::forget('profile:status_count:'.$status->profile_id);
+            Cache::forget('profile:embed:'.$status->profile_id);
             StatusService::del($status->id, true);
-            Cache::forget('profile:status_count:' . $status->profile_id);
+            Cache::forget('profile:status_count:'.$status->profile_id);
             $status->uri ? RemoteStatusDelete::dispatch($status) : StatusDelete::dispatch($status);
         }
 
@@ -356,7 +356,7 @@ class StatusController extends Controller
             ReblogService::add($profile->id, $status->id);
         }
 
-        Cache::forget('status:' . $status->id . ':sharedby:userid:' . $user->id);
+        Cache::forget('status:'.$status->id.':sharedby:userid:'.$user->id);
         StatusService::del($status->id);
 
         if ($request->ajax()) {
@@ -370,7 +370,7 @@ class StatusController extends Controller
 
     public function showActivityPub(Request $request, $status)
     {
-        $key = 'pf:status:ap:v1:sid:' . $status['id'];
+        $key = 'pf:status:ap:v1:sid:'.$status['id'];
 
         return Cache::remember($key, 3600, function () use ($status) {
             $status = Status::findOrFail($status['id']);
@@ -412,7 +412,7 @@ class StatusController extends Controller
         $status->media->each(function ($media) use ($licenseId) {
             $media->license = $licenseId;
             $media->save();
-            Cache::forget('status:transformer:media:attachments:' . $media->status_id);
+            Cache::forget('status:transformer:media:attachments:'.$media->status_id);
         });
 
         return redirect($status->url());
@@ -506,7 +506,7 @@ class StatusController extends Controller
             return response()->json(0);
         }
 
-        Cache::forget('profile:home-timeline-cursor:' . $request->user()->id);
+        Cache::forget('profile:home-timeline-cursor:'.$request->user()->id);
 
         foreach ($views as $view) {
             if (! isset($view['sid']) || ! isset($view['pid'])) {

--- a/app/Http/Controllers/Stories/StoryApiV1Controller.php
+++ b/app/Http/Controllers/Stories/StoryApiV1Controller.php
@@ -41,7 +41,7 @@ class StoryApiV1Controller extends Controller
         $pid = $request->user()->profile_id;
 
         if (config('database.default') == 'pgsql') {
-            $s = Cache::remember(self::RECENT_KEY . $pid, self::RECENT_TTL, function () use ($pid) {
+            $s = Cache::remember(self::RECENT_KEY.$pid, self::RECENT_TTL, function () use ($pid) {
                 return Story::select('stories.*', 'followers.following_id')
                     ->leftJoin('followers', 'followers.following_id', 'stories.profile_id')
                     ->where('followers.profile_id', $pid)
@@ -59,7 +59,7 @@ class StoryApiV1Controller extends Controller
                     ->unique('profile_id');
             });
         } else {
-            $s = Cache::remember(self::RECENT_KEY . $pid, self::RECENT_TTL, function () use ($pid) {
+            $s = Cache::remember(self::RECENT_KEY.$pid, self::RECENT_TTL, function () use ($pid) {
                 return Story::select('stories.*', 'followers.following_id')
                     ->leftJoin('followers', 'followers.following_id', 'stories.profile_id')
                     ->where('followers.profile_id', $pid)
@@ -93,7 +93,7 @@ class StoryApiV1Controller extends Controller
                     url("/i/rs/{$profile['id']}");
 
                 return [
-                    'id' => 'pfs:' . $profile['id'],
+                    'id' => 'pfs:'.$profile['id'],
                     'user' => [
                         'id' => (string) $profile['id'],
                         'username' => $profile['username'],
@@ -154,7 +154,7 @@ class StoryApiV1Controller extends Controller
         $pid = $request->user()->profile_id;
 
         if (config('database.default') == 'pgsql') {
-            $s = Cache::remember(self::RECENT_KEY . $pid, self::RECENT_TTL, function () use ($pid) {
+            $s = Cache::remember(self::RECENT_KEY.$pid, self::RECENT_TTL, function () use ($pid) {
                 return Story::select('stories.*', 'followers.following_id')
                     ->leftJoin('followers', 'followers.following_id', 'stories.profile_id')
                     ->where('followers.profile_id', $pid)
@@ -172,7 +172,7 @@ class StoryApiV1Controller extends Controller
                     ->unique('profile_id');
             });
         } else {
-            $s = Cache::remember(self::RECENT_KEY . $pid, self::RECENT_TTL, function () use ($pid) {
+            $s = Cache::remember(self::RECENT_KEY.$pid, self::RECENT_TTL, function () use ($pid) {
                 return Story::select('stories.*', 'followers.following_id')
                     ->leftJoin('followers', 'followers.following_id', 'stories.profile_id')
                     ->where('followers.profile_id', $pid)
@@ -206,7 +206,7 @@ class StoryApiV1Controller extends Controller
                     url("/i/rs/{$profile['id']}");
 
                 return [
-                    'id' => 'pfs:' . $profile['id'],
+                    'id' => 'pfs:'.$profile['id'],
                     'user' => [
                         'id' => (string) $profile['id'],
                         'username' => $profile['username'],
@@ -269,7 +269,7 @@ class StoryApiV1Controller extends Controller
             'file' => [
                 'required',
                 'mimetypes:image/jpeg,image/jpg,image/png,video/mp4',
-                'max:' . config_cache('pixelfed.max_photo_size'),
+                'max:'.config_cache('pixelfed.max_photo_size'),
             ],
             'duration' => 'sometimes|integer|min:0|max:30',
         ]);
@@ -296,7 +296,7 @@ class StoryApiV1Controller extends Controller
         $story->path = $path;
         $story->local = true;
         $story->size = $photo->getSize();
-        $story->bearcap_token = str_random(64);
+        $story->bearcap_token = Str::random(64);
         $story->expires_at = now()->addMinutes(1440);
         $story->save();
 
@@ -306,7 +306,7 @@ class StoryApiV1Controller extends Controller
             'code' => 200,
             'msg' => 'Successfully added',
             'media_id' => (string) $story->id,
-            'media_url' => url(Storage::url($url)) . '?v=' . time(),
+            'media_url' => url(Storage::url($url)).'?v='.time(),
             'media_type' => $story->type,
         ];
 
@@ -420,7 +420,7 @@ class StoryApiV1Controller extends Controller
         if ($count >= Story::MAX_PER_DAY) {
             return response()->json([
                 'code' => 418,
-                'error' => 'You’ve reached your daily limit of ' . Story::MAX_PER_DAY . ' Stories.',
+                'error' => 'You’ve reached your daily limit of '.Story::MAX_PER_DAY.' Stories.',
             ], 418, [], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
         }
 
@@ -578,7 +578,7 @@ class StoryApiV1Controller extends Controller
 
         $rows = DB::table('profiles as p')
             ->select('p.id', 'p.username')
-            ->where('p.username', 'like', $q . '%')
+            ->where('p.username', 'like', $q.'%')
             ->whereExists(function ($sub) use ($pid) {
                 $sub->select(DB::raw(1))
                     ->from('followers as f')
@@ -658,7 +658,7 @@ class StoryApiV1Controller extends Controller
             if ($story->local == false) {
                 StoryViewDeliver::dispatch($story, $authed)->onQueue('story');
             }
-            Cache::forget('stories:recent:by_id:' . $pid);
+            Cache::forget('stories:recent:by_id:'.$pid);
             StoryService::addSeen($pid, $story->id);
         }
 
@@ -726,7 +726,7 @@ class StoryApiV1Controller extends Controller
             $n->profile_id = $dm->to_id;
             $n->actor_id = $dm->from_id;
             $n->item_id = $dm->id;
-            $n->item_type = \App\DirectMessage::class;
+            $n->item_type = DirectMessage::class;
             $n->action = 'story:comment';
             $n->save();
         } else {
@@ -753,7 +753,7 @@ class StoryApiV1Controller extends Controller
         }
 
         $storagePath = MediaPathService::story($user->profile);
-        $path = $photo->storePubliclyAs($storagePath, Str::random(random_int(2, 12)) . '_' . Str::random(random_int(32, 35)) . '_' . Str::random(random_int(1, 14)) . '.' . $photo->extension());
+        $path = $photo->storePubliclyAs($storagePath, Str::random(random_int(2, 12)).'_'.Str::random(random_int(32, 35)).'_'.Str::random(random_int(1, 14)).'.'.$photo->extension());
 
         return $path;
     }

--- a/app/Http/Controllers/StoryComposeController.php
+++ b/app/Http/Controllers/StoryComposeController.php
@@ -73,7 +73,7 @@ class StoryComposeController extends Controller
         $story->path = $path;
         $story->local = true;
         $story->size = $photo->getSize();
-        $story->bearcap_token = str_random(64);
+        $story->bearcap_token = Str::random(64);
         $story->expires_at = now()->addMinutes(1440);
         $story->save();
 
@@ -460,7 +460,7 @@ class StoryComposeController extends Controller
         abort_if(! FollowerService::follows($pid, $story->profile_id), 422, 'Cannot report a story from an account you do not follow');
 
         if (Report::whereProfileId($pid)
-            ->whereObjectType(\App\Story::class)
+            ->whereObjectType(Story::class)
             ->whereObjectId($story->id)
             ->exists()
         ) {
@@ -474,7 +474,7 @@ class StoryComposeController extends Controller
         $report->profile_id = $pid;
         $report->user_id = $request->user()->id;
         $report->object_id = $story->id;
-        $report->object_type = \App\Story::class;
+        $report->object_type = Story::class;
         $report->reported_profile_id = $story->profile_id;
         $report->type = $type;
         $report->message = null;
@@ -550,7 +550,7 @@ class StoryComposeController extends Controller
             $n->profile_id = $dm->to_id;
             $n->actor_id = $dm->from_id;
             $n->item_id = $dm->id;
-            $n->item_type = \App\DirectMessage::class;
+            $n->item_type = DirectMessage::class;
             $n->action = 'story:react';
             $n->save();
         } else {
@@ -627,7 +627,7 @@ class StoryComposeController extends Controller
             $n->profile_id = $dm->to_id;
             $n->actor_id = $dm->from_id;
             $n->item_id = $dm->id;
-            $n->item_type = \App\DirectMessage::class;
+            $n->item_type = DirectMessage::class;
             $n->action = 'story:comment';
             $n->save();
         } else {

--- a/app/Http/Controllers/UserInviteController.php
+++ b/app/Http/Controllers/UserInviteController.php
@@ -9,6 +9,7 @@ use App\UserInvite;
 use Auth;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Str;
 
 class UserInviteController extends Controller
 {
@@ -55,8 +56,8 @@ class UserInviteController extends Controller
         $invite->profile_id = Auth::user()->profile_id;
         $invite->email = $email;
         $invite->message = $request->input('message');
-        $invite->key = str_random(random_int(6, 9)).'_'.str_random(random_int(14, 20)).'_'.str_random(random_int(32, 64));
-        $invite->token = str_random(random_int(32, 69));
+        $invite->key = Str::random(random_int(6, 9)).'_'.Str::random(random_int(14, 20)).'_'.Str::random(random_int(32, 64));
+        $invite->token = Str::random(random_int(32, 69));
         $invite->save();
 
         // Mail::to($email)->send(new UserInviteMail($invite));

--- a/app/Jobs/GroupPipeline/NewStatusPipeline.php
+++ b/app/Jobs/GroupPipeline/NewStatusPipeline.php
@@ -18,6 +18,7 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Str;
 
 class NewStatusPipeline implements ShouldQueue
 {
@@ -75,7 +76,7 @@ class NewStatusPipeline implements ShouldQueue
             }
 
             DB::transaction(function () use ($status, $tag, $gp) {
-                $slug = str_slug($tag, '-', false);
+                $slug = Str::slug($tag, '-', false);
                 $hashtag = Hashtag::firstOrCreate(
                     ['name' => $tag, 'slug' => $slug]
                 );

--- a/app/Jobs/RemoteFollowPipeline/RemoteFollowImportRecent.php
+++ b/app/Jobs/RemoteFollowPipeline/RemoteFollowImportRecent.php
@@ -16,6 +16,7 @@ use Illuminate\Http\File;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Str;
 use Log;
 use Storage;
 
@@ -222,7 +223,7 @@ class RemoteFollowImportRecent implements ShouldQueue
             $info = pathinfo($url);
             $url = str_replace(' ', '%20', $url);
             $img = file_get_contents($url);
-            $file = '/tmp/'.str_random(64);
+            $file = '/tmp/'.Str::random(64);
             file_put_contents($file, $img);
             $path = Storage::putFile($storagePath, new File($file), 'public');
 

--- a/app/Jobs/StatusPipeline/StatusEntityLexer.php
+++ b/app/Jobs/StatusPipeline/StatusEntityLexer.php
@@ -24,6 +24,7 @@ use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
 
 class StatusEntityLexer implements ShouldQueue
 {
@@ -124,7 +125,7 @@ class StatusEntityLexer implements ShouldQueue
                 continue;
             }
             DB::transaction(function () use ($status, $tag) {
-                $slug = str_slug($tag, '-', false);
+                $slug = Str::slug($tag, '-', false);
 
                 $hashtag = Hashtag::firstOrCreate([
                     'slug' => $slug,

--- a/app/Jobs/StatusPipeline/StatusTagsPipeline.php
+++ b/app/Jobs/StatusPipeline/StatusTagsPipeline.php
@@ -18,6 +18,7 @@ use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
 
 class StatusTagsPipeline implements ShouldQueue
 {
@@ -94,9 +95,9 @@ class StatusTagsPipeline implements ShouldQueue
 
                 if (config('database.default') === 'pgsql') {
                     $hashtag = DB::transaction(function () use ($name) {
-                        $slug = str_slug($name, '-', false);
+                        $slug = Str::slug($name, '-', false);
 
-                        // Use slug for lookup (case-insensitive via str_slug normalization)
+                        // Use slug for lookup (case-insensitive via Str::slug normalization)
                         $existing = Hashtag::where('slug', $slug)
                             ->lockForUpdate()
                             ->first();
@@ -112,7 +113,7 @@ class StatusTagsPipeline implements ShouldQueue
                     });
                 } else {
                     $hashtag = DB::transaction(function () use ($name) {
-                        $baseSlug = str_slug($name, '-', false);
+                        $baseSlug = Str::slug($name, '-', false);
                         $slug = $baseSlug;
                         $counter = 1;
 

--- a/app/Models/CuratedRegister.php
+++ b/app/Models/CuratedRegister.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Str;
 
 class CuratedRegister extends Model
 {
@@ -60,7 +61,7 @@ class CuratedRegister extends Model
 
     public function emailReplyUrl()
     {
-        return url('/auth/sign_up/concierge?sid='.$this->id.'&code='.$this->verify_code.'&sc='.str_random(8));
+        return url('/auth/sign_up/concierge?sid='.$this->id.'&code='.$this->verify_code.'&sc='.Str::random(8));
     }
 
     public function adminReviewUrl()

--- a/app/Rules/PixelfedUsername.php
+++ b/app/Rules/PixelfedUsername.php
@@ -5,13 +5,14 @@ namespace App\Rules;
 use App\Util\Lexer\RestrictedNames;
 use Closure;
 use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Translation\PotentiallyTranslatedString;
 
 class PixelfedUsername implements ValidationRule
 {
     /**
      * Run the validation rule.
      *
-     * @param  \Closure(string): \Illuminate\Translation\PotentiallyTranslatedString  $fail
+     * @param  Closure(string): PotentiallyTranslatedString  $fail
      */
     public function validate(string $attribute, mixed $value, Closure $fail): void
     {
@@ -19,7 +20,7 @@ class PixelfedUsername implements ValidationRule
         $underscore = substr_count($value, '_');
         $period = substr_count($value, '.');
 
-        if (ends_with($value, ['.php', '.js', '.css'])) {
+        if (str_ends_with($value, ['.php', '.js', '.css'])) {
             $fail('Username is invalid.');
 
             return;

--- a/app/Services/Internal/BeagleService.php
+++ b/app/Services/Internal/BeagleService.php
@@ -7,6 +7,7 @@ use App\Services\StatusService;
 use App\Util\ActivityPub\Helpers;
 use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Http\Client\RequestException;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
 
@@ -112,7 +113,7 @@ class BeagleService
                     $domain = parse_url($post['id'], PHP_URL_HOST);
                     if ($domain === config_cache('pixelfed.domain.app')) {
                         $parts = explode('/', $post['id']);
-                        $id = array_last($parts);
+                        $id = Arr::last($parts);
 
                         return StatusService::get($id);
                     }

--- a/app/Util/ActivityPub/Inbox.php
+++ b/app/Util/ActivityPub/Inbox.php
@@ -50,6 +50,7 @@ use App\Util\ActivityPub\Validator\MoveValidator;
 use App\Util\ActivityPub\Validator\RejectValidator;
 use App\Util\ActivityPub\Validator\UpdatePersonValidator;
 use Cache;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
@@ -421,7 +422,7 @@ class Inbox
         }
         $actor = $this->actorFirstOrCreate($this->payload['actor']);
         $profile = Profile::whereNull('domain')
-            ->whereUsername(array_last(explode('/', $to[0])))
+            ->whereUsername(Arr::last(explode('/', $to[0])))
             ->firstOrFail();
 
         if (! $actor || in_array($actor->id, $profile->blockedIds()->toArray())) {
@@ -536,7 +537,7 @@ class Inbox
 
         $nf = UserFilter::whereUserId($profile->id)
             ->whereFilterableId($actor->id)
-            ->whereFilterableType(\App\Profile::class)
+            ->whereFilterableType(Profile::class)
             ->whereFilterType('dm.mute')
             ->exists();
 
@@ -546,7 +547,7 @@ class Inbox
             $notification->actor_id = $actor->id;
             $notification->action = 'dm';
             $notification->item_id = $dm->id;
-            $notification->item_type = \App\DirectMessage::class;
+            $notification->item_type = DirectMessage::class;
             $notification->save();
 
             if (NotificationAppGatewayService::enabled()) {
@@ -675,7 +676,7 @@ class Inbox
                 'actor_id' => $actor->id,
                 'action' => 'share',
                 'item_id' => $parent->id,
-                'item_type' => \App\Status::class,
+                'item_type' => Status::class,
             ]
         );
 
@@ -813,7 +814,7 @@ class Inbox
                     }
                     $notifications = Notification::whereActorId($status->profile_id)
                         ->whereItemId($status->id)
-                        ->whereItemType(\App\Status::class)
+                        ->whereItemType(Status::class)
                         ->get();
                     foreach ($notifications as $notification) {
                         $notification->forceDelete();
@@ -948,7 +949,7 @@ class Inbox
                     ->whereActorId($profile->id)
                     ->whereAction('share')
                     ->whereItemId($status->id)
-                    ->whereItemType(\App\Status::class)
+                    ->whereItemType(Status::class)
                     ->get();
                 foreach ($notifications as $notification) {
                     $notification->forceDelete();
@@ -976,7 +977,7 @@ class Inbox
                     ->whereActorId($profile->id)
                     ->whereAction('follow')
                     ->whereItemId($following->id)
-                    ->whereItemType(\App\Profile::class)
+                    ->whereItemType(Profile::class)
                     ->get();
                 foreach ($notifications as $notification) {
                     $notification->forceDelete();
@@ -1010,7 +1011,7 @@ class Inbox
                     ->whereActorId($profile->id)
                     ->whereAction('like')
                     ->whereItemId($status->id)
-                    ->whereItemType(\App\Status::class)
+                    ->whereItemType(Status::class)
                     ->get();
 
                 foreach ($notifications as $notification) {
@@ -1195,7 +1196,7 @@ class Inbox
         $n->profile_id = $dm->to_id;
         $n->actor_id = $dm->from_id;
         $n->item_id = $dm->id;
-        $n->item_type = \App\DirectMessage::class;
+        $n->item_type = DirectMessage::class;
         $n->action = 'story:react';
         $n->save();
     }
@@ -1314,7 +1315,7 @@ class Inbox
         $n->profile_id = $dm->to_id;
         $n->actor_id = $dm->from_id;
         $n->item_id = $dm->id;
-        $n->item_type = \App\DirectMessage::class;
+        $n->item_type = DirectMessage::class;
         $n->action = 'story:comment';
         $n->save();
     }

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,6 @@
         "laravel-notification-channels/expo": "^2.0.0",
         "laravel-notification-channels/webpush": "^10.2",
         "laravel/framework": "^12.0",
-        "laravel/helpers": "^1.1",
         "laravel/horizon": "^5.0",
         "laravel/passport": "^13.4.4",
         "laravel/pulse": "^1.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c6e65b6fc21bd97e1f3e7533ec4bde30",
+    "content-hash": "3f9605bcb018445854695b1622c79767",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -2456,63 +2456,6 @@
                 "source": "https://github.com/laravel/framework"
             },
             "time": "2026-08-25T14:18:36+00:00"
-        },
-        {
-            "name": "laravel/helpers",
-            "version": "v1.8.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laravel/helpers.git",
-                "reference": "5915be977c7cc05fe2498d561b8c026ee56567dd"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laravel/helpers/zipball/5915be977c7cc05fe2498d561b8c026ee56567dd",
-                "reference": "5915be977c7cc05fe2498d561b8c026ee56567dd",
-                "shasum": ""
-            },
-            "require": {
-                "illuminate/support": "~5.8.0|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
-                "php": "^7.2.0|^8.0"
-            },
-            "require-dev": {
-                "phpstan/phpstan": "^1.10",
-                "phpunit/phpunit": "^7.0|^8.0|^9.0|^10.0|^11.0|^12.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.x-dev"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "src/helpers.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Taylor Otwell",
-                    "email": "taylor@laravel.com"
-                },
-                {
-                    "name": "Dries Vints",
-                    "email": "dries@laravel.com"
-                }
-            ],
-            "description": "Provides backwards compatibility for helpers in the latest Laravel release.",
-            "keywords": [
-                "helpers",
-                "laravel"
-            ],
-            "support": {
-                "source": "https://github.com/laravel/helpers/tree/v1.8.3"
-            },
-            "time": "2026-03-17T16:40:11+00:00"
         },
         {
             "name": "laravel/horizon",

--- a/config/cache.php
+++ b/config/cache.php
@@ -1,5 +1,7 @@
 <?php
 
+use Illuminate\Support\Str;
+
 return [
 
     /*
@@ -40,22 +42,22 @@ return [
         ],
 
         'database' => [
-            'driver'     => 'database',
-            'table'      => 'cache',
+            'driver' => 'database',
+            'table' => 'cache',
             'connection' => null,
             'lock_connection' => null,
         ],
 
         'file' => [
             'driver' => 'file',
-            'path'   => storage_path('framework/cache/data'),
+            'path' => storage_path('framework/cache/data'),
             'lock_path' => storage_path('framework/cache/data'),
         ],
 
         'memcached' => [
-            'driver'        => 'memcached',
+            'driver' => 'memcached',
             'persistent_id' => env('MEMCACHED_PERSISTENT_ID'),
-            'sasl'          => [
+            'sasl' => [
                 env('MEMCACHED_USERNAME'),
                 env('MEMCACHED_PASSWORD'),
             ],
@@ -64,8 +66,8 @@ return [
             ],
             'servers' => [
                 [
-                    'host'   => env('MEMCACHED_HOST', '127.0.0.1'),
-                    'port'   => env('MEMCACHED_PORT', 11211),
+                    'host' => env('MEMCACHED_HOST', '127.0.0.1'),
+                    'port' => env('MEMCACHED_PORT', 11211),
                     'weight' => 100,
                 ],
             ],
@@ -77,29 +79,29 @@ return [
             'client' => env('REDIS_CLIENT', 'predis'),
 
             'default' => [
-                'scheme'   => env('REDIS_SCHEME', 'tcp'),
-                'path'     => env('REDIS_PATH'),
-                'host'     => env('REDIS_HOST', 'localhost'),
+                'scheme' => env('REDIS_SCHEME', 'tcp'),
+                'path' => env('REDIS_PATH'),
+                'host' => env('REDIS_HOST', 'localhost'),
                 'password' => env('REDIS_PASSWORD', null),
-                'port'     => env('REDIS_PORT', 6379),
+                'port' => env('REDIS_PORT', 6379),
                 'database' => env('REDIS_DATABASE', 0),
             ],
 
             'session' => [
-                'scheme'   => env('REDIS_SCHEME', 'tcp'),
-                'path'     => env('REDIS_PATH'),
-                'host'     => env('REDIS_HOST', '127.0.0.1'),
+                'scheme' => env('REDIS_SCHEME', 'tcp'),
+                'path' => env('REDIS_PATH'),
+                'host' => env('REDIS_HOST', '127.0.0.1'),
                 'password' => env('REDIS_PASSWORD', null),
-                'port'     => env('REDIS_PORT', 6379),
+                'port' => env('REDIS_PORT', 6379),
                 'database' => env('REDIS_DATABASE_SESSION', 1),
             ],
 
             'pulse' => [
-                'scheme'   => env('REDIS_SCHEME', 'tcp'),
-                'path'     => env('REDIS_PATH'),
-                'host'     => env('REDIS_HOST', '127.0.0.1'),
+                'scheme' => env('REDIS_SCHEME', 'tcp'),
+                'path' => env('REDIS_PATH'),
+                'host' => env('REDIS_HOST', '127.0.0.1'),
                 'password' => env('REDIS_PASSWORD', null),
-                'port'     => env('REDIS_PORT', 6379),
+                'port' => env('REDIS_PORT', 6379),
                 'database' => env('REDIS_DATABASE_PULSE', 2),
             ],
 
@@ -139,7 +141,7 @@ return [
 
     'prefix' => env(
         'CACHE_PREFIX',
-        str_slug(env('APP_NAME', 'laravel'), '_').'_cache'
+        Str::slug(env('APP_NAME', 'laravel'), '_').'_cache'
     ),
 
     'limiter' => env('CACHE_LIMITER_DRIVER', 'redis'),

--- a/database/migrations/2021_10_01_083917_create_group_categories_table.php
+++ b/database/migrations/2021_10_01_083917_create_group_categories_table.php
@@ -1,9 +1,10 @@
 <?php
 
+use App\Models\GroupCategory;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
-use App\Models\GroupCategory;
+use Illuminate\Support\Str;
 
 class CreateGroupCategoriesTable extends Migration
 {
@@ -27,53 +28,53 @@ class CreateGroupCategoriesTable extends Migration
         });
 
         $default = [
-        	'General',
-			'Photography',
-			'Fediverse',
-			'CompSci & Programming',
-			'Causes & Movements',
-			'Humor',
-			'Science & Tech',
-			'Travel',
-			'Buy & Sell',
-			'Business',
-			'Style',
-			'Animals',
-			'Sports & Fitness',
-			'Education',
-			'Arts',
-			'Entertainment',
-			'Faith & Spirituality',
-			'Relationships & Identity',
-			'Parenting',
-			'Hobbies & Interests',
-			'Food & Drink',
-			'Vehicles & Commutes',
-			'Civics & Community',
-		];
+            'General',
+            'Photography',
+            'Fediverse',
+            'CompSci & Programming',
+            'Causes & Movements',
+            'Humor',
+            'Science & Tech',
+            'Travel',
+            'Buy & Sell',
+            'Business',
+            'Style',
+            'Animals',
+            'Sports & Fitness',
+            'Education',
+            'Arts',
+            'Entertainment',
+            'Faith & Spirituality',
+            'Relationships & Identity',
+            'Parenting',
+            'Hobbies & Interests',
+            'Food & Drink',
+            'Vehicles & Commutes',
+            'Civics & Community',
+        ];
 
-		for ($i=1; $i <= 23; $i++) {
-			$cat = new GroupCategory;
-			$cat->name = $default[$i - 1];
-			$cat->slug = str_slug($cat->name);
-			$cat->active = true;
-			$cat->order = $i;
-			$cat->save();
-		}
+        for ($i = 1; $i <= 23; $i++) {
+            $cat = new GroupCategory;
+            $cat->name = $default[$i - 1];
+            $cat->slug = Str::slug($cat->name);
+            $cat->active = true;
+            $cat->order = $i;
+            $cat->save();
+        }
 
-		Schema::table('groups', function (Blueprint $table) {
-			$table->unsignedInteger('category_id')->default(1)->index()->after('id');
-			$table->unsignedInteger('member_count')->nullable();
-			$table->boolean('recommended')->default(false)->index();
-			$table->boolean('discoverable')->default(false)->index();
-			$table->boolean('activitypub')->default(false);
-			$table->boolean('is_nsfw')->default(false);
-			$table->boolean('dms')->default(false);
-			$table->boolean('autospam')->default(false);
-			$table->boolean('verified')->default(false);
-			$table->timestamp('last_active_at')->nullable();
-			$table->softDeletes();
-		});
+        Schema::table('groups', function (Blueprint $table) {
+            $table->unsignedInteger('category_id')->default(1)->index()->after('id');
+            $table->unsignedInteger('member_count')->nullable();
+            $table->boolean('recommended')->default(false)->index();
+            $table->boolean('discoverable')->default(false)->index();
+            $table->boolean('activitypub')->default(false);
+            $table->boolean('is_nsfw')->default(false);
+            $table->boolean('dms')->default(false);
+            $table->boolean('autospam')->default(false);
+            $table->boolean('verified')->default(false);
+            $table->timestamp('last_active_at')->nullable();
+            $table->softDeletes();
+        });
     }
 
     /**
@@ -85,18 +86,18 @@ class CreateGroupCategoriesTable extends Migration
     {
         Schema::dropIfExists('group_categories');
 
-		Schema::table('groups', function (Blueprint $table) {
-			$table->dropColumn('category_id');
-			$table->dropColumn('member_count');
-			$table->dropColumn('recommended');
-			$table->dropColumn('activitypub');
-			$table->dropColumn('is_nsfw');
-			$table->dropColumn('discoverable');
-			$table->dropColumn('dms');
-			$table->dropColumn('autospam');
-			$table->dropColumn('verified');
-			$table->dropColumn('last_active_at');
-			$table->dropColumn('deleted_at');
-		});
+        Schema::table('groups', function (Blueprint $table) {
+            $table->dropColumn('category_id');
+            $table->dropColumn('member_count');
+            $table->dropColumn('recommended');
+            $table->dropColumn('activitypub');
+            $table->dropColumn('is_nsfw');
+            $table->dropColumn('discoverable');
+            $table->dropColumn('dms');
+            $table->dropColumn('autospam');
+            $table->dropColumn('verified');
+            $table->dropColumn('last_active_at');
+            $table->dropColumn('deleted_at');
+        });
     }
 }


### PR DESCRIPTION
Replace all deprecated helper function calls:
- str_slug() → Str::slug()
- starts_with() → str_starts_with()
- ends_with() → str_ends_with()
- array_first() → Arr::first()
- array_last() → Arr::last()
- array_flatten() → Arr::flatten()

Remove laravel/helpers package from composer.json as it is no longer needed and will not be maintained for Laravel 13.