### PR TITLE
Add country filtering to location search

### DIFF
--- a/app/Http/Controllers/ComposeController.php
+++ b/app/Http/Controllers/ComposeController.php
@@ -346,7 +346,13 @@ class ComposeController extends Controller
         abort_if($request->user()->has_roles && ! UserRoleService::can('can-post', $request->user()->id), 403, 'Invalid permissions for this action');
         $pid = $request->user()->profile_id;
         abort_if(! $pid, 400);
-        $q = e($request->input('q'));
+
+        $raw = e($request->input('q'));
+
+        $country = null;
+        if (str_contains($raw, ',')) {
+            [$raw, $country] = array_map('trim', explode(',', $raw, 2));
+        }
 
         $popular = Cache::remember('pf:search:location:v1:popular', 1209600, function () {
             $minId = SnowflakeService::byDate(now()->subDays(290));
@@ -388,14 +394,20 @@ class ComposeController extends Controller
                     ];
                 });
         });
-        $q = '%'.$q.'%';
+        
         $wildcard = config('database.default') === 'pgsql' ? 'ilike' : 'like';
+        $q = '%'.$raw.'%';
 
-        $places = DB::table('places')
-            ->where('name', $wildcard, $q)
-            ->limit((strlen($q) > 5 ? 360 : 30))
+        $placesQuery = DB::table('places')->where('name', $wildcard, $q);
+
+        if ($country) {
+            $placesQuery->where('country', $wildcard, '%'.$country.'%');
+        }
+
+        $places = $placesQuery
+            ->limit((strlen($raw) > 5 ? 360 : 30))
             ->get()
-            ->sortByDesc(function ($place, $key) use ($popular) {
+            ->sortByDesc(function ($place) use ($popular) {
                 return $popular->filter(function ($p) use ($place) {
                     return $p['id'] == $place->id;
                 })->map(function ($p) use ($place) {

--- a/tests/Feature/ComposeControllerTest.php
+++ b/tests/Feature/ComposeControllerTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\DB;
+use Database\Factories\ProfileFactory;
+use App\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class ComposeControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function search_location_can_filter_by_country()
+    {
+        $user = User::factory()->create();
+
+        $profile = ProfileFactory::new()->create([
+            'user_id' => $user->id,
+        ]);
+
+        $user->update([
+            'profile_id' => $profile->id,
+        ]);
+
+        $user->refresh();
+
+        DB::table('places')->insert([
+            [
+                'id' => 1,
+                'slug' => 'san-francisco-usa',
+                'name' => 'San Francisco',
+                'state' => 'California',
+                'country' => 'USA',
+                'aliases' => null,
+                'lat' => 37.7749,
+                'long' => -122.4194,
+                'score' => 100,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+            [
+                'id' => 2,
+                'slug' => 'san-francisco-philippines',
+                'name' => 'San Francisco',
+                'state' => 'Cebu',
+                'country' => 'Philippines',
+                'aliases' => null,
+                'lat' => 10.3,
+                'long' => 123.9,
+                'score' => 50,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+        ]);
+
+        $response = $this->actingAs($user, 'api')
+            ->get('/api/v1.1/compose/search/location?q=San%20Francisco%2C%20USA');
+
+        $response->assertJsonCount(1);
+
+        $response->assertJsonFragment([
+            'name' => 'San Francisco',
+            'country' => 'USA',
+        ]);
+
+        $response->assertJsonMissing([
+            'country' => 'Philippines',
+        ]);
+    }
+}


### PR DESCRIPTION
## Why this PR is needed
As mentioned in #6893, when user adds a location when posting a photo, the search engine should support search by country to be more convenient.

## What this PR does
Implement filter by country in database query. 

## Testing
I added 3 cities to the local database and tested location search using the `City, Country` format.

[Screencast from 2026-08-29 16-37-30.webm](https://github.com/user-attachments/assets/6a1a7994-978b-4e6e-802b-8f1aeaeebb7a)

## Note
I am aware that the web UI is being replaced by the new frontend. However, this PR only modifies the backend location search API. Hope it will be still compatible with upcoming frontend implementation