### PR TITLE
Fix Larastan error

### DIFF
--- a/app/Services/NotificationService.php
+++ b/app/Services/NotificationService.php
@@ -4,7 +4,7 @@ namespace App\Services;
 
 use App\Jobs\InternalPipeline\NotificationEpochUpdatePipeline;
 use App\Models\Notification;
-use App\Status;
+use App\Models\Status;
 use App\Transformer\Api\NotificationTransformer;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Log;


### PR DESCRIPTION
Use App\Models\Status instead of the non-existent App\Status class.