### PR TITLE
fix: replace backslash-prefixed facade calls with imported references

### DIFF
--- a/app/Http/Controllers/Api/BaseApiController.php
+++ b/app/Http/Controllers/Api/BaseApiController.php
@@ -16,6 +16,7 @@ use App\Transformer\Api\StatusStatelessTransformer;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
 use League\Fractal;
 use League\Fractal\Serializer\ArraySerializer;
 
@@ -141,7 +142,7 @@ class BaseApiController extends Controller
         $user = $request->user();
         $limit = $request->input('limit', 10);
 
-        $res = \DB::table('likes')
+        $res = DB::table('likes')
             ->whereProfileId($user->profile_id)
             ->latest()
             ->simplePaginate($limit)

--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -51,7 +51,7 @@ class RegisterController extends Controller
 
     public function getRegisterToken()
     {
-        return \Cache::remember('pf:register:rt', 900, function () {
+        return Cache::remember('pf:register:rt', 900, function () {
             return Str::random(40);
         });
     }

--- a/app/Http/Controllers/Import/Instagram.php
+++ b/app/Http/Controllers/Import/Instagram.php
@@ -203,7 +203,7 @@ trait Instagram
                 ->firstOrFail();
             ImportInstagram::dispatch($import);
         } catch (\Exception $e) {
-            \Log::info($e);
+            Log::info($e);
         }
 
         return redirect(route('settings'))->with(['status' => 'Import successful! It may take a few minutes to finish.']);

--- a/app/Http/Controllers/ImportPostController.php
+++ b/app/Http/Controllers/ImportPostController.php
@@ -185,7 +185,7 @@ class ImportPostController extends Controller
                 ImportService::getPostCount($pid, true);
             } catch (\Exception $e) {
                 $errors[] = $e->getMessage();
-                \Log::error('Import error: '.$e->getMessage());
+                Log::error('Import error: '.$e->getMessage());
 
                 continue;
             }

--- a/app/Http/Controllers/Stories/StoryApiV1Controller.php
+++ b/app/Http/Controllers/Stories/StoryApiV1Controller.php
@@ -552,7 +552,7 @@ class StoryApiV1Controller extends Controller
             return response()->json($res);
         } catch (\Exception $e) {
             DB::rollback();
-            \Log::error('Story creation failed', [
+            Log::error('Story creation failed', [
                 'user_id' => $user->id,
                 'error' => $e->getMessage(),
             ]);

--- a/app/Models/CustomFilter.php
+++ b/app/Models/CustomFilter.php
@@ -383,7 +383,7 @@ class CustomFilter extends Model
                         $keywordMatches = array_slice($matches[0], 0, $maxReportedMatches);
                     }
                 } catch (\Throwable $e) {
-                    \Log::error('Filter regex error: '.$e->getMessage(), [
+                    Log::error('Filter regex error: '.$e->getMessage(), [
                         'filter_id' => $filter->id,
                     ]);
                 }

--- a/app/Services/ActivityPubDeliveryService.php
+++ b/app/Services/ActivityPubDeliveryService.php
@@ -52,7 +52,7 @@ class ActivityPubDeliveryService
         abort_if($this->sender->domain != null || $this->sender->status != null, 400);
 
         if (config('app.env') !== 'production') {
-            \Log::info('Skipped delivery to '.$this->to);
+            Log::info('Skipped delivery to '.$this->to);
 
             return;
         }

--- a/app/Services/TrendingHashtagService.php
+++ b/app/Services/TrendingHashtagService.php
@@ -5,6 +5,7 @@ namespace App\Services;
 use App\Hashtag;
 use App\StatusHashtag;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
 
 class TrendingHashtagService
 {
@@ -62,7 +63,7 @@ class TrendingHashtagService
         $skipIds = array_merge(self::getBannedHashtags(), self::getNonTrendingHashtags(), self::getNsfwHashtags());
 
         return Cache::remember(self::CACHE_KEY, config('trending.hashtags.ttl'), function () use ($minId, $skipIds) {
-            return StatusHashtag::select('hashtag_id', \DB::raw('count(*) as total'))
+            return StatusHashtag::select('hashtag_id', DB::raw('count(*) as total'))
                 ->whereNotIn('hashtag_id', $skipIds)
                 ->where('id', '>', $minId)
                 ->groupBy('hashtag_id')


### PR DESCRIPTION
Replace \Cache::, \Log::, \DB:: calls with their imported facade equivalents. The backslash-prefix relies on global aliases which PHPStan cannot resolve, causing class.notFound errors.