### PR TITLE
fix: enable MySQL strict mode and remove defaultStringLength(191)

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -34,7 +34,6 @@ use Illuminate\Pagination\Paginator;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\RateLimiter;
-use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Facades\URL;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\ServiceProvider;
@@ -58,7 +57,6 @@ class AppServiceProvider extends ServiceProvider
         Passport::$clientUuids = false;
         Passport::authorizationView('auth.oauth.authorize');
 
-        Schema::defaultStringLength(191);
         Paginator::useBootstrap();
         Avatar::observe(AvatarObserver::class);
         Follower::observe(FollowerObserver::class);

--- a/config/database.php
+++ b/config/database.php
@@ -73,7 +73,7 @@ return [
             'collation' => env('DB_COLLATION', 'utf8mb4_unicode_ci'),
             'prefix' => '',
             'prefix_indexes' => true,
-            'strict' => env('DB_STRICT', true),
+            'strict' => true,
             'engine' => null,
             'options' => extension_loaded('pdo_mysql') ? array_filter([
                 (class_exists('Pdo\Mysql') ? Mysql::ATTR_SSL_CA : PDO::MYSQL_ATTR_SSL_CA) => env('MYSQL_ATTR_SSL_CA'),

--- a/config/database.php
+++ b/config/database.php
@@ -52,7 +52,7 @@ return [
             'charset' => 'utf8mb4',
             'collation' => 'utf8mb4_unicode_ci',
             'prefix' => '',
-            'strict' => true,
+            'strict' => env('DB_STRICT', true),
             'engine' => null,
             'dump' => [
                 'use_single_transaction',
@@ -73,7 +73,7 @@ return [
             'collation' => env('DB_COLLATION', 'utf8mb4_unicode_ci'),
             'prefix' => '',
             'prefix_indexes' => true,
-            'strict' => true,
+            'strict' => env('DB_STRICT', true),
             'engine' => null,
             'options' => extension_loaded('pdo_mysql') ? array_filter([
                 (class_exists('Pdo\Mysql') ? Mysql::ATTR_SSL_CA : PDO::MYSQL_ATTR_SSL_CA) => env('MYSQL_ATTR_SSL_CA'),

--- a/config/database.php
+++ b/config/database.php
@@ -52,7 +52,7 @@ return [
             'charset' => 'utf8mb4',
             'collation' => 'utf8mb4_unicode_ci',
             'prefix' => '',
-            'strict' => false,
+            'strict' => true,
             'engine' => null,
             'dump' => [
                 'use_single_transaction',

--- a/config/database.php
+++ b/config/database.php
@@ -73,7 +73,7 @@ return [
             'collation' => env('DB_COLLATION', 'utf8mb4_unicode_ci'),
             'prefix' => '',
             'prefix_indexes' => true,
-            'strict' => env('DB_STRICT', false),
+            'strict' => env('DB_STRICT', true),
             'engine' => null,
             'options' => extension_loaded('pdo_mysql') ? array_filter([
                 (class_exists('Pdo\Mysql') ? Mysql::ATTR_SSL_CA : PDO::MYSQL_ATTR_SSL_CA) => env('MYSQL_ATTR_SSL_CA'),

--- a/config/database.php
+++ b/config/database.php
@@ -52,7 +52,7 @@ return [
             'charset' => 'utf8mb4',
             'collation' => 'utf8mb4_unicode_ci',
             'prefix' => '',
-            'strict' => env('DB_STRICT', true),
+            'strict' => env('DB_STRICT', false),
             'engine' => null,
             'dump' => [
                 'use_single_transaction',
@@ -73,7 +73,7 @@ return [
             'collation' => env('DB_COLLATION', 'utf8mb4_unicode_ci'),
             'prefix' => '',
             'prefix_indexes' => true,
-            'strict' => env('DB_STRICT', true),
+            'strict' => env('DB_STRICT', false),
             'engine' => null,
             'options' => extension_loaded('pdo_mysql') ? array_filter([
                 (class_exists('Pdo\Mysql') ? Mysql::ATTR_SSL_CA : PDO::MYSQL_ATTR_SSL_CA) => env('MYSQL_ATTR_SSL_CA'),


### PR DESCRIPTION
- Enable strict mode for MySQL connection to prevent silent data truncation, zero-date insertion, and division-by-zero errors.
- Remove Schema::defaultStringLength(191) which was a MySQL 5.7 workaround no longer needed on MySQL 8.0+ / MariaDB 10.3+.