### PR TITLE
fix: replace Auth facade with $request->user() in request-scoped classes

### DIFF
--- a/app/Http/Controllers/Api/BaseApiController.php
+++ b/app/Http/Controllers/Api/BaseApiController.php
@@ -88,7 +88,7 @@ class BaseApiController extends Controller
         ]);
 
         try {
-            $user = Auth::user();
+            $user = $request->user();
             $profile = $user->profile;
             $file = $request->file('upload');
             $path = (new AvatarController)->getPath($user, $file);

--- a/app/Http/Controllers/AvatarController.php
+++ b/app/Http/Controllers/AvatarController.php
@@ -5,7 +5,6 @@ namespace App\Http\Controllers;
 use App\Avatar;
 use App\Jobs\AvatarPipeline\AvatarOptimize;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Str;
 
@@ -23,7 +22,7 @@ class AvatarController extends Controller
         ]);
 
         try {
-            $user = Auth::user();
+            $user = $request->user();
             $profile = $user->profile;
             $file = $request->file('avatar');
             $path = $this->getPath($user, $file);
@@ -114,7 +113,7 @@ class AvatarController extends Controller
 
     public function deleteAvatar(Request $request)
     {
-        $user = Auth::user();
+        $user = $request->user();
         $profile = $user->profile;
 
         $avatar = $profile->avatar;

--- a/app/Http/Controllers/CircleController.php
+++ b/app/Http/Controllers/CircleController.php
@@ -4,7 +4,6 @@ namespace App\Http\Controllers;
 
 use App\Circle;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Auth;
 use Illuminate\Validation\Rule;
 
 class CircleController extends Controller
@@ -16,7 +15,7 @@ class CircleController extends Controller
 
     public function home(Request $request)
     {
-        $circles = Circle::whereProfileId(Auth::user()->profile->id)
+        $circles = Circle::whereProfileId($request->user()->profile->id)
             ->orderByDesc('created_at')
             ->paginate(10);
 
@@ -46,7 +45,7 @@ class CircleController extends Controller
         ]);
 
         $circle = Circle::firstOrCreate([
-            'profile_id' => Auth::user()->profile->id,
+            'profile_id' => $request->user()->profile->id,
             'name' => $request->input('name'),
         ], [
             'description' => $request->input('description'),

--- a/app/Http/Controllers/CollectionController.php
+++ b/app/Http/Controllers/CollectionController.php
@@ -10,14 +10,13 @@ use App\Services\FollowerService;
 use App\Services\StatusService;
 use App\Status;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Auth;
 
 class CollectionController extends Controller
 {
     public function create(Request $request)
     {
-        abort_if(! Auth::check(), 403);
-        $profile = Auth::user()->profile;
+        abort_if(! $request->user(), 403);
+        $profile = $request->user()->profile;
 
         $collection = Collection::firstOrCreate([
             'profile_id' => $profile->id,
@@ -49,7 +48,7 @@ class CollectionController extends Controller
 
     public function index(Request $request)
     {
-        abort_if(! Auth::check(), 403);
+        abort_if(! $request->user(), 403);
 
         return $request->all();
     }
@@ -83,7 +82,7 @@ class CollectionController extends Controller
             'description' => 'nullable|max:500',
             'visibility' => 'required|alpha|in:public,private,draft',
         ]);
-        $profile = Auth::user()->profile;
+        $profile = $request->user()->profile;
         $collection = Collection::whereProfileId($profile->id)->findOrFail($id);
         if ($collection->items()->count() == 0) {
             abort(404);

--- a/app/Http/Controllers/CommentController.php
+++ b/app/Http/Controllers/CommentController.php
@@ -11,7 +11,6 @@ use App\Status;
 use App\Transformer\Api\StatusTransformer;
 use App\UserFilter;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use League\Fractal;
 use League\Fractal\Serializer\ArraySerializer;
@@ -26,7 +25,7 @@ class CommentController extends Controller
 
     public function store(Request $request)
     {
-        if (Auth::check() === false) {
+        if (! $request->user()) {
             abort(403);
         }
         $this->validate($request, [
@@ -38,7 +37,7 @@ class CommentController extends Controller
         $statusId = $request->input('item');
         $nsfw = $request->input('sensitive', false);
 
-        $user = Auth::user();
+        $user = $request->user();
         $profile = $user->profile;
         $status = Status::findOrFail($statusId);
 

--- a/app/Http/Controllers/ComposeController.php
+++ b/app/Http/Controllers/ComposeController.php
@@ -172,7 +172,7 @@ class ComposeController extends Controller
             ],
         ]);
 
-        $user = Auth::user();
+        $user = $request->user();
         abort_if($user->has_roles && ! UserRoleService::can('can-post', $user->id), 403, 'Invalid permissions for this action');
 
         $limitKey = 'compose:rate-limit:media-updates:'.$user->id;

--- a/app/Http/Controllers/ContactController.php
+++ b/app/Http/Controllers/ContactController.php
@@ -6,7 +6,6 @@ use App\Contact;
 use App\Jobs\ContactPipeline\ContactPipeline;
 use App\Rules\MaxMultiLine;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Auth;
 
 class ContactController extends Controller
 {
@@ -20,7 +19,7 @@ class ContactController extends Controller
     public function store(Request $request)
     {
         abort_if(! config('instance.contact.enabled'), 404);
-        abort_if(! Auth::check(), 403);
+        abort_if(! $request->user(), 403);
 
         $this->validate($request, [
             'message' => ['required', 'string', 'min:5', new MaxMultiLine('500')],
@@ -29,7 +28,7 @@ class ContactController extends Controller
 
         $message = $request->input('message');
         $request_response = $request->input('request_response') == 'on' ? true : false;
-        $user = Auth::user();
+        $user = $request->user();
 
         $max = config('instance.contact.max_per_day');
         $contact = Contact::whereUserId($user->id)

--- a/app/Http/Controllers/DiscoverController.php
+++ b/app/Http/Controllers/DiscoverController.php
@@ -21,7 +21,6 @@ use App\Services\TrendingHashtagService;
 use App\Services\UserFilterService;
 use App\Status;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 
@@ -29,7 +28,7 @@ class DiscoverController extends Controller
 {
     public function home(Request $request)
     {
-        abort_if(! Auth::check() && config('instance.discover.public') == false, 403);
+        abort_if(! $request->user() && config('instance.discover.public') == false, 403);
 
         return view('discover.home');
     }
@@ -39,7 +38,7 @@ class DiscoverController extends Controller
         if ($request->user()) {
             return redirect('/i/web/hashtag/'.$hashtag.'?src=pd');
         }
-        abort_if(! config('instance.discover.tags.is_public') && ! Auth::check(), 403);
+        abort_if(! config('instance.discover.tags.is_public') && ! $request->user(), 403);
 
         $tag = Hashtag::whereName($hashtag)
             ->orWhere('slug', $hashtag)
@@ -180,7 +179,7 @@ class DiscoverController extends Controller
                 ->pluck('id');
         });
 
-        $filtered = Auth::check() ? UserFilterService::filters(Auth::user()->profile_id) : [];
+        $filtered = $request->user() !== null ? UserFilterService::filters($request->user()->profile_id) : [];
 
         $res = $ids->map(function ($s) {
             return StatusService::get($s);

--- a/app/Http/Controllers/HashtagFollowController.php
+++ b/app/Http/Controllers/HashtagFollowController.php
@@ -21,7 +21,7 @@ class HashtagFollowController extends Controller
             'name' => 'required|alpha_num|min:1|max:124|exists:hashtags,name',
         ]);
 
-        $user = Auth::user();
+        $user = $request->user();
         $profile = $user->profile;
         $tag = $request->input('name');
 

--- a/app/Http/Controllers/Import/Instagram.php
+++ b/app/Http/Controllers/Import/Instagram.php
@@ -6,7 +6,6 @@ use App\ImportData;
 use App\ImportJob;
 use App\Jobs\ImportPipeline\ImportInstagram;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
@@ -27,7 +26,7 @@ trait Instagram
         if ((bool) config_cache('pixelfed.import.instagram.enabled') != true) {
             abort(404, 'Feature not enabled');
         }
-        $completed = ImportJob::whereProfileId(Auth::user()->profile->id)
+        $completed = ImportJob::whereProfileId($request->user()->profile->id)
             ->whereService('instagram')
             ->whereNotNull('completed_at')
             ->exists();
@@ -44,7 +43,7 @@ trait Instagram
         if ((bool) config_cache('pixelfed.import.instagram.enabled') != true) {
             abort(404, 'Feature not enabled');
         }
-        $profile = Auth::user()->profile;
+        $profile = request()->user()->profile;
         $exists = ImportJob::whereProfileId($profile->id)
             ->whereService('instagram')
             ->whereNull('completed_at')
@@ -71,7 +70,7 @@ trait Instagram
         if ((bool) config_cache('pixelfed.import.instagram.enabled') != true) {
             abort(404, 'Feature not enabled');
         }
-        $profile = Auth::user()->profile;
+        $profile = $request->user()->profile;
         $job = ImportJob::whereProfileId($profile->id)
             ->whereNull('completed_at')
             ->whereUuid($uuid)
@@ -93,7 +92,7 @@ trait Instagram
         ]);
         $media = $request->file('media');
 
-        $profile = Auth::user()->profile;
+        $profile = $request->user()->profile;
         $job = ImportJob::whereProfileId($profile->id)
             ->whereNull('completed_at')
             ->whereUuid($uuid)
@@ -132,7 +131,7 @@ trait Instagram
         if ((bool) config_cache('pixelfed.import.instagram.enabled') != true) {
             abort(404, 'Feature not enabled');
         }
-        $profile = Auth::user()->profile;
+        $profile = $request->user()->profile;
         $job = ImportJob::whereProfileId($profile->id)
             ->whereNull('completed_at')
             ->whereUuid($uuid)
@@ -150,7 +149,7 @@ trait Instagram
         $this->validate($request, [
             'media' => 'required|file|max:1000',
         ]);
-        $profile = Auth::user()->profile;
+        $profile = $request->user()->profile;
         $job = ImportJob::whereProfileId($profile->id)
             ->whereNull('completed_at')
             ->whereUuid($uuid)
@@ -176,7 +175,7 @@ trait Instagram
         if ((bool) config_cache('pixelfed.import.instagram.enabled') != true) {
             abort(404, 'Feature not enabled');
         }
-        $profile = Auth::user()->profile;
+        $profile = $request->user()->profile;
         $job = ImportJob::whereProfileId($profile->id)
             ->whereService('instagram')
             ->whereNull('completed_at')
@@ -192,7 +191,7 @@ trait Instagram
         if ((bool) config_cache('pixelfed.import.instagram.enabled') != true) {
             abort(404, 'Feature not enabled');
         }
-        $profile = Auth::user()->profile;
+        $profile = $request->user()->profile;
 
         try {
             $import = ImportJob::whereProfileId($profile->id)

--- a/app/Http/Controllers/InternalApiController.php
+++ b/app/Http/Controllers/InternalApiController.php
@@ -20,7 +20,6 @@ use App\Status; // StatusMediaContainerTransformer,
 use App\Transformer\Api\StatusTransformer;
 use App\User;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Redis;
 use Illuminate\Validation\Rule;
@@ -69,7 +68,7 @@ class InternalApiController extends Controller
 
     public function directMessage(Request $request, $profileId, $threadId)
     {
-        $profile = Auth::user()->profile;
+        $profile = $request->user()->profile;
 
         if ($profileId != $profile->id) {
             abort(403);
@@ -134,7 +133,7 @@ class InternalApiController extends Controller
 
     public function modAction(Request $request)
     {
-        abort_unless(Auth::user()->is_admin, 400);
+        abort_unless($request->user()->is_admin, 400);
         $this->validate($request, [
             'action' => [
                 'required',
@@ -167,7 +166,7 @@ class InternalApiController extends Controller
                 $status->is_nsfw = true;
                 $status->save();
                 ModLogService::boot()
-                    ->user(Auth::user())
+                    ->user($request->user())
                     ->objectUid($status->profile->user_id)
                     ->objectId($status->id)
                     ->objectType('App\Status::class')
@@ -212,7 +211,7 @@ class InternalApiController extends Controller
                 $status->is_nsfw = false;
                 $status->save();
                 ModLogService::boot()
-                    ->user(Auth::user())
+                    ->user($request->user())
                     ->objectUid($status->profile->user_id)
                     ->objectId($status->id)
                     ->objectType('App\Status::class')
@@ -238,7 +237,7 @@ class InternalApiController extends Controller
                 $status->save();
                 PublicTimelineService::del($status->id);
                 ModLogService::boot()
-                    ->user(Auth::user())
+                    ->user($request->user())
                     ->objectUid($status->profile->user_id)
                     ->objectId($status->id)
                     ->objectType('App\Status::class')
@@ -282,7 +281,7 @@ class InternalApiController extends Controller
             case 'spammer':
                 HandleSpammerPipeline::dispatch($status->profile);
                 ModLogService::boot()
-                    ->user(Auth::user())
+                    ->user($request->user())
                     ->objectUid($status->profile->user_id)
                     ->objectId($status->id)
                     ->objectType('App\User::class')
@@ -355,10 +354,10 @@ class InternalApiController extends Controller
             ['photo', 'photo:album', 'video', 'video:album', 'share', 'reply'];
 
         if ($profile->is_private) {
-            if (! Auth::check()) {
+            if (! $request->user()) {
                 return response()->json([]);
             }
-            $pid = Auth::user()->profile->id;
+            $pid = $request->user()->profile->id;
             $following = Cache::remember('profile:following:'.$pid, now()->addMinutes(1440), function () use ($pid) {
                 $following = Follower::whereProfileId($pid)->pluck('following_id');
 
@@ -366,8 +365,8 @@ class InternalApiController extends Controller
             });
             $visibility = in_array($profile->id, $following) == true ? ['public', 'unlisted', 'private'] : [];
         } else {
-            if (Auth::check()) {
-                $pid = Auth::user()->profile->id;
+            if ($request->user() !== null) {
+                $pid = $request->user()->profile->id;
                 $following = Cache::remember('profile:following:'.$pid, now()->addMinutes(1440), function () use ($pid) {
                     $following = Follower::whereProfileId($pid)->pluck('following_id');
 

--- a/app/Http/Controllers/MicroController.php
+++ b/app/Http/Controllers/MicroController.php
@@ -5,7 +5,6 @@ namespace App\Http\Controllers;
 use App\Status;
 use App\Transformer\Api\StatusTransformer;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Validation\Rule;
 use League\Fractal\Manager;
@@ -40,7 +39,7 @@ class MicroController extends Controller
                 ]),
             ],
         ]);
-        $profile = Auth::user()->profile;
+        $profile = $request->user()->profile;
         $title = $request->input('title');
         $content = $request->input('content');
         $visibility = $request->input('visibility');

--- a/app/Http/Controllers/NewsroomController.php
+++ b/app/Http/Controllers/NewsroomController.php
@@ -4,7 +4,6 @@ namespace App\Http\Controllers;
 
 use App\Newsroom;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Redis;
 use Illuminate\Support\Str;
 
@@ -12,7 +11,7 @@ class NewsroomController extends Controller
 {
     public function index(Request $request)
     {
-        if (Auth::check()) {
+        if ($request->user() !== null) {
             $posts = Newsroom::whereNotNull('published_at')->latest()->paginate(9);
         } else {
             $posts = Newsroom::whereNotNull('published_at')
@@ -53,7 +52,7 @@ class NewsroomController extends Controller
 
     public function timelineApi(Request $request)
     {
-        abort_if(! Auth::check(), 404);
+        abort_if(! $request->user(), 404);
 
         $key = 'newsroom:read:profileid:'.$request->user()->profile_id;
         $read = Redis::smembers($key);
@@ -79,7 +78,7 @@ class NewsroomController extends Controller
 
     public function markAsRead(Request $request)
     {
-        abort_if(! Auth::check(), 404);
+        abort_if(! $request->user(), 404);
 
         $this->validate($request, [
             'id' => 'required|integer|min:1',

--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -66,7 +66,7 @@ class ProfileController extends Controller
     {
         $carousel = (bool) $request->filled('carousel');
         $username = $user->username;
-        $loggedIn = Auth::check();
+        $loggedIn = $request->user() !== null;
         $isPrivate = false;
         $isBlocked = false;
         if (! $loggedIn) {
@@ -117,10 +117,10 @@ class ProfileController extends Controller
             $isBlocked = $this->blockedProfileCheck($user);
 
             $owner = $loggedIn && Auth::id() === $user->user_id;
-            $is_following = ($owner == false && Auth::check()) ? $user->followedBy(Auth::user()->profile) : false;
+            $is_following = ($owner == false && $request->user() !== null) ? $user->followedBy($request->user()->profile) : false;
 
             if ($isPrivate == true || $isBlocked == true) {
-                $requested = Auth::check() ? FollowRequest::whereFollowerId(Auth::user()->profile_id)
+                $requested = $request->user() !== null ? FollowRequest::whereFollowerId($request->user()->profile_id)
                     ->whereFollowingId($user->id)
                     ->exists() : false;
 
@@ -187,11 +187,11 @@ class ProfileController extends Controller
 
     protected function privateProfileCheck(Profile $profile, $loggedIn)
     {
-        if (! Auth::check()) {
+        if (! request()->user()) {
             return true;
         }
 
-        $user = Auth::user()->profile;
+        $user = request()->user()->profile;
         if ($user->id == $profile->id || ! $profile->is_private) {
             return false;
         }
@@ -221,7 +221,7 @@ class ProfileController extends Controller
 
     protected function blockedProfileCheck(Profile $profile)
     {
-        $pid = Auth::user()->profile->id;
+        $pid = request()->user()->profile->id;
         $blocks = UserFilter::whereUserId($profile->id)
             ->whereFilterType('block')
             ->whereFilterableType(Profile::class)
@@ -330,11 +330,11 @@ class ProfileController extends Controller
             ->withHeaders($data['headers']);
     }
 
-    public function meRedirect()
+    public function meRedirect(Request $request)
     {
-        abort_if(! Auth::check(), 404);
+        abort_if(! $request->user(), 404);
 
-        return redirect(Auth::user()->url());
+        return redirect($request->user()->url());
     }
 
     public function embed(Request $request, $username)
@@ -383,7 +383,7 @@ class ProfileController extends Controller
         abort_if(! (bool) config_cache('instance.stories.enabled') || ! $request->user(), 404);
         $profile = Profile::whereNull('domain')->whereUsername($username)->firstOrFail();
         $pid = $profile->id;
-        $authed = Auth::user()->profile_id;
+        $authed = $request->user()->profile_id;
         abort_if($pid != $authed && ! FollowerService::follows($authed, $pid), 404);
         $exists = Story::whereProfileId($pid)
             ->whereActive(true)

--- a/app/Http/Controllers/PublicApiController.php
+++ b/app/Http/Controllers/PublicApiController.php
@@ -19,7 +19,6 @@ use App\Services\UserFilterService;
 use App\Status;
 use App\Transformer\Api\StatusStatelessTransformer;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Cache;
 use League\Fractal;
 use League\Fractal\Pagination\IlluminatePaginatorAdapter;
@@ -93,7 +92,7 @@ class PublicApiController extends Controller
         $profile = Profile::whereUsername($username)->whereNull('status')->firstOrFail();
         $status = Status::whereProfileId($profile->id)->findOrFail($postid);
         $this->scopeCheck($profile, $status);
-        if (! Auth::check()) {
+        if (! $request->user()) {
             $res = [
                 'user' => [],
                 'likes' => [],
@@ -134,8 +133,8 @@ class PublicApiController extends Controller
         $status = Status::whereProfileId($profile->id)->whereCommentsDisabled(false)->findOrFail($postId);
         $this->scopeCheck($profile, $status);
 
-        if (Auth::check()) {
-            $p = Auth::user()->profile;
+        if ($request->user() !== null) {
+            $p = $request->user()->profile;
             $scope = $p->id == $status->profile_id || FollowerService::follows($p->id, $profile->id) ? ['public', 'private', 'unlisted'] : ['public', 'unlisted'];
         } else {
             $scope = ['public', 'unlisted'];
@@ -178,7 +177,7 @@ class PublicApiController extends Controller
 
     protected function scopeCheck(Profile $profile, Status $status)
     {
-        if ($profile->is_private == true && Auth::check() == false) {
+        if ($profile->is_private == true && ! request()->user()) {
             abort(404);
         }
 
@@ -187,7 +186,7 @@ class PublicApiController extends Controller
             case 'unlisted':
                 break;
             case 'private':
-                $user = Auth::check() ? Auth::user() : false;
+                $user = request()->user() !== null ? request()->user() : false;
                 if (! $user) {
                     abort(403);
                 } else {
@@ -634,7 +633,7 @@ class PublicApiController extends Controller
 
     public function relationships(Request $request)
     {
-        if (! Auth::check()) {
+        if (! $request->user()) {
             return response()->json([]);
         }
 

--- a/app/Http/Controllers/ReportController.php
+++ b/app/Http/Controllers/ReportController.php
@@ -116,7 +116,7 @@ class ReportController extends Controller
             'msg' => 'nullable|string|max:150',
         ]);
 
-        $profile = Auth::user()->profile;
+        $profile = $request->user()->profile;
         $reportType = $request->input('report');
         $object_id = $request->input('id');
         $object_type = $request->input('type');

--- a/app/Http/Controllers/Settings/ExportSettings.php
+++ b/app/Http/Controllers/Settings/ExportSettings.php
@@ -29,9 +29,9 @@ trait ExportSettings
         return view('settings.dataexport');
     }
 
-    public function exportAccount()
+    public function exportAccount(Request $request)
     {
-        $profile = Auth::user()->profile;
+        $profile = $request->user()->profile;
         $fractal = new Fractal\Manager;
         $fractal->setSerializer(new ArraySerializer);
         $resource = new Fractal\Resource\Item($profile, new ProfileTransformer);
@@ -45,9 +45,9 @@ trait ExportSettings
         ]);
     }
 
-    public function exportFollowing()
+    public function exportFollowing(Request $request)
     {
-        $profile = Auth::user()->profile;
+        $profile = $request->user()->profile;
         $userId = Auth::id();
 
         $userExportPath = 'user_exports/'.$userId;
@@ -109,9 +109,9 @@ trait ExportSettings
         }
     }
 
-    public function exportFollowers()
+    public function exportFollowers(Request $request)
     {
-        $profile = Auth::user()->profile;
+        $profile = $request->user()->profile;
         $userId = Auth::id();
 
         $userExportPath = 'user_exports/'.$userId;
@@ -173,16 +173,16 @@ trait ExportSettings
         }
     }
 
-    public function exportMuteBlockList()
+    public function exportMuteBlockList(Request $request)
     {
-        $profile = Auth::user()->profile;
+        $profile = $request->user()->profile;
         $exists = UserFilter::select('id')
             ->whereUserId($profile->id)
             ->exists();
         if (! $exists) {
             return redirect()->back();
         }
-        $data = Cache::remember('account:export:profile:muteblocklist:'.Auth::user()->profile->id, now()->addMinutes(60), function () use ($profile) {
+        $data = Cache::remember('account:export:profile:muteblocklist:'.$request->user()->profile->id, now()->addMinutes(60), function () use ($profile) {
             return json_encode([
                 'muted' => $profile->mutedProfileUrls(),
                 'blocked' => $profile->blockedProfileUrls(),
@@ -198,7 +198,7 @@ trait ExportSettings
 
     public function exportStatuses(Request $request)
     {
-        $profile = Auth::user()->profile;
+        $profile = $request->user()->profile;
         $userId = Auth::id();
         $userExportPath = self::STORAGE_BASE.'/'.$userId;
         $filename = 'pixelfed-statuses.json';

--- a/app/Http/Controllers/Settings/HomeSettings.php
+++ b/app/Http/Controllers/Settings/HomeSettings.php
@@ -20,9 +20,9 @@ use Purify;
 
 trait HomeSettings
 {
-    public function home()
+    public function home(Request $request)
     {
-        $id = Auth::user()->profile_id;
+        $id = $request->user()->profile_id;
         $storage = [];
         $used = Media::whereProfileId($id)->sum('size');
         $storage['limit'] = config_cache('pixelfed.max_account_size') * 1024;
@@ -50,7 +50,7 @@ trait HomeSettings
         $bio = $request->filled('bio') ? strip_tags(Purify::clean($request->input('bio'))) : null;
         $website = $request->input('website');
         $language = $request->input('language');
-        $user = Auth::user();
+        $user = $request->user();
         $profile = $user->profile;
         $pronouns = $request->input('pronouns');
         $existingPronouns = PronounService::get($profile->id);
@@ -176,7 +176,7 @@ trait HomeSettings
         ]);
         $changes = false;
         $email = $request->input('email');
-        $user = Auth::user();
+        $user = $request->user();
         $profile = $user->profile;
 
         $validate = config_cache('pixelfed.enforce_email_verification');

--- a/app/Http/Controllers/Settings/PrivacySettings.php
+++ b/app/Http/Controllers/Settings/PrivacySettings.php
@@ -9,15 +9,14 @@ use App\Services\AccountService;
 use App\Services\RelationshipService;
 use App\UserFilter;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 
 trait PrivacySettings
 {
-    public function privacy()
+    public function privacy(Request $request)
     {
-        $user = Auth::user();
+        $user = $request->user();
         $settings = $user->settings;
         $profile = $user->profile;
         $is_private = $profile->is_private;
@@ -115,9 +114,9 @@ trait PrivacySettings
         return redirect(route('settings.privacy'))->with('status', 'Settings successfully updated!');
     }
 
-    public function mutedUsers()
+    public function mutedUsers(Request $request)
     {
-        $pid = Auth::user()->profile->id;
+        $pid = $request->user()->profile->id;
         $ids = (new UserFilter)->mutedUserIds($pid);
         $users = Profile::whereIn('id', $ids)->simplePaginate(15);
 
@@ -130,7 +129,7 @@ trait PrivacySettings
             'profile_id' => 'required|integer|min:1',
         ]);
         $fid = $request->input('profile_id');
-        $pid = Auth::user()->profile->id;
+        $pid = $request->user()->profile->id;
         DB::transaction(function () use ($fid, $pid) {
             $filter = UserFilter::whereUserId($pid)
                 ->whereFilterableId($fid)
@@ -144,9 +143,9 @@ trait PrivacySettings
         return redirect()->back();
     }
 
-    public function blockedUsers()
+    public function blockedUsers(Request $request)
     {
-        $pid = Auth::user()->profile->id;
+        $pid = $request->user()->profile->id;
         $ids = (new UserFilter)->blockedUserIds($pid);
         $users = Profile::whereIn('id', $ids)->simplePaginate(15);
 
@@ -159,7 +158,7 @@ trait PrivacySettings
             'profile_id' => 'required|integer|min:1',
         ]);
         $fid = $request->input('profile_id');
-        $pid = Auth::user()->profile->id;
+        $pid = $request->user()->profile->id;
         DB::transaction(function () use ($fid, $pid) {
             $filter = UserFilter::whereUserId($pid)
                 ->whereFilterableId($fid)
@@ -211,8 +210,8 @@ trait PrivacySettings
         $duration = $request->input('duration');
         // $newRequests = $request->input('newrequests');
 
-        $profile = Auth::user()->profile;
-        $settings = Auth::user()->settings;
+        $profile = $request->user()->profile;
+        $settings = $request->user()->settings;
 
         if ($mode !== 'keep-all') {
             switch ($mode) {

--- a/app/Http/Controllers/Settings/RelationshipSettings.php
+++ b/app/Http/Controllers/Settings/RelationshipSettings.php
@@ -3,7 +3,6 @@
 namespace App\Http\Controllers\Settings;
 
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Auth;
 
 trait RelationshipSettings
 {
@@ -14,7 +13,7 @@ trait RelationshipSettings
         ]);
 
         $mode = $request->input('mode') ?? 'followers';
-        $profile = Auth::user()->profile;
+        $profile = $request->user()->profile;
 
         switch ($mode) {
             case 'following':

--- a/app/Http/Controllers/Settings/SecuritySettings.php
+++ b/app/Http/Controllers/Settings/SecuritySettings.php
@@ -10,15 +10,14 @@ use BaconQrCode\Renderer\RendererStyle\RendererStyle;
 use BaconQrCode\Writer;
 use Carbon\Carbon;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Str;
 use PragmaRX\Google2FA\Google2FA;
 
 trait SecuritySettings
 {
-    public function security()
+    public function security(Request $request)
     {
-        $user = Auth::user();
+        $user = $request->user();
 
         $activity = AccountLog::whereUserId($user->id)
             ->orderBy('created_at', 'desc')
@@ -35,7 +34,7 @@ trait SecuritySettings
 
     public function securityTwoFactorSetup(Request $request)
     {
-        $user = Auth::user();
+        $user = $request->user();
         if ($user->{'2fa_enabled'} && $user->{'2fa_secret'}) {
             return redirect(route('account.security'));
         }
@@ -77,7 +76,7 @@ trait SecuritySettings
 
     public function securityTwoFactorSetupStore(Request $request)
     {
-        $user = Auth::user();
+        $user = $request->user();
         if ($user->{'2fa_enabled'} && $user->{'2fa_secret'}) {
             abort(403, 'Two factor auth is already setup.');
         }
@@ -100,7 +99,7 @@ trait SecuritySettings
 
     public function securityTwoFactorEdit(Request $request)
     {
-        $user = Auth::user();
+        $user = $request->user();
 
         if (! $user->{'2fa_enabled'} || ! $user->{'2fa_secret'}) {
             abort(403);
@@ -111,7 +110,7 @@ trait SecuritySettings
 
     public function securityTwoFactorRecoveryCodes(Request $request)
     {
-        $user = Auth::user();
+        $user = $request->user();
 
         if (! $user->{'2fa_enabled'} || ! $user->{'2fa_secret'} || ! $user->{'2fa_backup_codes'}) {
             abort(403);
@@ -123,7 +122,7 @@ trait SecuritySettings
 
     public function securityTwoFactorRecoveryCodesRegenerate(Request $request)
     {
-        $user = Auth::user();
+        $user = $request->user();
 
         if (! $user->{'2fa_enabled'} || ! $user->{'2fa_secret'}) {
             abort(403);
@@ -137,7 +136,7 @@ trait SecuritySettings
 
     public function securityTwoFactorUpdate(Request $request)
     {
-        $user = Auth::user();
+        $user = $request->user();
 
         if (! $user->{'2fa_enabled'} || ! $user->{'2fa_secret'} || ! $user->{'2fa_backup_codes'}) {
             abort(403);

--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -37,9 +37,9 @@ class SettingsController extends Controller
         $this->middleware('auth');
     }
 
-    public function accessibility()
+    public function accessibility(Request $request)
     {
-        $settings = Auth::user()->settings;
+        $settings = $request->user()->settings;
 
         return view('settings.accessibility', compact('settings'));
     }
@@ -96,7 +96,7 @@ class SettingsController extends Controller
 
     public function removeAccountTemporary(Request $request)
     {
-        $user = Auth::user();
+        $user = $request->user();
         abort_if(! config('pixelfed.account_deletion'), 403);
         abort_if($user->is_admin, 403);
 
@@ -105,7 +105,7 @@ class SettingsController extends Controller
 
     public function removeAccountTemporarySubmit(Request $request)
     {
-        $user = Auth::user();
+        $user = $request->user();
         abort_if(! config('pixelfed.account_deletion'), 403);
         abort_if($user->is_admin, 403);
         $profile = $user->profile;
@@ -121,7 +121,7 @@ class SettingsController extends Controller
 
     public function removeAccountPermanent(Request $request)
     {
-        $user = Auth::user();
+        $user = $request->user();
         abort_if($user->is_admin, 403);
 
         return view('settings.remove.permanent');
@@ -132,7 +132,7 @@ class SettingsController extends Controller
         if (config('pixelfed.account_deletion') == false) {
             abort(404);
         }
-        $user = Auth::user();
+        $user = $request->user();
         abort_if(! config('pixelfed.account_deletion'), 403);
         abort_if($user->is_admin, 403);
 
@@ -163,7 +163,7 @@ class SettingsController extends Controller
 
     public function requestFullExport(Request $request)
     {
-        $user = Auth::user();
+        $user = $request->user();
 
         return view('settings.export.show');
     }
@@ -185,14 +185,14 @@ class SettingsController extends Controller
         return response()->json([200])->cookie($cookie);
     }
 
-    public function sponsor()
+    public function sponsor(Request $request)
     {
         $default = [
             'patreon' => null,
             'liberapay' => null,
             'opencollective' => null,
         ];
-        $sponsors = ProfileSponsor::whereProfileId(Auth::user()->profile->id)->first();
+        $sponsors = ProfileSponsor::whereProfileId($request->user()->profile->id)->first();
         $sponsors = $sponsors ? json_decode($sponsors->sponsors, true) : $default;
 
         return view('settings.sponsor', compact('sponsors'));
@@ -233,7 +233,7 @@ class SettingsController extends Controller
         ];
 
         $sponsors = ProfileSponsor::firstOrCreate([
-            'profile_id' => Auth::user()->profile_id ?? Auth::user()->profile->id,
+            'profile_id' => $request->user()->profile_id ?? $request->user()->profile->id,
         ]);
         $sponsors->sponsors = json_encode($res);
         $sponsors->save();

--- a/app/Http/Controllers/SiteController.php
+++ b/app/Http/Controllers/SiteController.php
@@ -10,7 +10,6 @@ use App\User;
 use App\Util\ActivityPub\Helpers;
 use App\Util\Localization\Localization;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\View;
 use Illuminate\Support\Str;
@@ -19,7 +18,7 @@ class SiteController extends Controller
 {
     public function home(Request $request)
     {
-        if (Auth::check()) {
+        if ($request->user() !== null) {
             return $this->homeTimeline($request);
         } else {
             return $this->homeGuest();

--- a/app/Http/Controllers/StatusController.php
+++ b/app/Http/Controllers/StatusController.php
@@ -18,7 +18,6 @@ use App\Transformer\ActivityPub\Verb\Note;
 use App\Transformer\ActivityPub\Verb\Question;
 use App\Util\Media\License;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 use League\Fractal;
@@ -221,10 +220,10 @@ class StatusController extends Controller
         abort_if($status->uri, 404);
 
         if ($status->visibility == 'private' || $user->is_private) {
-            if (! Auth::check()) {
+            if (! $request->user()) {
                 abort(403);
             }
-            $pid = Auth::user()->profile;
+            $pid = $request->user()->profile;
             if ($user->followedBy($pid) == false && $user->id !== $pid->id) {
                 abort(403);
             }
@@ -252,7 +251,7 @@ class StatusController extends Controller
 
         $status = Status::findOrFail($request->input('item'));
 
-        $user = Auth::user();
+        $user = $request->user();
 
         if (
             $status->profile_id != $user->profile->id &&
@@ -321,7 +320,7 @@ class StatusController extends Controller
             'item' => 'required|integer|min:1',
         ]);
 
-        $user = Auth::user();
+        $user = $request->user();
         $profile = $user->profile;
         $status = Status::whereScope('public')
             ->findOrFail($request->input('item'));
@@ -330,11 +329,11 @@ class StatusController extends Controller
 
         $count = $status->reblogs_count;
         $defaultCaption = config_cache('database.default') === 'mysql' ? null : '';
-        $exists = Status::whereProfileId(Auth::user()->profile->id)
+        $exists = Status::whereProfileId($request->user()->profile->id)
             ->whereReblogOfId($status->id)
             ->exists();
         if ($exists == true) {
-            $shares = Status::whereProfileId(Auth::user()->profile->id)
+            $shares = Status::whereProfileId($request->user()->profile->id)
                 ->whereReblogOfId($status->id)
                 ->get();
             foreach ($shares as $share) {
@@ -386,7 +385,7 @@ class StatusController extends Controller
     public function edit(Request $request, $username, $id)
     {
         $this->authCheck();
-        $user = Auth::user()->profile;
+        $user = $request->user()->profile;
         $status = Status::whereProfileId($user->id)
             ->with(['media'])
             ->findOrFail($id);
@@ -398,7 +397,7 @@ class StatusController extends Controller
     public function editStore(Request $request, $username, $id)
     {
         $this->authCheck();
-        $user = Auth::user()->profile;
+        $user = $request->user()->profile;
         $status = Status::whereProfileId($user->id)
             ->with(['media'])
             ->findOrFail($id);
@@ -420,7 +419,7 @@ class StatusController extends Controller
 
     protected function authCheck()
     {
-        if (Auth::check() == false) {
+        if (! request()->user()) {
             abort(403);
         }
     }
@@ -479,7 +478,7 @@ class StatusController extends Controller
             'disableComments' => 'required|boolean',
         ]);
 
-        $user = Auth::user();
+        $user = $request->user();
         $id = $request->input('item');
         $state = $request->input('disableComments');
 

--- a/app/Http/Controllers/TimelineController.php
+++ b/app/Http/Controllers/TimelineController.php
@@ -7,7 +7,6 @@ use App\Status;
 use App\Transformer\Api\StatusTimelineTransformer;
 use App\UserFilter;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Cache;
 use League\Fractal;
 use League\Fractal\Serializer\ArraySerializer;
@@ -54,7 +53,7 @@ class TimelineController extends Controller
             'limit' => 'nullable|integer|max:30',
         ]);
 
-        if (config('instance.timeline.local.is_public') == false && ! Auth::check()) {
+        if (config('instance.timeline.local.is_public') == false && ! $request->user()) {
             abort(403, 'Authentication required.');
         }
 

--- a/app/Http/Controllers/UserInviteController.php
+++ b/app/Http/Controllers/UserInviteController.php
@@ -16,7 +16,7 @@ class UserInviteController extends Controller
     public function create(Request $request)
     {
         abort_if(! config('pixelfed.user_invites.enabled'), 404);
-        abort_unless(Auth::check(), 403);
+        abort_unless($request->user() !== null, 403);
 
         return view('settings.invites.create');
     }
@@ -24,7 +24,7 @@ class UserInviteController extends Controller
     public function show(Request $request)
     {
         abort_if(! config('pixelfed.user_invites.enabled'), 404);
-        abort_unless(Auth::check(), 403);
+        abort_unless($request->user() !== null, 403);
         $invites = UserInvite::whereUserId(Auth::id())->paginate(10);
         $limit = config('pixelfed.user_invites.limit.total');
         $used = UserInvite::whereUserId(Auth::id())->count();
@@ -35,7 +35,7 @@ class UserInviteController extends Controller
     public function store(Request $request)
     {
         abort_if(! config('pixelfed.user_invites.enabled'), 404);
-        abort_unless(Auth::check(), 403);
+        abort_unless($request->user() !== null, 403);
         $this->validate($request, [
             'email' => 'required|email|unique:users|unique:user_invites',
             'message' => 'nullable|string|max:500',
@@ -53,7 +53,7 @@ class UserInviteController extends Controller
 
         $invite = new UserInvite;
         $invite->user_id = Auth::id();
-        $invite->profile_id = Auth::user()->profile_id;
+        $invite->profile_id = $request->user()->profile_id;
         $invite->email = $email;
         $invite->message = $request->input('message');
         $invite->key = Str::random(random_int(6, 9)).'_'.Str::random(random_int(14, 20)).'_'.Str::random(random_int(32, 64));

--- a/app/Http/Middleware/AccountInterstitial.php
+++ b/app/Http/Middleware/AccountInterstitial.php
@@ -4,7 +4,6 @@ namespace App\Http\Middleware;
 
 use Closure;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Auth;
 
 class AccountInterstitial
 {
@@ -29,7 +28,7 @@ class AccountInterstitial
             'site/kb/community-guidelines',
         ];
 
-        if (Auth::check() && ! $request->is($ar)) {
+        if ($request->user() !== null && ! $request->is($ar)) {
             if ($request->user()->has_interstitial) {
                 if ($request->wantsJson()) {
                     $res = ['_refresh' => true, 'error' => 403, 'message' => \App\AccountInterstitial::JSON_MESSAGE];

--- a/app/Http/Middleware/Admin.php
+++ b/app/Http/Middleware/Admin.php
@@ -4,7 +4,6 @@ namespace App\Http\Middleware;
 
 use Closure;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Auth;
 
 class Admin
 {
@@ -16,7 +15,7 @@ class Admin
      */
     public function handle($request, Closure $next)
     {
-        if (Auth::check() == false || Auth::user()->is_admin == false) {
+        if (! $request->user() || $request->user()->is_admin == false) {
             return redirect(config('app.url'));
         }
 

--- a/app/Http/Middleware/Api/Admin.php
+++ b/app/Http/Middleware/Api/Admin.php
@@ -4,7 +4,6 @@ namespace App\Http\Middleware\Api;
 
 use Closure;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Auth;
 
 class Admin
 {
@@ -16,7 +15,7 @@ class Admin
      */
     public function handle($request, Closure $next)
     {
-        if (Auth::check() == false || Auth::user()->is_admin == false) {
+        if (! $request->user() || $request->user()->is_admin == false) {
             return abort(403, 'You must be an administrator to do that');
         }
 

--- a/app/Http/Middleware/DangerZone.php
+++ b/app/Http/Middleware/DangerZone.php
@@ -29,7 +29,7 @@ class DangerZone
 
             return redirect(route('login'));
         }
-        if (! Auth::check()) {
+        if (! $request->user()) {
             return redirect(route('login'));
         }
         if (! $request->is('i/auth/sudo') && $request->session()->get('sudoTrustDevice') != 1) {


### PR DESCRIPTION
Replace Auth::user() with $request->user() and Auth::check() with $request->user() !== null (or ! $request->user()) across all controllers and middleware that have access to the request object.

This resolves 99 larastan.noAuthFacadeInRequestScope errors and improves Octane compatibility.

For protected helper methods without $request in scope, uses the request() helper instead.

Methods that previously lacked a Request parameter but used Auth facade now accept Request $request via Laravel's auto-injection.