### PR TITLE
Stream deletions with cursor and batch notification lookups in delete jobs

### DIFF
--- a/app/Jobs/DeletePipeline/DeleteAccountPipeline.php
+++ b/app/Jobs/DeletePipeline/DeleteAccountPipeline.php
@@ -174,14 +174,13 @@ class DeleteAccountPipeline implements ShouldQueue
         Mention::whereProfileId($id)->forceDelete();
 
         StoryView::whereProfileId($id)->delete();
-        $stories = Story::whereProfileId($id)->get();
-        foreach ($stories as $story) {
+        Story::whereProfileId($id)->cursor()->each(function ($story) {
             $path = storage_path('app/'.$story->path);
             if (is_file($path)) {
                 unlink($path);
             }
             $story->forceDelete();
-        }
+        });
 
         UserDevice::whereUserId($user->id)->forceDelete();
         UserFilter::whereUserId($user->id)->forceDelete();
@@ -192,11 +191,10 @@ class DeleteAccountPipeline implements ShouldQueue
             ->orWhere('actor_id', $id)
             ->forceDelete();
 
-        $collections = Collection::whereProfileId($id)->get();
-        foreach ($collections as $collection) {
+        Collection::whereProfileId($id)->cursor()->each(function ($collection) {
             $collection->items()->delete();
             $collection->delete();
-        }
+        });
         Contact::whereUserId($user->id)->delete();
         HashtagFollow::whereUserId($user->id)->delete();
         OauthClient::whereUserId($user->id)->delete();

--- a/app/Jobs/DeletePipeline/DeleteRemoteProfilePipeline.php
+++ b/app/Jobs/DeletePipeline/DeleteRemoteProfilePipeline.php
@@ -109,14 +109,13 @@ class DeleteRemoteProfilePipeline implements ShouldQueue
 
         // Delete Story Views + Stories
         StoryView::whereProfileId($pid)->delete();
-        $stories = Story::whereProfileId($pid)->get();
-        foreach ($stories as $story) {
+        Story::whereProfileId($pid)->cursor()->each(function ($story) {
             $path = storage_path('app/'.$story->path);
             if (is_file($path)) {
                 unlink($path);
             }
             $story->forceDelete();
-        }
+        });
 
         // Delete mutes/blocks
         UserFilter::whereFilterableType(Profile::class)->whereFilterableId($pid)->delete();

--- a/app/Jobs/StatusPipeline/RemoteStatusDelete.php
+++ b/app/Jobs/StatusPipeline/RemoteStatusDelete.php
@@ -138,16 +138,16 @@ class RemoteStatusDelete implements ShouldBeUniqueUntilProcessing, ShouldQueue
                 CollectionService::removeItem($col->collection_id, $col->object_id);
                 $col->delete();
             });
-        $dms = DirectMessage::whereStatusId($status->id)->get();
-        foreach ($dms as $dm) {
-            $not = Notification::whereItemType(DirectMessage::class)
-                ->whereItemId($dm->id)
-                ->first();
-            if ($not) {
-                NotificationService::del($not->profile_id, $not->id);
-                $not->forceDeleteQuietly();
-            }
-            $dm->delete();
+        $dmIds = DirectMessage::whereStatusId($status->id)->pluck('id');
+        if ($dmIds->isNotEmpty()) {
+            Notification::whereItemType(DirectMessage::class)
+                ->whereIn('item_id', $dmIds)
+                ->cursor()
+                ->each(function ($not) {
+                    NotificationService::del($not->profile_id, $not->id);
+                    $not->forceDeleteQuietly();
+                });
+            DirectMessage::whereIn('id', $dmIds)->delete();
         }
         Like::whereStatusId($status->id)->forceDelete();
         $media = Media::whereStatusId($status->id)->get();
@@ -160,16 +160,16 @@ class RemoteStatusDelete implements ShouldBeUniqueUntilProcessing, ShouldQueue
             $m->status_id = null;
             MediaDeletePipeline::dispatch($m)->onQueue('mmo');
         });
-        $mediaTags = MediaTag::where('status_id', $status->id)->get();
-        foreach ($mediaTags as $mtag) {
-            $not = Notification::whereItemType(MediaTag::class)
-                ->whereItemId($mtag->id)
-                ->first();
-            if ($not) {
-                NotificationService::del($not->profile_id, $not->id);
-                $not->forceDeleteQuietly();
-            }
-            $mtag->delete();
+        $mediaTagIds = MediaTag::where('status_id', $status->id)->pluck('id');
+        if ($mediaTagIds->isNotEmpty()) {
+            Notification::whereItemType(MediaTag::class)
+                ->whereIn('item_id', $mediaTagIds)
+                ->cursor()
+                ->each(function ($not) {
+                    NotificationService::del($not->profile_id, $not->id);
+                    $not->forceDeleteQuietly();
+                });
+            MediaTag::whereIn('id', $mediaTagIds)->delete();
         }
         Mention::whereStatusId($status->id)->forceDelete();
         Notification::whereItemType(Status::class)

--- a/app/Jobs/StatusPipeline/StatusDelete.php
+++ b/app/Jobs/StatusPipeline/StatusDelete.php
@@ -130,29 +130,29 @@ class StatusDelete implements ShouldQueue
                 $col->delete();
             });
 
