### PR TITLE
Eager load avatar relation to avoid N+1 in profile lists

### DIFF
--- a/app/Http/Controllers/AccountController.php
+++ b/app/Http/Controllers/AccountController.php
@@ -400,10 +400,15 @@ class AccountController extends Controller
     public function followRequestsJson(Request $request): JsonResponse
     {
         $pid = $request->user()->profile_id;
-        $followers = FollowRequest::whereFollowingId($pid)->orderBy('id', 'desc')->whereIsRejected(0)->get();
+        $baseQuery = FollowRequest::whereFollowingId($pid)->whereIsRejected(0);
+        $followers = (clone $baseQuery)
+            ->with('actor.avatar')
+            ->orderBy('id', 'desc')
+            ->take(10)
+            ->get();
         $res = [
-            'count' => $followers->count(),
-            'accounts' => $followers->take(10)->map(function ($a) {
+            'count' => $baseQuery->count(),
+            'accounts' => $followers->map(function ($a) {
                 $actor = $a->actor;
 
                 return [

--- a/app/Http/Controllers/ComposeController.php
+++ b/app/Http/Controllers/ComposeController.php
@@ -271,6 +271,7 @@ class ComposeController extends Controller
             'profiles.username',
             'profiles.followers_count',
         ])
+            ->with('avatar')
             ->selectRaw('MAX(CASE WHEN followers.following_id IS NOT NULL THEN 1 ELSE 0 END) as is_followed')
             ->leftJoin('followers', function ($join) use ($currentUserId) {
                 $join->on('followers.following_id', '=', 'profiles.id')

--- a/app/Http/Controllers/DirectMessageController.php
+++ b/app/Http/Controllers/DirectMessageController.php
@@ -57,7 +57,7 @@ class DirectMessageController extends Controller
         $baseQuery = DirectMessage::select(
             'id', 'type', 'to_id', 'from_id', 'status_id',
             'is_hidden', 'meta', 'created_at', 'read_at'
-        )->with(['author', 'status', 'recipient']);
+        )->with(['author.avatar', 'status', 'recipient.avatar']);
 
         if (config('database.default') == 'pgsql') {
             $query = match ($action) {

--- a/app/Http/Controllers/SearchController.php
+++ b/app/Http/Controllers/SearchController.php
@@ -243,6 +243,7 @@ class SearchController extends Controller
                 $users = Profile::select('status', 'domain', 'username', 'name', 'id')
                     ->whereNull('status')
                     ->where('username', 'like', '%'.$tag.'%')
+                    ->with('avatar')
                     ->limit(20)
                     ->orderBy('domain')
                     ->get();


### PR DESCRIPTION
## Summary

`Profile::avatarUrl()` lazy-loads the `avatar` relation on cache miss, so mapping it over a profile collection issued one query per row. Eager load the avatar (and nested actor/recipient avatars) at the collection call sites:

- `ComposeController::searchTag` mention search results
- `DirectMessageController` thread list (`author.avatar`, `recipient.avatar`)
- `AccountController::followRequestsJson` (`actor.avatar`; also bounds the fetch to 10 rows at the DB level while preserving the total `count` via a cloned query)
- `SearchController` profile results

## Notes
Query-count optimization only; response shapes are unchanged. Pint clean.