### PR TITLE
feat: add global throttle:api middleware to the api route

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -97,7 +97,7 @@ class AppServiceProvider extends ServiceProvider
         }
 
         RateLimiter::for('api', function (Request $request) {
-            return Limit::perMinute(240)->by($request->user()?->id ?: $request->ip());
+            return Limit::perMinute(512)->by($request->user()?->id ?: $request->ip());
         });
 
         RateLimiter::for('app-signup', function (Request $request) {

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -96,6 +96,10 @@ class AppServiceProvider extends ServiceProvider
             });
         }
 
+        RateLimiter::for('api', function (Request $request) {
+            return Limit::perMinute(240)->by($request->user()?->id ?: $request->ip());
+        });
+
         RateLimiter::for('app-signup', function (Request $request) {
             return Limit::perDay(100)->by($request->ip());
         });

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -10,6 +10,7 @@ use App\Http\Middleware\RedirectIfAuthenticated;
 use App\Http\Middleware\RestrictedAccess;
 use App\Http\Middleware\TwoFactorAuth;
 use GuzzleHttp\Exception\ConnectException;
+use Illuminate\Auth\AuthenticationException;
 use Illuminate\Auth\Middleware\Authenticate;
 use Illuminate\Auth\Middleware\AuthenticateWithBasicAuth;
 use Illuminate\Auth\Middleware\Authorize;
@@ -100,6 +101,7 @@ return Application::configure(basePath: dirname(__DIR__))
         ]);
 
         $middleware->group('api', [
+            'throttle:api',
             'bindings',
         ]);
 
@@ -187,7 +189,7 @@ return Application::configure(basePath: dirname(__DIR__))
                     return $e->getResponse();
                 }
 
-                if ($e instanceof \Illuminate\Auth\AuthenticationException) {
+                if ($e instanceof AuthenticationException) {
                     return response()->json(
                         ['error' => $e->getMessage()],
                         401,


### PR DESCRIPTION
Adds a global rate limiter (512 req/min per user or IP) to all API routes.