-        $dms = DirectMessage::whereStatusId($status->id)->get();
-        foreach ($dms as $dm) {
-            $not = Notification::whereItemType(DirectMessage::class)
-                ->whereItemId($dm->id)
-                ->first();
-            if ($not) {
-                NotificationService::del($not->profile_id, $not->id);
-                $not->forceDeleteQuietly();
-            }
-            $dm->delete();
+        $dmIds = DirectMessage::whereStatusId($status->id)->pluck('id');
+        if ($dmIds->isNotEmpty()) {
+            Notification::whereItemType(DirectMessage::class)
+                ->whereIn('item_id', $dmIds)
+                ->cursor()
+                ->each(function ($not) {
+                    NotificationService::del($not->profile_id, $not->id);
+                    $not->forceDeleteQuietly();
+                });
+            DirectMessage::whereIn('id', $dmIds)->delete();
         }
         Like::whereStatusId($status->id)->delete();
 
-        $mediaTags = MediaTag::where('status_id', $status->id)->get();
-        foreach ($mediaTags as $mtag) {
-            $not = Notification::whereItemType(MediaTag::class)
-                ->whereItemId($mtag->id)
-                ->first();
-            if ($not) {
-                NotificationService::del($not->profile_id, $not->id);
-                $not->forceDeleteQuietly();
-            }
-            $mtag->delete();
+        $mediaTagIds = MediaTag::where('status_id', $status->id)->pluck('id');
+        if ($mediaTagIds->isNotEmpty()) {
+            Notification::whereItemType(MediaTag::class)
+                ->whereIn('item_id', $mediaTagIds)
+                ->cursor()
+                ->each(function ($not) {
+                    NotificationService::del($not->profile_id, $not->id);
+                    $not->forceDeleteQuietly();
+                });
+            MediaTag::whereIn('id', $mediaTagIds)->delete();
         }
         Mention::whereStatusId($status->id)->forceDelete();
 

--- a/tests/Feature/StatusDeleteCleanupTest.php
+++ b/tests/Feature/StatusDeleteCleanupTest.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Jobs\StatusPipeline\StatusDelete;
+use App\Models\DirectMessage;
+use App\Models\MediaTag;
+use App\Models\Notification;
+use App\Models\Status;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+/*
+|--------------------------------------------------------------------------
+| StatusDelete cleanup
+|--------------------------------------------------------------------------
+|
+| unlinkRemoveMedia() previously looped over each associated DirectMessage
+| and MediaTag, running a per-row Notification lookup and delete. It now
+| fetches the ids, resolves notifications in a single query, clears each
+| notification (cache + redis) via cursor, then bulk deletes. These tests
+| lock in the observable cleanup behaviour.
+|
+*/
+
+class StatusDeleteCleanupTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function deleting_a_status_removes_associated_dms_and_their_notifications()
+    {
+        $user = User::factory()->create();
+        $user->refresh();
+
+        $status = Status::factory()->create([
+            'profile_id' => $user->profile_id,
+            'type' => 'photo',
+        ]);
+
+        $dm = new DirectMessage;
+        $dm->to_id = $user->profile_id;
+        $dm->from_id = $user->profile_id;
+        $dm->status_id = $status->id;
+        $dm->save();
+
+        $notification = Notification::create([
+            'profile_id' => $user->profile_id,
+            'actor_id' => $user->profile_id,
+            'action' => 'dm',
+            'item_type' => DirectMessage::class,
+            'item_id' => $dm->id,
+        ]);
+
+        (new StatusDelete($status))->handle();
+
+        $this->assertNull(DirectMessage::find($dm->id));
+        $this->assertNull(Notification::find($notification->id));
+        $this->assertNull(Status::find($status->id));
+    }
+
+    #[Test]
+    public function deleting_a_status_removes_associated_media_tags_and_their_notifications()
+    {
+        $user = User::factory()->create();
+        $user->refresh();
+
+        $status = Status::factory()->create([
+            'profile_id' => $user->profile_id,
+            'type' => 'photo',
+        ]);
+
+        $tag = MediaTag::create([
+            'status_id' => $status->id,
+            'media_id' => 1,
+            'profile_id' => $user->profile_id,
+            'tagged_username' => 'someone',
+        ]);
+
+        $notification = Notification::create([
+            'profile_id' => $user->profile_id,
+            'actor_id' => $user->profile_id,
+            'action' => 'tagged',
+            'item_type' => MediaTag::class,
+            'item_id' => $tag->id,
+        ]);
+
+        (new StatusDelete($status))->handle();
+
+        $this->assertNull(MediaTag::find($tag->id));
+        $this->assertNull(Notification::find($notification->id));
+    }
+
+    #[Test]
+    public function deleting_a_status_without_dms_or_tags_still_deletes_the_status()
+    {
+        $user = User::factory()->create();
+        $user->refresh();
+
+        $status = Status::factory()->create([
+            'profile_id' => $user->profile_id,
+            'type' => 'photo',
+        ]);
+
+        (new StatusDelete($status))->handle();
+
+        $this->assertNull(Status::find($status->id));
+    }
+}


### PR DESCRIPTION
## Summary

The status- and account-deletion jobs loaded whole collections with `->get()` and then looped, running a per-row `Notification` lookup inside each iteration.

- **StatusDelete / RemoteStatusDelete**: resolve associated `DirectMessage` and `MediaTag` ids, fetch their notifications in a single `whereIn` query, clear each via `cursor()` (`NotificationService::del` must run per row for cache/redis cleanup), then bulk delete the DMs and media tags.
- **DeleteAccountPipeline / DeleteRemoteProfilePipeline**: stream Story and Collection deletions with `cursor()` instead of loading every row into memory. Per-row file unlink and item deletes are preserved.

## Tests
Adds `tests/Feature/StatusDeleteCleanupTest.php` covering DM + notification cleanup, media-tag + notification cleanup, and the no-associations case (3 passing).

Run with `composer test` (starts Redis in Docker). Pint clean.