### PR TITLE
Drop the no-op pf_type assignment in the group topic feed

### DIFF
--- a/app/Http/Controllers/Groups/GroupsTopicController.php
+++ b/app/Http/Controllers/Groups/GroupsTopicController.php
@@ -107,7 +107,6 @@ class GroupsTopicController extends Controller
                 }
                 $status['favourited'] = (bool) GroupsLikeService::liked($pid, $gp['status_id']);
                 $status['favourites_count'] = GroupsLikeService::count($gp['status_id']);
-                $status['pf_type'] = $status['pf_type'];
                 $status['visibility'] = 'public';
 
                 return $status;


### PR DESCRIPTION
In `GroupsTopicController::showTopicFeedApi` the map callback sets `$status['pf_type'] = $status['pf_type'];`, which is a no-op. The commented-out version of the same block four lines above it reads `$status['pf_type'] = $gp['type'];`, so it looks like the line got half-rewritten when the block was brought back.

Nothing is missing though: `GroupPostService::get()` already does `$res['pf_type'] = $gp['type']` before returning, so the value is right either way and dropping the line keeps the response identical. The sibling assignments around it (`favourited`, `favourites_count`, `visibility`) do add something, which is why this one reads as if it did too.
