### PR TITLE
chore: add composer psalm:report script for a full local txt report

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -102,6 +102,7 @@
         "analyse": "./vendor/bin/phpstan analyse --memory-limit=512M",
         "psalm": "./vendor/bin/psalm",
         "psalm:baseline": "./vendor/bin/psalm --update-baseline",
+        "psalm:report": "./vendor/bin/psalm --ignore-baseline --no-cache --show-info=true --report=psalm-report.txt --report-show-info=true",
         "test": [
             "docker compose -f docker-compose.test.yml up -d --wait",
             "./vendor/bin/pest --compact",


### PR DESCRIPTION
Adds a psalm:report script that ignores the baseline and writes a full human-readable report to psalm-report.txt, including informational issues, so all outstanding items to fix are surfaced in one file.