### PR TITLE
Fix VueIntersect single-element warning in notifications section

### DIFF
--- a/resources/assets/components/sections/Notifications.vue
+++ b/resources/assets/components/sections/Notifications.vue
@@ -167,10 +167,12 @@
 
 						<div v-else>
 							<intersect v-if="hasLoaded && canLoadMore" @enter="enterIntersect">
-								<placeholder small style="margin-top: -6px" />
-								<placeholder small/>
-								<placeholder small/>
-								<placeholder small/>
+								<div>
+									<placeholder small style="margin-top: -6px" />
+									<placeholder small/>
+									<placeholder small/>
+									<placeholder small/>
+								</div>
 							</intersect>
 
 							<div v-else class="d-block" style="height: 10px;">


### PR DESCRIPTION
fix error `[VueIntersect] You may only wrap one element in a <intersect> component.`