### PR TITLE
fix: emoji admin URLs and cloud-migration guard

### DIFF
--- a/app/Console/Commands/Admin/EmojiMoveStorageLocalToCloud.php
+++ b/app/Console/Commands/Admin/EmojiMoveStorageLocalToCloud.php
@@ -36,7 +36,12 @@ class EmojiMoveStorageLocalToCloud extends Command
 
     public function handle(): int
     {
-        if (! (bool) config_cache('pixelfed.cloud_storage')) {
+        // Consider cloud enabled if either the live config or the (possibly
+        // 12h-cached) config_cache value says so, so a stale cache can't make
+        // this silently no-op right after cloud is turned on.
+        $cloudEnabled = (bool) config('pixelfed.cloud_storage') || (bool) config_cache('pixelfed.cloud_storage');
+
+        if (! $cloudEnabled) {
             $this->error('Cloud storage is not enabled (pixelfed.cloud_storage is false).');
 
             return self::FAILURE;

--- a/database/migrations/2026_08_30_050000_migrate_local_emoji_to_cloud.php
+++ b/database/migrations/2026_08_30_050000_migrate_local_emoji_to_cloud.php
@@ -15,7 +15,11 @@ return new class extends Migration
      */
     public function up(): void
     {
-        if (! (bool) config_cache('pixelfed.cloud_storage')) {
+        // Consider cloud enabled if either the live config or the (possibly
+        // cached) config_cache value says so; the command guards again anyway.
+        $cloudEnabled = (bool) config('pixelfed.cloud_storage') || (bool) config_cache('pixelfed.cloud_storage');
+
+        if (! $cloudEnabled) {
             return;
         }
 

--- a/resources/views/admin/custom-emoji/duplicates.blade.php
+++ b/resources/views/admin/custom-emoji/duplicates.blade.php
@@ -28,7 +28,7 @@
 			<div class="list-group">
 				<div class="list-group-item">
 					<div class="media align-items-center">
-						<img src="{{url('storage/' . $emoji->media_path)}}" width="40" height="40" class="mr-3">
+						<img src="{{ $emoji->url() }}" width="40" height="40" class="mr-3">
 
 						<div class="media-body">
 							<p class="font-weight-bold mb-0">{{ $emoji->shortcode }}</p>
@@ -62,7 +62,7 @@
 				@foreach($emojis as $emoji)
 				<div class="list-group-item">
 					<div class="media align-items-center">
-						<img src="{{url('storage/' . $emoji->media_path)}}" width="40" height="40" class="mr-3">
+						<img src="{{ $emoji->url() }}" width="40" height="40" class="mr-3">
 
 						<div class="media-body">
 							<p class="font-weight-bold mb-0">{{ $emoji->shortcode }}</p>

--- a/resources/views/admin/custom-emoji/home.blade.php
+++ b/resources/views/admin/custom-emoji/home.blade.php
@@ -105,7 +105,7 @@
 				@foreach($emojis as $emoji)
 				<div class="list-group-item">
 					<div class="media align-items-center">
-						<img src="{{url('storage/' . $emoji->media_path)}}" width="40" height="40" class="mr-3">
+						<img src="{{ $emoji->url() }}" width="40" height="40" class="mr-3">
 
 						<div class="media-body">
 							<p class="font-weight-bold mb-0">{{ $emoji->shortcode }}</p>


### PR DESCRIPTION
Two issues prevented emoji from serving/migrating correctly on cloud:

- Admin custom-emoji views hardcoded url('storage/'.media_path), so they always showed local URLs and bypassed cloud resolution. Use $emoji->url().
- The migration/command guard relied solely on config_cache('pixelfed.cloud_storage'), which is DB/12h-cached and can read stale-false right after cloud is enabled, causing the migration to silently no-op. Treat cloud as enabled when either live config() or config_cache() is true.