### PR TITLE
refactor: update phpstan.neon with Larastan 3.x best practices

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,22 +3,7 @@ includes:
     - vendor/nesbot/carbon/extension.neon
 
 parameters:
-    # Level 10 is the highest level
     level: 0
-
-    # Laravel specific configurations
-    noModelMake: true
-    noUnnecessaryCollectionCall: true
-    checkModelProperties: true
-    checkOctaneCompatibility: true
-    noEnvCallsOutsideOfConfig: true
-    checkModelAppends: true
-    checkModelMethodVisibility: true
-    checkAuthCallsWhenInRequestScope: true
-
-    checkMissingTranslations: false
-    translationDirectories:
-        - resources/lang
 
     paths:
         - app/
@@ -29,5 +14,30 @@ parameters:
         - bootstrap/cache/*
         - storage/
         - vendor/
+
+    # Laravel-specific analysis
+    databaseMigrationsPath:
+        - database/migrations
+    configDirectories:
+        - config
+    translationDirectories:
+        - resources/lang
+
+    # Feature checks
+    noModelMake: true
+    noUnnecessaryCollectionCall: true
+    checkModelProperties: true
+    checkOctaneCompatibility: true
+    noEnvCallsOutsideOfConfig: true
+    checkModelAppends: true
+    checkModelMethodVisibility: true
+    checkAuthCallsWhenInRequestScope: true
+    parseModelCastsMethod: true
+    enableMigrationCache: true
+    checkMissingTranslations: false
+
+    # Ignore intentional patterns
+    ignoreErrors:
+        - '#Unsafe usage of new static#'
 
     reportUnmatchedIgnoredErrors: false

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,7 +3,7 @@ includes:
     - vendor/nesbot/carbon/extension.neon
 
 parameters:
-    level: 0
+    level: 0 #Larascan supports 0-9. 10 is not required
 
     paths:
         - app/


### PR DESCRIPTION
Updates the Larastan to follow best practices for Laravel 12+ per the official Larastan docs.
