### PR TITLE
Query optimizations: avatar N+1, delete-job streaming, following-ids service

### DIFF
--- a/app/Http/Controllers/AccountController.php
+++ b/app/Http/Controllers/AccountController.php
@@ -400,10 +400,15 @@ class AccountController extends Controller
     public function followRequestsJson(Request $request): JsonResponse
     {
         $pid = $request->user()->profile_id;
-        $followers = FollowRequest::whereFollowingId($pid)->orderBy('id', 'desc')->whereIsRejected(0)->get();
+        $baseQuery = FollowRequest::whereFollowingId($pid)->whereIsRejected(0);
+        $followers = (clone $baseQuery)
+            ->with('actor.avatar')
+            ->orderBy('id', 'desc')
+            ->take(10)
+            ->get();
         $res = [
-            'count' => $followers->count(),
-            'accounts' => $followers->take(10)->map(function ($a) {
+            'count' => $baseQuery->count(),
+            'accounts' => $followers->map(function ($a) {
                 $actor = $a->actor;
 
                 return [

--- a/app/Http/Controllers/Api/ApiV1Controller.php
+++ b/app/Http/Controllers/Api/ApiV1Controller.php
@@ -2802,11 +2802,7 @@ class ApiV1Controller extends Controller
             return $this->json($res->toArray(), 200, $headers);
         }
 
-        $following = Cache::remember('profile:following:'.$pid, 1209600, function () use ($pid) {
-            $following = Follower::whereProfileId($pid)->pluck('following_id');
-
-            return $following->push($pid)->toArray();
-        });
+        $following = FollowerService::getFollowingIds($pid);
 
         $muted = UserFilterService::mutes($pid);
 

--- a/app/Http/Controllers/ComposeController.php
+++ b/app/Http/Controllers/ComposeController.php
@@ -276,6 +276,7 @@ class ComposeController extends Controller
             'profiles.username',
             'profiles.followers_count',
         ])
+            ->with('avatar')
             ->selectRaw('MAX(CASE WHEN followers.following_id IS NOT NULL THEN 1 ELSE 0 END) as is_followed')
             ->leftJoin('followers', function ($join) use ($currentUserId) {
                 $join->on('followers.following_id', '=', 'profiles.id')

--- a/app/Http/Controllers/DirectMessageController.php
+++ b/app/Http/Controllers/DirectMessageController.php
@@ -57,7 +57,7 @@ class DirectMessageController extends Controller
         $baseQuery = DirectMessage::select(
             'id', 'type', 'to_id', 'from_id', 'status_id',
             'is_hidden', 'meta', 'created_at', 'read_at'
-        )->with(['author', 'status', 'recipient']);
+        )->with(['author.avatar', 'status', 'recipient.avatar']);
 
         if (config('database.default') == 'pgsql') {
             $query = match ($action) {

--- a/app/Http/Controllers/InternalApiController.php
+++ b/app/Http/Controllers/InternalApiController.php
@@ -7,7 +7,6 @@ use App\Models\AccountInterstitial;
 use App\Models\Bookmark;
 use App\Models\DirectMessage;
 use App\Models\DiscoverCategory;
-use App\Models\Follower;
 use App\Models\Profile;
 use App\Models\Status;
 use App\Models\User;
@@ -23,7 +22,6 @@ use Illuminate\Contracts\View\View;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Redis;
 use Illuminate\Validation\Rule;
 use League\Fractal;
@@ -312,20 +310,12 @@ class InternalApiController extends Controller
                 return response()->json([]);
             }
             $pid = $request->user()->profile->id;
-            $following = Cache::remember('profile:following:'.$pid, now()->addMinutes(1440), function () use ($pid) {
-                $following = Follower::whereProfileId($pid)->pluck('following_id');
-
-                return $following->push($pid)->toArray();
-            });
+            $following = FollowerService::getFollowingIds($pid);
             $visibility = in_array($profile->id, $following) == true ? ['public', 'unlisted', 'private'] : [];
         } else {
             if ($request->user() !== null) {
                 $pid = $request->user()->profile->id;
-                $following = Cache::remember('profile:following:'.$pid, now()->addMinutes(1440), function () use ($pid) {
-                    $following = Follower::whereProfileId($pid)->pluck('following_id');
-
-                    return $following->push($pid)->toArray();
-                });
+                $following = FollowerService::getFollowingIds($pid);
                 $visibility = in_array($profile->id, $following) == true ? ['public', 'unlisted', 'private'] : ['public', 'unlisted'];
             } else {
                 $visibility = ['public', 'unlisted'];

--- a/app/Http/Controllers/PublicApiController.php
+++ b/app/Http/Controllers/PublicApiController.php
@@ -2,7 +2,6 @@
 
 namespace App\Http\Controllers;
 
-use App\Models\Follower;
 use App\Models\Profile;
 use App\Models\Status;
 use App\Services\AccountService;
@@ -390,11 +389,7 @@ class PublicApiController extends Controller
 
         $pid = $user->profile_id;
 
-        $following = Cache::remember('profile:following:'.$pid, 1209600, function () use ($pid) {
-            $following = Follower::whereProfileId($pid)->pluck('following_id');
-
-            return $following->push($pid)->toArray();
-        });
+        $following = FollowerService::getFollowingIds($pid);
 
         $filtered = $user ? UserFilterService::filters($user->profile_id) : [];
         $types = ['photo', 'photo:album', 'video', 'video:album', 'photo:video:album'];

--- a/app/Http/Controllers/SearchController.php
+++ b/app/Http/Controllers/SearchController.php
@@ -243,6 +243,7 @@ class SearchController extends Controller
                 $users = Profile::select('status', 'domain', 'username', 'name', 'id')
                     ->whereNull('status')
                     ->where('username', 'like', '%'.$tag.'%')
+                    ->with('avatar')
                     ->limit(20)
                     ->orderBy('domain')
                     ->get();

--- a/app/Jobs/DeletePipeline/DeleteAccountPipeline.php
+++ b/app/Jobs/DeletePipeline/DeleteAccountPipeline.php
@@ -174,14 +174,13 @@ class DeleteAccountPipeline implements ShouldQueue
         Mention::whereProfileId($id)->forceDelete();
 
         StoryView::whereProfileId($id)->delete();
-        $stories = Story::whereProfileId($id)->get();
-        foreach ($stories as $story) {
+        Story::whereProfileId($id)->cursor()->each(function ($story) {
             $path = storage_path('app/'.$story->path);
             if (is_file($path)) {
                 unlink($path);
             }
             $story->forceDelete();
-        }
+        });
 
         UserDevice::whereUserId($user->id)->forceDelete();
         UserFilter::whereUserId($user->id)->forceDelete();
@@ -192,11 +191,10 @@ class DeleteAccountPipeline implements ShouldQueue
             ->orWhere('actor_id', $id)
             ->forceDelete();
 
-        $collections = Collection::whereProfileId($id)->get();
-        foreach ($collections as $collection) {
+        Collection::whereProfileId($id)->cursor()->each(function ($collection) {
             $collection->items()->delete();
             $collection->delete();
-        }
+        });
         Contact::whereUserId($user->id)->delete();
         HashtagFollow::whereUserId($user->id)->delete();
         OauthClient::whereUserId($user->id)->delete();

--- a/app/Jobs/DeletePipeline/DeleteRemoteProfilePipeline.php
+++ b/app/Jobs/DeletePipeline/DeleteRemoteProfilePipeline.php
@@ -109,14 +109,13 @@ class DeleteRemoteProfilePipeline implements ShouldQueue
 
         // Delete Story Views + Stories
         StoryView::whereProfileId($pid)->delete();
-        $stories = Story::whereProfileId($pid)->get();
-        foreach ($stories as $story) {
+        Story::whereProfileId($pid)->cursor()->each(function ($story) {
             $path = storage_path('app/'.$story->path);
             if (is_file($path)) {
                 unlink($path);
             }
             $story->forceDelete();
-        }
+        });
 
         // Delete mutes/blocks
         UserFilter::whereFilterableType(Profile::class)->whereFilterableId($pid)->delete();

--- a/app/Jobs/HomeFeedPipeline/HashtagUnfollowPipeline.php
+++ b/app/Jobs/HomeFeedPipeline/HashtagUnfollowPipeline.php
@@ -2,8 +2,8 @@
 
 namespace App\Jobs\HomeFeedPipeline;
 
-use App\Models\Follower;
 use App\Models\Hashtag;
+use App\Services\FollowerService;
 use App\Services\HomeTimelineService;
 use App\Services\StatusService;
 use Illuminate\Bus\Queueable;
@@ -11,7 +11,6 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
-use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Log;
 
 class HashtagUnfollowPipeline implements ShouldQueue
@@ -76,11 +75,7 @@ class HashtagUnfollowPipeline implements ShouldQueue
 
         $statusIds = HomeTimelineService::get($pid, 0, -1);
 
-        $followingIds = Cache::remember('profile:following:'.$pid, 1209600, function () use ($pid) {
-            $following = Follower::whereProfileId($pid)->pluck('following_id');
-
-            return $following->push($pid)->toArray();
-        });
+        $followingIds = FollowerService::getFollowingIds($pid);
 
         foreach ($statusIds as $id) {
             $status = StatusService::get($id, false);

--- a/app/Jobs/StatusPipeline/RemoteStatusDelete.php
+++ b/app/Jobs/StatusPipeline/RemoteStatusDelete.php
@@ -138,16 +138,16 @@ class RemoteStatusDelete implements ShouldBeUniqueUntilProcessing, ShouldQueue
                 CollectionService::removeItem($col->collection_id, $col->object_id);
                 $col->delete();
             });
-        $dms = DirectMessage::whereStatusId($status->id)->get();
-        foreach ($dms as $dm) {
-            $not = Notification::whereItemType(DirectMessage::class)
-                ->whereItemId($dm->id)
-                ->first();
-            if ($not) {
-                NotificationService::del($not->profile_id, $not->id);
-                $not->forceDeleteQuietly();
-            }
-            $dm->delete();
+        $dmIds = DirectMessage::whereStatusId($status->id)->pluck('id');
+        if ($dmIds->isNotEmpty()) {
+            Notification::whereItemType(DirectMessage::class)
+                ->whereIn('item_id', $dmIds)
+                ->cursor()
+                ->each(function ($not) {
+                    NotificationService::del($not->profile_id, $not->id);
+                    $not->forceDeleteQuietly();
+                });
+            DirectMessage::whereIn('id', $dmIds)->delete();
         }
         Like::whereStatusId($status->id)->forceDelete();
         $media = Media::whereStatusId($status->id)->get();
@@ -160,16 +160,16 @@ class RemoteStatusDelete implements ShouldBeUniqueUntilProcessing, ShouldQueue
             $m->status_id = null;
             MediaDeletePipeline::dispatch($m)->onQueue('mmo');
         });
-        $mediaTags = MediaTag::where('status_id', $status->id)->get();
-        foreach ($mediaTags as $mtag) {
-            $not = Notification::whereItemType(MediaTag::class)
-                ->whereItemId($mtag->id)
-                ->first();
-            if ($not) {
-                NotificationService::del($not->profile_id, $not->id);
-                $not->forceDeleteQuietly();
-            }
-            $mtag->delete();
+        $mediaTagIds = MediaTag::where('status_id', $status->id)->pluck('id');
+        if ($mediaTagIds->isNotEmpty()) {
+            Notification::whereItemType(MediaTag::class)
+                ->whereIn('item_id', $mediaTagIds)
+                ->cursor()
+                ->each(function ($not) {
+                    NotificationService::del($not->profile_id, $not->id);
+                    $not->forceDeleteQuietly();
+                });
+            MediaTag::whereIn('id', $mediaTagIds)->delete();
         }
         Mention::whereStatusId($status->id)->forceDelete();
         Notification::whereItemType(Status::class)

--- a/app/Jobs/StatusPipeline/StatusDelete.php
+++ b/app/Jobs/StatusPipeline/StatusDelete.php
@@ -130,29 +130,29 @@ class StatusDelete implements ShouldQueue
                 $col->delete();
             });
 
-        $dms = DirectMessage::whereStatusId($status->id)->get();
-        foreach ($dms as $dm) {
-            $not = Notification::whereItemType(DirectMessage::class)
-                ->whereItemId($dm->id)
-                ->first();
-            if ($not) {
-                NotificationService::del($not->profile_id, $not->id);
-                $not->forceDeleteQuietly();
-            }
-            $dm->delete();
+        $dmIds = DirectMessage::whereStatusId($status->id)->pluck('id');
+        if ($dmIds->isNotEmpty()) {
+            Notification::whereItemType(DirectMessage::class)
+                ->whereIn('item_id', $dmIds)
+                ->cursor()
+                ->each(function ($not) {
+                    NotificationService::del($not->profile_id, $not->id);
+                    $not->forceDeleteQuietly();
+                });
+            DirectMessage::whereIn('id', $dmIds)->delete();
         }
         Like::whereStatusId($status->id)->delete();
 
-        $mediaTags = MediaTag::where('status_id', $status->id)->get();
-        foreach ($mediaTags as $mtag) {
-            $not = Notification::whereItemType(MediaTag::class)
-                ->whereItemId($mtag->id)
-                ->first();
-            if ($not) {
-                NotificationService::del($not->profile_id, $not->id);
-                $not->forceDeleteQuietly();
-            }
-            $mtag->delete();
+        $mediaTagIds = MediaTag::where('status_id', $status->id)->pluck('id');
+        if ($mediaTagIds->isNotEmpty()) {
+            Notification::whereItemType(MediaTag::class)
+                ->whereIn('item_id', $mediaTagIds)
+                ->cursor()
+                ->each(function ($not) {
+                    NotificationService::del($not->profile_id, $not->id);
+                    $not->forceDeleteQuietly();
+                });
+            MediaTag::whereIn('id', $mediaTagIds)->delete();
         }
         Mention::whereStatusId($status->id)->forceDelete();
 

--- a/app/Services/FollowerService.php
+++ b/app/Services/FollowerService.php
@@ -79,6 +79,23 @@ class FollowerService
         return Redis::zrevrange(self::FOLLOWING_KEY.$id, $start, $stop);
     }
 
+    /**
+     * Return the profile ids a profile follows, including the profile's own
+     * id, as an array. Cached under the 'profile:following:{pid}' key, which
+     * is invalidated by add()/remove().
+     *
+     * @return array<int, int>
+     */
+    public static function getFollowingIds($pid)
+    {
+        return Cache::remember('profile:following:'.$pid, 1209600, function () use ($pid) {
+            return Follower::whereProfileId($pid)
+                ->pluck('following_id')
+                ->push($pid)
+                ->toArray();
+        });
+    }
+
     public static function followersPaginate($id, $page = 1, $limit = 10)
     {
         $start = $page == 1 ? 0 : $page * $limit - $limit;

--- a/tests/Feature/FollowerServiceFollowingIdsTest.php
+++ b/tests/Feature/FollowerServiceFollowingIdsTest.php
@@ -1,0 +1,55 @@
+<?php
+
+use App\Models\Follower;
+use App\Models\User;
+use App\Services\FollowerService;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Illuminate\Support\Facades\Cache;
+
+uses(LazilyRefreshDatabase::class);
+
+/*
+|--------------------------------------------------------------------------
+| FollowerService::getFollowingIds
+|--------------------------------------------------------------------------
+|
+| Extracted from four inline copies of the same
+| Cache::remember('profile:following:'.$pid, ...) pattern. Verifies the
+| method returns the followed profile ids plus the caller's own id.
+|
+*/
+
+beforeEach(function () {
+    Cache::flush();
+});
+
+it('returns followed ids plus the callers own id', function () {
+    $user = User::factory()->create();
+    $user->refresh();
+    $a = User::factory()->create();
+    $a->refresh();
+    $b = User::factory()->create();
+    $b->refresh();
+
+    foreach ([$a->profile_id, $b->profile_id] as $targetId) {
+        $f = new Follower;
+        $f->profile_id = $user->profile_id;
+        $f->following_id = $targetId;
+        $f->save();
+    }
+
+    $ids = FollowerService::getFollowingIds($user->profile_id);
+
+    expect($ids)->toContain($a->profile_id)
+        ->toContain($b->profile_id)
+        ->toContain($user->profile_id);
+});
+
+it('returns only the callers own id when following nobody', function () {
+    $user = User::factory()->create();
+    $user->refresh();
+
+    $ids = FollowerService::getFollowingIds($user->profile_id);
+
+    expect($ids)->toBe([$user->profile_id]);
+});

--- a/tests/Feature/StatusDeleteCleanupTest.php
+++ b/tests/Feature/StatusDeleteCleanupTest.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Jobs\StatusPipeline\StatusDelete;
+use App\Models\DirectMessage;
+use App\Models\MediaTag;
+use App\Models\Notification;
+use App\Models\Status;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+/*
+|--------------------------------------------------------------------------
+| StatusDelete cleanup
+|--------------------------------------------------------------------------
+|
+| unlinkRemoveMedia() previously looped over each associated DirectMessage
+| and MediaTag, running a per-row Notification lookup and delete. It now
+| fetches the ids, resolves notifications in a single query, clears each
+| notification (cache + redis) via cursor, then bulk deletes. These tests
+| lock in the observable cleanup behaviour.
+|
+*/
+
+class StatusDeleteCleanupTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function deleting_a_status_removes_associated_dms_and_their_notifications()
+    {
+        $user = User::factory()->create();
+        $user->refresh();
+
+        $status = Status::factory()->create([
+            'profile_id' => $user->profile_id,
+            'type' => 'photo',
+        ]);
+
+        $dm = new DirectMessage;
+        $dm->to_id = $user->profile_id;
+        $dm->from_id = $user->profile_id;
+        $dm->status_id = $status->id;
+        $dm->save();
+
+        $notification = Notification::create([
+            'profile_id' => $user->profile_id,
+            'actor_id' => $user->profile_id,
+            'action' => 'dm',
+            'item_type' => DirectMessage::class,
+            'item_id' => $dm->id,
+        ]);
+
+        (new StatusDelete($status))->handle();
+
+        $this->assertNull(DirectMessage::find($dm->id));
+        $this->assertNull(Notification::find($notification->id));
+        $this->assertNull(Status::find($status->id));
+    }
+
+    #[Test]
+    public function deleting_a_status_removes_associated_media_tags_and_their_notifications()
+    {
+        $user = User::factory()->create();
+        $user->refresh();
+
+        $status = Status::factory()->create([
+            'profile_id' => $user->profile_id,
+            'type' => 'photo',
+        ]);
+
+        $tag = MediaTag::create([
+            'status_id' => $status->id,
+            'media_id' => 1,
+            'profile_id' => $user->profile_id,
+            'tagged_username' => 'someone',
+        ]);
+
+        $notification = Notification::create([
+            'profile_id' => $user->profile_id,
+            'actor_id' => $user->profile_id,
+            'action' => 'tagged',
+            'item_type' => MediaTag::class,
+            'item_id' => $tag->id,
+        ]);
+
+        (new StatusDelete($status))->handle();
+
+        $this->assertNull(MediaTag::find($tag->id));
+        $this->assertNull(Notification::find($notification->id));
+    }
+
+    #[Test]
+    public function deleting_a_status_without_dms_or_tags_still_deletes_the_status()
+    {
+        $user = User::factory()->create();
+        $user->refresh();
+
+        $status = Status::factory()->create([
+            'profile_id' => $user->profile_id,
+            'type' => 'photo',
+        ]);
+
+        (new StatusDelete($status))->handle();
+
+        $this->assertNull(Status::find($status->id));
+    }
+}


### PR DESCRIPTION
Groups three related query-performance cleanups. Each is a separate commit for easier review.

## 1. Eager load avatar to avoid N+1 in profile lists
`Profile::avatarUrl()` lazy-loads the `avatar` relation on cache miss, so mapping it over a collection ran one query per row. Eager load it at the collection call sites:
- `ComposeController::searchTag` (mention search)
- `DirectMessageController` thread list (`author.avatar`, `recipient.avatar`)
- `AccountController::followRequestsJson` (`actor.avatar`; also bounds the fetch to 10 at the DB level while preserving the total `count`)
- `SearchController` profile results

## 2. Stream deletions with cursor and batch notification lookups
The status/account deletion jobs loaded whole collections with `->get()` then looped with a per-row `Notification` lookup inside each iteration:
- `StatusDelete` / `RemoteStatusDelete`: resolve DM and MediaTag ids, fetch their notifications in one `whereIn` query, clear each via `cursor()` (`NotificationService::del` must run per row for cache/redis cleanup), then bulk delete.
- `DeleteAccountPipeline` / `DeleteRemoteProfilePipeline`: stream Story and Collection deletions with `cursor()` instead of loading every row. Per-row file unlink / item deletes preserved.

## 3. Extract following-ids lookup into FollowerService
The `Cache::remember('profile:following:'.$pid, ...)` block was copy-pasted in four places with inconsistent TTLs (1440 min vs 1209600 s). Added `FollowerService::getFollowingIds($pid)` (owns the cache key that `add()`/`remove()` already invalidate) and used it from `InternalApiController`, `PublicApiController`, `ApiV1Controller`, and `HashtagUnfollowPipeline`. Removed now-unused imports.

## Tests
- `tests/Feature/StatusDeleteCleanupTest.php` — DM + notification cleanup, media-tag + notification cleanup, no-associations case
- `tests/Feature/FollowerServiceFollowingIdsTest.php` — followed-ids-plus-self, follows-nobody
- (avatar eager-loading is a query-count optimization with unchanged response shape; covered indirectly by existing endpoint behaviour)

Run with `composer test` (starts Redis in Docker). Pint clean.

## Notes
No response-shape or behaviour changes intended; the following-ids TTL is standardised to the 14-day value already used by 3 of the 4 call sites.