### PR TITLE
Fix DeleteAccountPipeline to use injected user

### DIFF
--- a/app/Jobs/DeletePipeline/DeleteAccountPipeline.php
+++ b/app/Jobs/DeletePipeline/DeleteAccountPipeline.php
@@ -75,18 +75,7 @@ class DeleteAccountPipeline implements ShouldQueue
 
     public function handle()
     {
-        $job = ImportJob::find($this->import->id);
-        if (!$job) {
-            return;
-        }
-
-        $profile = Profile::find($job->profile_id);
-        if (!$profile) {
-            $job->delete();
-            return;
-        }
-
-        $user = $profile->user;
+        $user = $this->user;
 
         // Verify user exists
         if (! $user) {


### PR DESCRIPTION
Remove leftover ImportJob lookup that referenced a non-existent $this->import property and missing ImportJob class. The job receives a User via its constructor, so handle() now operates on $this->user directly. Resolves larastan property.notFound and class.notFound errors.