### PR TITLE
fix: skip missing.png in emoji cloud migration

### DIFF
--- a/app/Console/Commands/Admin/EmojiMoveStorageLocalToCloud.php
+++ b/app/Console/Commands/Admin/EmojiMoveStorageLocalToCloud.php
@@ -115,9 +115,12 @@ class EmojiMoveStorageLocalToCloud extends Command
         $bar->start();
 
         foreach ($files as $localPath) {
-            // Preserve dotfiles such as a directory .gitignore.
             $filename = basename($localPath);
-            if (str_starts_with($filename, '.')) {
+
+            // Preserve dotfiles such as a directory .gitignore, and the
+            // missing.png placeholder which the frontend hardcodes as a local
+            // /storage/emoji/missing.png onerror fallback (must stay local).
+            if (str_starts_with($filename, '.') || $filename === 'missing.png') {
                 $skipped++;
                 $bar->advance();
 


### PR DESCRIPTION
The frontend renders a hardcoded /storage/emoji/missing.png local onerror fallback for emoji, so that placeholder must stay on local disk. Skip it in the migration so it is never moved to cloud or deleted locally.