### PR TITLE
Return shaped JSON from curated-register message endpoints

### DIFF
--- a/app/Http/Controllers/AdminCuratedRegisterController.php
+++ b/app/Http/Controllers/AdminCuratedRegisterController.php
@@ -170,9 +170,15 @@ class AdminCuratedRegisterController extends Controller
 
     public function apiMessagePreviewStore(Request $request, $id)
     {
+        $this->validate($request, [
+            'message' => 'required|string|min:5|max:3000',
+        ]);
         $record = CuratedRegister::findOrFail($id);
 
-        return $request->all();
+        return response()->json([
+            'id' => $record->id,
+            'message' => $request->input('message'),
+        ]);
     }
 
     public function apiMessageSendStore(Request $request, $id)
@@ -195,7 +201,10 @@ class AdminCuratedRegisterController extends Controller
         $record->save();
         Mail::to($record->email)->send(new CuratedRegisterRequestDetailsFromUser($record, $activity));
 
-        return $request->all();
+        return response()->json([
+            'id' => $record->id,
+            'success' => true,
+        ]);
     }
 
     public function previewDetailsMessageShow(Request $request, $id)


### PR DESCRIPTION
## Summary

`AdminCuratedRegisterController::apiMessagePreviewStore` and `apiMessageSendStore` ended with `return $request->all()`, echoing the raw request back to the client.

- **preview**: now validates `message` (required, 5–3000 chars) and returns `{ id, message }`.
- **send**: returns `{ id, success: true }`.

The admin UI (`activity-log.blade.php`) only `console.log`s the preview response and only checks that send resolves, so the shape change is safe.

## Notes
`send` already did the real work (persist activity + mail the user); only its return value changed. Pint clean.