### PR TITLE
Remove dead debug methods that echoed the raw request

### DIFF
--- a/app/Http/Controllers/CollectionController.php
+++ b/app/Http/Controllers/CollectionController.php
@@ -47,13 +47,6 @@ class CollectionController extends Controller
         return view('collection.show', compact('collection'));
     }
 
-    public function index(Request $request)
-    {
-        abort_if(! $request->user(), 403);
-
-        return $request->all();
-    }
-
     public function store(Request $request, $id)
     {
         abort_if(! $request->user(), 403);

--- a/app/Http/Controllers/StoryComposeController.php
+++ b/app/Http/Controllers/StoryComposeController.php
@@ -323,14 +323,6 @@ class StoryComposeController extends Controller
         return view('stories.compose');
     }
 
-    public function createPoll(Request $request)
-    {
-        abort_if(! (bool) config_cache('instance.stories.enabled') || ! $request->user(), 404);
-        abort_if(! config('instance.polls.enabled'), 404);
-
-        return $request->all();
-    }
-
     public function publishStoryPoll(Request $request): array
     {
         abort_if(! (bool) config_cache('instance.stories.enabled') || ! $request->user(), 404);


### PR DESCRIPTION
## Summary

Two controller methods had no route mapping and simply returned `$request->all()` — unreachable debug leftovers:

- `CollectionController::index`
- `StoryComposeController::createPoll`

Both are removed. Verified via `php artisan route:list` that nothing maps to either. The live `/poll` route maps to `ComposeController::createPoll`, which is a different method and is unaffected.

## Notes
Pure dead-code removal, no behaviour change. Pint clean.