### PR TITLE
refactor: rename status debug commands to status: prefix

### DIFF
--- a/app/Console/Commands/StatusPost.php
+++ b/app/Console/Commands/StatusPost.php
@@ -10,14 +10,14 @@ use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 
-class PostStatus extends Command
+class StatusPost extends Command
 {
     /**
      * The name and signature of the console command.
      *
      * @var string
      */
-    protected $signature = 'post:status {id : Status id, or a post URL like https://host/p/username/ID}';
+    protected $signature = 'status:post {id : Status id, or a post URL like https://host/p/username/ID}';
 
     /**
      * The console command description.

--- a/app/Console/Commands/StatusProfile.php
+++ b/app/Console/Commands/StatusProfile.php
@@ -8,14 +8,14 @@ use App\Models\User;
 use Illuminate\Console\Command;
 use Illuminate\Support\Str;
 
-class ProfileStatus extends Command
+class StatusProfile extends Command
 {
     /**
      * The name and signature of the console command.
      *
      * @var string
      */
-    protected $signature = 'profile:status {id : Profile id, username, user@domain, @user@domain, webfinger, or remote_url}';
+    protected $signature = 'status:profile {id : Profile id, username, user@domain, @user@domain, webfinger, or remote_url}';
 
     /**
      * The console command description.
@@ -212,7 +212,7 @@ class ProfileStatus extends Command
             ['last_active_at', $this->format($user->last_active_at)],
         ];
         $this->table(['User Field', 'Value'], $rows);
-        $this->comment('Tip: run `user:status '.$user->username.'` for full auth diagnostics.');
+        $this->comment('Tip: run `status:user '.$user->username.'` for full auth diagnostics.');
     }
 
     protected function dumpInstance(Profile $profile): void

--- a/app/Console/Commands/StatusUser.php
+++ b/app/Console/Commands/StatusUser.php
@@ -9,14 +9,14 @@ use Illuminate\Console\Command;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
-class UserStatus extends Command
+class StatusUser extends Command
 {
     /**
      * The name and signature of the console command.
      *
      * @var string
      */
-    protected $signature = 'user:status {id : Username or numeric user id}
+    protected $signature = 'status:user {id : Username or numeric user id}
         {--logs=10 : Number of recent account log entries to show}';
 
     /**


### PR DESCRIPTION
Rename user:status, profile:status, and post:status console commands to status:user, status:profile, and status:post. Rename the command files and classes to match (StatusUser, StatusProfile, StatusPost) and update the cross-reference tip in StatusProfile.